### PR TITLE
fix: Correctly resolve historical deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.21",
+  "version": "3.1.22",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -814,15 +814,8 @@ export class SpokePoolClient extends BaseAbstractClient {
         null,
         null,
         null,
-        destinationChainId,
+        null,
         depositId,
-        null,
-        null,
-        null,
-        depositor,
-        null,
-        null,
-        null
       ),
       {
         fromBlock: searchBounds.low,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -790,7 +790,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     return this.oldestTime;
   }
 
-  async findDeposit(depositId: number, destinationChainId: number, depositor: string): Promise<DepositWithBlock> {
+  async findDeposit(depositId: number, destinationChainId: number): Promise<DepositWithBlock> {
     // Binary search for event search bounds. This way we can get the blocks before and after the deposit with
     // deposit ID = fill.depositId and use those blocks to optimize the search for that deposit.
     // Stop searches after a maximum # of searches to limit number of eth_call requests. Make an
@@ -809,14 +809,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     const tStart = Date.now();
     const query = await paginatedEventQuery(
       this.spokePool,
-      this.spokePool.filters.V3FundsDeposited(
-        null,
-        null,
-        null,
-        null,
-        null,
-        depositId,
-      ),
+      this.spokePool.filters.V3FundsDeposited(null, null, null, null, null, depositId),
       {
         fromBlock: searchBounds.low,
         toBlock: searchBounds.high,

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -97,7 +97,7 @@ export async function queryHistoricalDepositForFill(
   if (isDefined(cachedDeposit)) {
     deposit = cachedDeposit as DepositWithBlock;
   } else {
-    deposit = await spokePoolClient.findDeposit(fill.depositId, fill.destinationChainId, fill.depositor);
+    deposit = await spokePoolClient.findDeposit(fill.depositId, fill.destinationChainId);
     if (cache) {
       await setDepositInCache(deposit, getCurrentTime(), cache, DEFAULT_CACHING_TTL);
     }


### PR DESCRIPTION
When the fill is totally malformed and filters on values that never existed (i.e. the real deposit for this deposit ID specified an alternative destinationChainId), it will skip returning the _actual_ deposit for this deposit ID.