### PR TITLE
improve(SpokePoolClient): Delete some depositRoute functions

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -169,24 +169,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
-   * Determines whether a deposit route is enabled for the given origin token and destination chain ID.
-   * @param originToken The origin token address.
-   * @param destinationChainId The destination chain ID.
-   * @returns True if the deposit route is enabled, false otherwise.
-   */
-  public isDepositRouteEnabled(originToken: string, destinationChainId: number): boolean {
-    return this.depositRoutes[originToken]?.[destinationChainId] ?? false;
-  }
-
-  /**
-   * Retrieves a list of all the available origin tokens that can be bridged.
-   * @returns A list of origin tokens.
-   */
-  public getAllOriginTokens(): string[] {
-    return Object.keys(this.depositRoutes);
-  }
-
-  /**
    * Retrieves a list of fills from the SpokePool contract.
    * @returns A list of fills.
    */

--- a/test/SpokePoolClient.DepositRoutes.ts
+++ b/test/SpokePoolClient.DepositRoutes.ts
@@ -22,7 +22,6 @@ describe("SpokePoolClient: Deposit Routes", function () {
     await enableRoutes(spokePool, [{ originToken, destinationChainId }]);
     await spokePoolClient.update();
     expect(spokePoolClient.getDepositRoutes()).to.deep.equal({ [originToken]: { [destinationChainId]: true } });
-    expect(spokePoolClient.isDepositRouteEnabled(originToken, destinationChainId)).to.be.true;
 
     // Enable another destination chain with the same origin token should append to the previous structure.
     const destinationChainId2 = destinationChainId + 1;
@@ -51,22 +50,11 @@ describe("SpokePoolClient: Deposit Routes", function () {
     await spokePool.setEnableRoute(originToken, destinationChainId, false); // Disable the route.
     await spokePoolClient.update();
     expect(spokePoolClient.getDepositRoutes()).to.deep.equal({ [originToken]: { [destinationChainId]: false } });
-    expect(spokePoolClient.isDepositRouteEnabled(originToken, destinationChainId)).to.be.false;
     const destinationChainId2 = destinationChainId + 1;
     await enableRoutes(spokePool, [{ originToken, destinationChainId: destinationChainId2 }]);
     await spokePoolClient.update();
     expect(spokePoolClient.getDepositRoutes()).to.deep.equal({
       [originToken]: { [destinationChainId]: false, [destinationChainId2]: true },
     });
-  });
-
-  it("Correctly fetches origin tokens", async function () {
-    const originToken = randomAddress();
-    await enableRoutes(spokePool, [{ originToken, destinationChainId }]);
-    const originToken2 = randomAddress();
-    await enableRoutes(spokePool, [{ originToken: originToken2, destinationChainId }]);
-    await spokePoolClient.update();
-
-    expect(spokePoolClient.getAllOriginTokens()).to.deep.equal([originToken, originToken2]);
   });
 });


### PR DESCRIPTION
We don't rely on these functions [anymore](https://github.com/across-protocol/relayer-v3/commit/d1a6c65478fed946df57958a74d2a4f6a4f6192a) in the Relayer so delete them to avoid future dependencies on them.

We favor instead mapping l1 and l2 tokens using PoolRebalanceRoutes which requires querying only the Hub chain as opposed to all Spoke chains, which is overall much faster.
