### PR TITLE
feat: add scroll to gas price oracle

### DIFF
--- a/e2e/oracle.e2e.ts
+++ b/e2e/oracle.e2e.ts
@@ -51,6 +51,7 @@ const networks: { [chainId: number]: string } = {
   324: "https://mainnet.era.zksync.io",
   8453: "https://mainnet.base.org",
   42161: "https://rpc.ankr.com/arbitrum",
+  534352: "https://rpc.scroll.io",
 };
 
 const stdGasPrice = ethersUtils.parseUnits("10", 9);
@@ -58,7 +59,7 @@ const stdMaxPriorityFeePerGas = ethersUtils.parseUnits("1.5", 9); // EIP-1559 ch
 const stdLastBaseFeePerGas = stdGasPrice.sub(stdMaxPriorityFeePerGas);
 const stdMaxFeePerGas = stdGasPrice;
 const eip1559Chains = [1, 10, 137, 8453, 42161];
-const legacyChains = [288, 324];
+const legacyChains = [288, 324, 534352];
 
 let providerInstances: { [chainId: number]: MockedProvider } = {};
 

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -33,6 +33,7 @@ export async function getGasPriceEstimate(
     [CHAIN_IDs.OPTIMISM]: ethereum.eip1559,
     [CHAIN_IDs.POLYGON]: polygon.gasStation,
     [CHAIN_IDs.ZK_SYNC]: ethereum.legacy,
+    [CHAIN_IDs.SCROLL]: ethereum.legacy,
   };
 
   let gasPriceFeed = gasPriceFeeds[chainId];


### PR DESCRIPTION
According to the last paragraph in  https://docs.scroll.io/en/developers/transaction-fees-on-scroll/#l1-originated-transactions, we can use the legacy RPC call `eth_gasPrice` to determine the gas price on Scroll:
> If your system supports off-chain mechanisms, you can also call eth_estimateGas and eth_gasPrice on any Scroll RPC node to get an estimate of the gas required for a given transaction.

Closes ACX-2356