### PR TITLE
refactor(SpokePoolClient): Drop CCTP queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -136,7 +136,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       oldestTime: 0,
       events,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,
-      hasCCTPBridgingEnabled: false,
     };
   }
 


### PR DESCRIPTION
This feature was introduced in advance of the CCTP rollout but it appears to be unused in the bots.