### PR TITLE
fix: add field to mark if destination chain is lite

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -546,8 +546,8 @@ export class SpokePoolClient extends BaseAbstractClient {
         // Derive and append the common properties that are not part of the onchain event.
         const { quoteBlock: quoteBlockNumber } = dataForQuoteTime[index];
         const deposit = { ...(rawDeposit as DepositWithBlock), originChainId: this.chainId, quoteBlockNumber };
-        deposit.fromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
-        deposit.toLiteChain = this.doesDepositDestinateToLiteChain(deposit);
+        deposit.fromLiteChain = this.isOriginLiteChain(deposit);
+        deposit.toLiteChain = this.isDestinationLiteChain(deposit);
         if (deposit.outputToken === ZERO_ADDRESS) {
           deposit.outputToken = this.getDestinationTokenForDeposit(deposit);
         }
@@ -868,7 +868,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
-   * Determines whether a deposit is destined to a lite chain.
+   * Determines whether the deposit destination chain is a lite chain.
    * @param deposit The deposit to evaluate.
    * @returns True if the deposit is destined to a lite chain, false otherwise. If the hub pool client is not defined,
    *          this method will return false.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -546,8 +546,8 @@ export class SpokePoolClient extends BaseAbstractClient {
         // Derive and append the common properties that are not part of the onchain event.
         const { quoteBlock: quoteBlockNumber } = dataForQuoteTime[index];
         const deposit = { ...(rawDeposit as DepositWithBlock), originChainId: this.chainId, quoteBlockNumber };
-        deposit.originatesFromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
-        deposit.destinedToLiteChain = this.doesDepositDestinateToLiteChain(deposit);
+        deposit.fromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
+        deposit.toLiteChain = this.doesDepositDestinateToLiteChain(deposit);
         if (deposit.outputToken === ZERO_ADDRESS) {
           deposit.outputToken = this.getDestinationTokenForDeposit(deposit);
         }
@@ -844,8 +844,8 @@ export class SpokePoolClient extends BaseAbstractClient {
           ? this.getDestinationTokenForDeposit({ ...partialDeposit, originChainId: this.chainId })
           : partialDeposit.outputToken,
     };
-    deposit.originatesFromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
-    deposit.destinedToLiteChain = this.doesDepositDestinateToLiteChain(deposit);
+    deposit.fromLiteChain = this.isOriginFromLiteChain(deposit);
+    deposit.toLiteChain = this.doesDepositDestinateToLiteChain(deposit);
 
     this.logger.debug({
       at: "SpokePoolClient#findDeposit",
@@ -863,7 +863,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns True if the deposit originates from a lite chain, false otherwise. If the hub pool client is not defined,
    *          this method will return false.
    */
-  protected doesDepositOriginateFromLiteChain(deposit: DepositWithBlock): boolean {
+  protected isOriginLiteChain(deposit: DepositWithBlock): boolean {
     return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.originChainId, deposit.quoteTimestamp) ?? false;
   }
 
@@ -873,7 +873,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns True if the deposit is destined to a lite chain, false otherwise. If the hub pool client is not defined,
    *          this method will return false.
    */
-  protected doesDepositDestinateToLiteChain(deposit: DepositWithBlock): boolean {
+  protected isDestinationLiteChain(deposit: DepositWithBlock): boolean {
     return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false;
   }
 }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -874,6 +874,8 @@ export class SpokePoolClient extends BaseAbstractClient {
    *          this method will return false.
    */
   protected isDestinationLiteChain(deposit: DepositWithBlock): boolean {
-    return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false;
+    return (
+      this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false
+    );
   }
 }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -844,8 +844,8 @@ export class SpokePoolClient extends BaseAbstractClient {
           ? this.getDestinationTokenForDeposit({ ...partialDeposit, originChainId: this.chainId })
           : partialDeposit.outputToken,
     };
-    deposit.fromLiteChain = this.isOriginFromLiteChain(deposit);
-    deposit.toLiteChain = this.doesDepositDestinateToLiteChain(deposit);
+    deposit.fromLiteChain = this.isOriginLiteChain(deposit);
+    deposit.toLiteChain = this.isDestinationLiteChain(deposit);
 
     this.logger.debug({
       at: "SpokePoolClient#findDeposit",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -547,6 +547,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         const { quoteBlock: quoteBlockNumber } = dataForQuoteTime[index];
         const deposit = { ...(rawDeposit as DepositWithBlock), originChainId: this.chainId, quoteBlockNumber };
         deposit.originatesFromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
+        deposit.destinedToLiteChain = this.doesDepositDestinateToLiteChain(deposit);
         if (deposit.outputToken === ZERO_ADDRESS) {
           deposit.outputToken = this.getDestinationTokenForDeposit(deposit);
         }
@@ -844,6 +845,7 @@ export class SpokePoolClient extends BaseAbstractClient {
           : partialDeposit.outputToken,
     };
     deposit.originatesFromLiteChain = this.doesDepositOriginateFromLiteChain(deposit);
+    deposit.destinedToLiteChain = this.doesDepositDestinateToLiteChain(deposit);
 
     this.logger.debug({
       at: "SpokePoolClient#findDeposit",
@@ -863,5 +865,15 @@ export class SpokePoolClient extends BaseAbstractClient {
    */
   protected doesDepositOriginateFromLiteChain(deposit: DepositWithBlock): boolean {
     return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.originChainId, deposit.quoteTimestamp) ?? false;
+  }
+
+  /**
+   * Determines whether a deposit is destined to a lite chain.
+   * @param deposit The deposit to evaluate.
+   * @returns True if the deposit is destined to a lite chain, false otherwise. If the hub pool client is not defined,
+   *          this method will return false.
+   */
+  protected doesDepositDestinateToLiteChain(deposit: DepositWithBlock): boolean {
+    return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false;
   }
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -28,8 +28,8 @@ export interface Deposit extends RelayData {
   updatedRecipient?: string;
   updatedOutputAmount?: BigNumber;
   updatedMessage?: string;
-  originatesFromLiteChain: boolean;
-  destinedToLiteChain: boolean;
+  fromLiteChain: boolean;
+  toLiteChain: boolean;
 }
 
 export interface DepositWithBlock extends Deposit, SortableEvent {

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -29,6 +29,7 @@ export interface Deposit extends RelayData {
   updatedOutputAmount?: BigNumber;
   updatedMessage?: string;
   originatesFromLiteChain: boolean;
+  destinedToLiteChain: boolean;
 }
 
 export interface DepositWithBlock extends Deposit, SortableEvent {

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -111,7 +111,7 @@ describe("SpokePoolClient: SpeedUp", function () {
       deepEqualsWithBigNumber(
         spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
         expectedDepositData,
-        [...ignoredFields, "realizedLpFeePct", "originatesFromLiteChain", "destinedToLiteChain"]
+        [...ignoredFields, "realizedLpFeePct", "fromLiteChain", "toLiteChain"]
       )
     ).to.be.true;
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(1);

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -111,7 +111,7 @@ describe("SpokePoolClient: SpeedUp", function () {
       deepEqualsWithBigNumber(
         spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
         expectedDepositData,
-        [...ignoredFields, "realizedLpFeePct", "originatesFromLiteChain"]
+        [...ignoredFields, "realizedLpFeePct", "originatesFromLiteChain", "destinedToLiteChain"]
       )
     ).to.be.true;
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(1);

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -216,7 +216,7 @@ describe("SpokePoolClient: Fill Validation", function () {
     await spokePoolClient1.update();
 
     expect(spokePoolClient1.getDepositForFill(fill))
-      .excludingEvery(["realizedLpFeePct", "quoteBlockNumber", "originatesFromLiteChain"])
+      .excludingEvery(["realizedLpFeePct", "quoteBlockNumber", "originatesFromLiteChain", "destinedToLiteChain"])
       .to.deep.equal(deposit);
   });
 
@@ -631,7 +631,7 @@ describe("SpokePoolClient: Fill Validation", function () {
     expect(fill_2.relayExecutionInfo.fillType === FillType.FastFill).to.be.true;
 
     expect(spokePoolClient1.getDepositForFill(fill_1))
-      .excludingEvery(["quoteBlockNumber", "realizedLpFeePct", "originatesFromLiteChain"])
+      .excludingEvery(["quoteBlockNumber", "realizedLpFeePct", "originatesFromLiteChain", "destinedToLiteChain"])
       .to.deep.equal(deposit_1);
     expect(spokePoolClient1.getDepositForFill(fill_2)).to.equal(undefined);
 

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -216,7 +216,7 @@ describe("SpokePoolClient: Fill Validation", function () {
     await spokePoolClient1.update();
 
     expect(spokePoolClient1.getDepositForFill(fill))
-      .excludingEvery(["realizedLpFeePct", "quoteBlockNumber", "originatesFromLiteChain", "destinedToLiteChain"])
+      .excludingEvery(["realizedLpFeePct", "quoteBlockNumber", "fromLiteChain", "toLiteChain"])
       .to.deep.equal(deposit);
   });
 
@@ -631,7 +631,7 @@ describe("SpokePoolClient: Fill Validation", function () {
     expect(fill_2.relayExecutionInfo.fillType === FillType.FastFill).to.be.true;
 
     expect(spokePoolClient1.getDepositForFill(fill_1))
-      .excludingEvery(["quoteBlockNumber", "realizedLpFeePct", "originatesFromLiteChain", "destinedToLiteChain"])
+      .excludingEvery(["quoteBlockNumber", "realizedLpFeePct", "fromLiteChain", "toLiteChain"])
       .to.deep.equal(deposit_1);
     expect(spokePoolClient1.getDepositForFill(fill_2)).to.equal(undefined);
 

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -135,7 +135,7 @@ describe("SpokePoolClient: Event Filtering", function () {
     });
   });
 
-  it("Correctly sets the `originatesFromLiteChain` flag by using `doesDepositOriginateFromLiteChain`", async function () {
+  it("Correctly sets the `fromLiteChain` flag by using `isOriginLiteChain`", async function () {
     // Update the config store to set the originChainId as a lite chain.
     configStoreClient.updateGlobalConfig(
       GLOBAL_CONFIG_STORE_KEYS.LITE_CHAIN_ID_INDICES,
@@ -158,13 +158,13 @@ describe("SpokePoolClient: Event Filtering", function () {
     // Confirm that the two updates have different timestamps.
     expect(liteChainIndicesUpdate1.timestamp).to.not.equal(liteChainIndicesUpdate2.timestamp);
 
-    // Inject a V3DepositWithBlock event that should have the `originatesFromLiteChain` flag set to false.
+    // Inject a V3DepositWithBlock event that should have the `fromLiteChain` flag set to false.
     // This is done by setting the quote timestamp to before the first lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate1.timestamp - 1);
-    // Inject a V3DepositWithBlock event that should have the `originatesFromLiteChain` flag set to true.
+    // Inject a V3DepositWithBlock event that should have the `fromLiteChain` flag set to true.
     // This is done by setting the quote timestamp to after the first lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate1.timestamp + 1);
-    // Inject a V3DepositWithBlock event that should have the `originatesFromLiteChain` flag set to false.
+    // Inject a V3DepositWithBlock event that should have the `fromLiteChain` flag set to false.
     // This is done by setting the quote timestamp to after the second lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate2.timestamp + 1);
 
@@ -172,15 +172,15 @@ describe("SpokePoolClient: Event Filtering", function () {
     originSpokePoolClient.setConfigStoreClient(configStoreClient);
     await originSpokePoolClient.update(["V3FundsDeposited"]);
 
-    // Of the three deposits, the first and third should have the `originatesFromLiteChain` flag set to false.
+    // Of the three deposits, the first and third should have the `fromLiteChain` flag set to false.
     const deposits = originSpokePoolClient.getDeposits();
     expect(deposits.length).to.equal(3);
-    expect(deposits[0].originatesFromLiteChain).to.equal(false);
-    expect(deposits[1].originatesFromLiteChain).to.equal(true);
-    expect(deposits[2].originatesFromLiteChain).to.equal(false);
+    expect(deposits[0].fromLiteChain).to.equal(false);
+    expect(deposits[1].fromLiteChain).to.equal(true);
+    expect(deposits[2].fromLiteChain).to.equal(false);
   });
 
-  it("Correctly sets the `destinedToLiteChain` flag by using `doesDepositDestinateToLiteChain`", async function () {
+  it("Correctly sets the `toLiteChain` flag by using `isDestinationLiteChain`", async function () {
     // Update the config store to set the originChainId as a lite chain.
     configStoreClient.updateGlobalConfig(
       GLOBAL_CONFIG_STORE_KEYS.LITE_CHAIN_ID_INDICES,
@@ -203,13 +203,13 @@ describe("SpokePoolClient: Event Filtering", function () {
     // Confirm that the two updates have different timestamps.
     expect(liteChainIndicesUpdate1.timestamp).to.not.equal(liteChainIndicesUpdate2.timestamp);
 
-    // Inject a V3DepositWithBlock event that should have the `doesDepositDestinateToLiteChain` flag set to false.
+    // Inject a V3DepositWithBlock event that should have the `toLiteChain` flag set to false.
     // This is done by setting the quote timestamp to before the first lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate1.timestamp - 1);
-    // Inject a V3DepositWithBlock event that should have the `doesDepositDestinateToLiteChain` flag set to true.
+    // Inject a V3DepositWithBlock event that should have the `toLiteChain` flag set to true.
     // This is done by setting the quote timestamp to after the first lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate1.timestamp + 1);
-    // Inject a V3DepositWithBlock event that should have the `doesDepositDestinateToLiteChain` flag set to false.
+    // Inject a V3DepositWithBlock event that should have the `toLiteChain` flag set to false.
     // This is done by setting the quote timestamp to after the second lite chain update.
     generateV3Deposit(originSpokePoolClient, liteChainIndicesUpdate2.timestamp + 1);
 
@@ -217,12 +217,12 @@ describe("SpokePoolClient: Event Filtering", function () {
     originSpokePoolClient.setConfigStoreClient(configStoreClient);
     await originSpokePoolClient.update(["V3FundsDeposited"]);
 
-    // Of the three deposits, the first and third should have the `destinedToLiteChain` flag set to false.
+    // Of the three deposits, the first and third should have the `toLiteChain` flag set to false.
     const deposits = originSpokePoolClient.getDeposits();
     expect(deposits.length).to.equal(3);
-    expect(deposits[0].destinedToLiteChain).to.equal(false);
-    expect(deposits[1].destinedToLiteChain).to.equal(true);
-    expect(deposits[2].destinedToLiteChain).to.equal(false);
+    expect(deposits[0].toLiteChain).to.equal(false);
+    expect(deposits[1].toLiteChain).to.equal(true);
+    expect(deposits[2].toLiteChain).to.equal(false);
   });
 
   it("Correctly substitutes outputToken when set to 0x0", async function () {


### PR DESCRIPTION
This PR renames `originatesFromLiteChain` and adds a corresponding check for the destination chain as well.