### PR TITLE
fix: cg lookup edge case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -256,19 +256,20 @@ export class RelayFeeCalculator {
       });
       throw error;
     });
-    const getTokenPrice = this.queries.getTokenPrice(token.symbol).catch((error) => {
-      this.logger.error({
-        at: "sdk/gasFeePercent",
-        message: "Error while fetching token price",
-        error,
-        destinationChainId: deposit.destinationChainId,
-        inputToken,
-      });
-      throw error;
-    });
     const [{ tokenGasCost }, tokenPrice] = await Promise.all([
       getGasCosts,
-      _tokenPrice !== undefined ? _tokenPrice : getTokenPrice,
+      _tokenPrice !== undefined
+        ? _tokenPrice
+        : this.queries.getTokenPrice(token.symbol).catch((error) => {
+            this.logger.error({
+              at: "sdk/gasFeePercent",
+              message: "Error while fetching token price",
+              error,
+              destinationChainId: deposit.destinationChainId,
+              inputToken,
+            });
+            throw error;
+          }),
     ]);
     const gasFeesInToken = nativeToToken(tokenGasCost, tokenPrice, token.decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay.toString());

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -258,18 +258,17 @@ export class RelayFeeCalculator {
     });
     const [{ tokenGasCost }, tokenPrice] = await Promise.all([
       getGasCosts,
-      _tokenPrice !== undefined
-        ? _tokenPrice
-        : this.queries.getTokenPrice(token.symbol).catch((error) => {
-            this.logger.error({
-              at: "sdk/gasFeePercent",
-              message: "Error while fetching token price",
-              error,
-              destinationChainId: deposit.destinationChainId,
-              inputToken,
-            });
-            throw error;
-          }),
+      _tokenPrice ??
+        this.queries.getTokenPrice(token.symbol).catch((error) => {
+          this.logger.error({
+            at: "sdk/gasFeePercent",
+            message: "Error while fetching token price",
+            error,
+            destinationChainId: deposit.destinationChainId,
+            inputToken,
+          });
+          throw error;
+        }),
     ]);
     const gasFeesInToken = nativeToToken(tokenGasCost, tokenPrice, token.decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay.toString());


### PR DESCRIPTION
The `gasFeePercent()` function always attempts to call into CoinGecko. It's possible that its API call returns faster than our logic and triggers a 500 internal server error.