### PR TITLE
refactor: improve `getGasCosts` rpc calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -58,16 +58,22 @@ export class QueryBase implements QueryInterface {
    * Retrieves the current gas costs of performing a fillRelay contract at the referenced SpokePool.
    * @param deposit V3 deposit instance.
    * @param relayerAddress Relayer address to simulate with.
+   * @param gasPrice Optional gas price to use for the simulation.
    * @returns The gas estimate for this function call (multplied with the optional buffer).
    */
-  async getGasCosts(deposit: Deposit, relayer = DEFAULT_SIMULATED_RELAYER_ADDRESS): Promise<TransactionCostEstimate> {
+  async getGasCosts(
+    deposit: Deposit,
+    relayer = DEFAULT_SIMULATED_RELAYER_ADDRESS,
+    gasPrice = this.fixedGasPrice
+  ): Promise<TransactionCostEstimate> {
     const tx = await populateV3Relay(this.spokePool, deposit, relayer);
     return estimateTotalGasRequiredByUnsignedTransaction(
       tx,
       relayer,
       this.provider,
       this.gasMarkup,
-      this.fixedGasPrice
+      gasPrice,
+      deposit.destinationChainId
     );
   }
 

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -67,14 +67,7 @@ export class QueryBase implements QueryInterface {
     gasPrice = this.fixedGasPrice
   ): Promise<TransactionCostEstimate> {
     const tx = await populateV3Relay(this.spokePool, deposit, relayer);
-    return estimateTotalGasRequiredByUnsignedTransaction(
-      tx,
-      relayer,
-      this.provider,
-      this.gasMarkup,
-      gasPrice,
-      deposit.destinationChainId
-    );
+    return estimateTotalGasRequiredByUnsignedTransaction(tx, relayer, this.provider, this.gasMarkup, gasPrice);
   }
 
   /**

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -242,7 +242,6 @@ export type TransactionCostEstimate = {
  * @param provider A valid ethers provider - will be used to reason the gas price.
  * @param gasMarkup Markup on the estimated gas cost. For example, 0.2 will increase this resulting value 1.2x.
  * @param gasPrice A manually provided gas price - if set, this function will not resolve the current gas price.
- * @param chainId The chain ID of the network that the transaction will be submitted to.
  * @returns Estimated cost in units of gas and the underlying gas token (gasPrice * estimatedGasUnits).
  */
 export async function estimateTotalGasRequiredByUnsignedTransaction(
@@ -250,15 +249,14 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   senderAddress: string,
   provider: providers.Provider | L2Provider<providers.Provider>,
   gasMarkup: number,
-  gasPrice?: BigNumberish,
-  chainId?: number
+  gasPrice?: BigNumberish
 ): Promise<TransactionCostEstimate> {
   assert(
     gasMarkup > -1 && gasMarkup <= 4,
     `Require -1.0 < Gas Markup (${gasMarkup}) <= 4.0 for a total gas multiplier within (0, +5.0]`
   );
   const gasTotalMultiplier = toBNWei(1.0 + gasMarkup);
-  chainId ??= (await provider.getNetwork()).chainId;
+  const { chainId } = await provider.getNetwork();
   const voidSigner = new VoidSigner(senderAddress, provider);
 
   // Estimate the Gas units required to submit this transaction.


### PR DESCRIPTION
While monitoring the speed of the `GET /suggested-fees` handler, I noticed some areas of improvement. For example, in the trace of the attached screenshot, you can see all RPC requests triggered by the `relayFeeCalculator`. This PR aims to reduce the number of those and parallelize a few by:

- allow passing in `gasPrice` to `getGasCosts` to allow caching of that value to prevent RPC calls
- allow passing `chainId` to `estimateTotalGasRequiredByUnsignedTransaction` to prevent additional RPC if chain already known
- for OP stack:
  - set `gasLimit` with already retrieved value to prevent redundant RPC call
  - concurrently call parts of `estimateTotalGasCost` for speed up

![image](https://github.com/across-protocol/sdk/assets/17645687/7286ab62-9903-4598-95f5-d2f175fc5b0e)
