### PR TITLE
fix: set gas limit and price for fill estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -59,15 +59,24 @@ export class QueryBase implements QueryInterface {
    * @param deposit V3 deposit instance.
    * @param relayerAddress Relayer address to simulate with.
    * @param gasPrice Optional gas price to use for the simulation.
+   * @param gasLimit Optional gas limit to use for the simulation.
    * @returns The gas estimate for this function call (multiplied with the optional buffer).
    */
   async getGasCosts(
     deposit: Deposit,
     relayer = DEFAULT_SIMULATED_RELAYER_ADDRESS,
-    gasPrice = this.fixedGasPrice
+    gasPrice = this.fixedGasPrice,
+    gasLimit?: BigNumberish
   ): Promise<TransactionCostEstimate> {
     const tx = await populateV3Relay(this.spokePool, deposit, relayer);
-    return estimateTotalGasRequiredByUnsignedTransaction(tx, relayer, this.provider, this.gasMarkup, gasPrice);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      relayer,
+      this.provider,
+      this.gasMarkup,
+      gasPrice,
+      gasLimit
+    );
   }
 
   /**

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -59,7 +59,7 @@ export class QueryBase implements QueryInterface {
    * @param deposit V3 deposit instance.
    * @param relayerAddress Relayer address to simulate with.
    * @param gasPrice Optional gas price to use for the simulation.
-   * @returns The gas estimate for this function call (multplied with the optional buffer).
+   * @returns The gas estimate for this function call (multiplied with the optional buffer).
    */
   async getGasCosts(
     deposit: Deposit,

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -242,6 +242,7 @@ export type TransactionCostEstimate = {
  * @param provider A valid ethers provider - will be used to reason the gas price.
  * @param gasMarkup Markup on the estimated gas cost. For example, 0.2 will increase this resulting value 1.2x.
  * @param gasPrice A manually provided gas price - if set, this function will not resolve the current gas price.
+ * @param gasLimit A manually provided gas limit - if set, this function will not estimate the gas limit.
  * @returns Estimated cost in units of gas and the underlying gas token (gasPrice * estimatedGasUnits).
  */
 export async function estimateTotalGasRequiredByUnsignedTransaction(
@@ -249,7 +250,8 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   senderAddress: string,
   provider: providers.Provider | L2Provider<providers.Provider>,
   gasMarkup: number,
-  gasPrice?: BigNumberish
+  gasPrice?: BigNumberish,
+  gasLimit?: BigNumberish
 ): Promise<TransactionCostEstimate> {
   assert(
     gasMarkup > -1 && gasMarkup <= 4,
@@ -262,8 +264,8 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   // Estimate the Gas units required to submit this transaction.
   let nativeGasCost = await voidSigner.estimateGas({
     ...unsignedTx,
-    gasPrice: gasPrice ?? undefined,
-    gasLimit: 8_000_000, // This prevents out of gas errors.
+    gasPrice,
+    gasLimit,
   });
   let tokenGasCost: BigNumber;
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -260,13 +260,16 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   const voidSigner = new VoidSigner(senderAddress, provider);
 
   // Estimate the Gas units required to submit this transaction.
-  let nativeGasCost = await voidSigner.estimateGas(unsignedTx);
+  let nativeGasCost = await voidSigner.estimateGas({
+    ...unsignedTx,
+    gasPrice: gasPrice ?? undefined,
+    gasLimit: 8_000_000, // This prevents out of gas errors.
+  });
   let tokenGasCost: BigNumber;
 
   // OP stack is a special case; gas cost is computed by the SDK, without having to query price.
   if (chainIsOPStack(chainId)) {
     assert(isOptimismL2Provider(provider), `Unexpected provider for chain ID ${chainId}.`);
-    assert(gasPrice === undefined, `Gas price (${gasPrice}) supplied for Optimism gas estimation (unused).`);
     const populatedTransaction = await voidSigner.populateTransaction({
       ...unsignedTx,
       gasLimit: nativeGasCost, // prevents additional gas estimation call

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -278,10 +278,11 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
     });
     // Concurrently estimate the gas cost on L1 and L2 instead of calling
     // `provider.estimateTotalGasCost` to improve performance.
-    const [l1GasCost, l2GasCost] = await Promise.all([
+    const [l1GasCost, l2GasPrice] = await Promise.all([
       provider.estimateL1GasCost(populatedTransaction),
-      provider.estimateL2GasCost(populatedTransaction),
+      gasPrice || provider.getGasPrice(),
     ]);
+    const l2GasCost = nativeGasCost.mul(l2GasPrice);
     tokenGasCost = l1GasCost.add(l2GasCost);
   } else {
     if (!gasPrice) {

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -39,12 +39,12 @@ describe("Utils test", () => {
     const spokePoolAddress = "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5"; // mainnet
     const relayerAddress = "0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010";
 
-    const gasPrice = toGWei(1);
-
     // @todo: Ensure that NODE_URL_1 is always defined in test CI?
     const rpcUrl = process.env.NODE_URL_1 ?? "https://cloudflare-eth.com";
     const provider = new providers.JsonRpcProvider(rpcUrl, 1);
     const spokePool: SpokePool = SpokePool__factory.connect(spokePoolAddress, provider);
+
+    const gasPrice = await provider.getGasPrice();
 
     const deposit = buildDepositForRelayerFeeTest("1", "usdc", 10, 1);
     const fill = await populateV3Relay(spokePool, deposit, relayerAddress);

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -9,7 +9,7 @@ import {
   retry,
   toBNWei,
 } from "../src/utils";
-import { toBN, toGWei } from "../src/utils/BigNumberUtils";
+import { toBN } from "../src/utils/BigNumberUtils";
 import { buildDepositForRelayerFeeTest, expect } from "./utils";
 
 dotenv.config();


### PR DESCRIPTION
Some integrators flagged an issue for fee estimation when setting custom messages. After some digging, a workaround is to set a large enough hardcoded gas limit and a gas price when calling `eth_estimateGas`. E.g. the following `eth_estimateGas` call fails where `gas` and `gasPrice` are not set:
```bash
curl https://arb1.arbitrum.io/rpc \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_estimateGas","params":[{"from":"0x428ab2ba90eba0a4be7af34c9ac451ab061ac010","to":"0xe35e9842fceaca96570b734083f4a58e8f7c5f2a","data":"0x2e3781150000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000a4b1000000000000000000000000ccb0be73bc7386db701006762dd7f8638d176d48000000000000000000000000ccb0be73bc7386db701006762dd7f8638d176d4800000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c3359000000000000000000000000af88d065e77c8cc2239327c5edb3a432268e58310000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000000000000000005f5e100000000000000000000000000000000000000000000000000000000000000008900000000000000000000000000000000000000000000000000000000ffffffff00000000000000000000000000000000000000000000000000000000ffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000400000000000000000000000005f851f67d24419982ecd7b7765defd64fbb50a97000000000000000000000000eefef4a7992d93a3d6f1135cc8ea02cd5b863c2a"}],"id":1,"jsonrpc":"2.0"}'
```
This one on the other hand succeeds with limit and price set
```bash
curl https://arb1.arbitrum.io/rpc \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_estimateGas","params":[{"from":"0x428ab2ba90eba0a4be7af34c9ac451ab061ac010","to":"0xe35e9842fceaca96570b734083f4a58e8f7c5f2a","gas":"0x989680","gasPrice":"0x989680","data":"0x2e3781150000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000a4b1000000000000000000000000ccb0be73bc7386db701006762dd7f8638d176d48000000000000000000000000ccb0be73bc7386db701006762dd7f8638d176d4800000000000000000000000000000000000000000000000000000000000000000000000000000000000000003c499c542cef5e3811e1192ce70d8cc03d5c3359000000000000000000000000af88d065e77c8cc2239327c5edb3a432268e58310000000000000000000000000000000000000000000000000000000005f5e1000000000000000000000000000000000000000000000000000000000005f5e100000000000000000000000000000000000000000000000000000000000000008900000000000000000000000000000000000000000000000000000000ffffffff00000000000000000000000000000000000000000000000000000000ffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000400000000000000000000000005f851f67d24419982ecd7b7765defd64fbb50a97000000000000000000000000eefef4a7992d93a3d6f1135cc8ea02cd5b863c2a"}],"id":1,"jsonrpc":"2.0"}'
```

This PR therefore proposes a change to allow us to pass a custom gas limit and price into the fee calculator.

