### PR TITLE
improve(NetworkUtils): add chainIsL1Function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.12",
+  "version": "3.1.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -90,6 +90,15 @@ export function chainIsLinea(chainId: number): boolean {
 }
 
 /**
+ * Determines whether a chain ID has a corresponding hub pool contract.
+ * @param chainId Chain ID to evaluate.
+ * @returns True if chain corresponding to chainId has a hub pool implementation.
+ */
+export function chainIsL1(chainId: number): boolean {
+  return [CHAIN_IDs.MAINNET, CHAIN_IDs.SEPOLIA].includes(chainId);
+}
+
+/**
  * Determines whether a chain ID has the capacity for having its USDC bridged via CCTP.
  * @param chainId Chain ID to evaluate.
  * @returns True if chainId is a CCTP-bridging enabled chain, otherwise false.


### PR DESCRIPTION
As we begin to introduce `tryMulticall` into the relayer, the `MulticallerClient` will need to be aware of whether it is calling a spoke pool or hub pool contract (to determine whether it can even call `tryMulticall`). One approach is to first check if the contract's chain ID we are calling is one which has a hub pool implementation. It would be ideal to introduce this code into the sdk, where there already exists a set of functions which performs similar checks with our other chain IDs. 