### PR TITLE
[WIP] improve(utils): Avoid recomputing relayData hashes

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -19,6 +19,7 @@ export interface RelayData {
   fillDeadline: number;
   exclusiveRelayer: string;
   exclusivityDeadline: number;
+  _hash?: Record<number, string>;
 }
 
 export interface Deposit extends RelayData {

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -216,7 +216,9 @@ export async function getDepositIdAtBlock(contract: Contract, blockTag: number):
  * @returns The corresponding RelayData hash.
  */
 export function getRelayDataHash(relayData: RelayData, destinationChainId: number): string {
-  return ethersUtils.keccak256(
+  relayData._hash ??= {};
+
+  return relayData._hash[destinationChainId] ??= ethersUtils.keccak256(
     ethersUtils.defaultAbiCoder.encode(
       [
         "tuple(" +


### PR DESCRIPTION
This will save redundant recomputation cycles of a relayData hash when it is needed more than once.

This PR will be updated with tests.