### PR TITLE
feat: Cheat codes for resolving provider URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.25",
+  "version": "3.1.26",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -1,4 +1,5 @@
 import { CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+import { RPCTransport } from "./types";
 
 // Chain-specific overrides for when the Alchemy endpoint does not match the canonical chain name.
 const endpoints: { [chainId: string]: string } = {
@@ -7,11 +8,11 @@ const endpoints: { [chainId: string]: string } = {
   [CHAIN_IDs.OPTIMISM]: "opt-mainnet",
 };
 
-export function getURL(chainId: number, apiKey: string): string {
+export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
   const host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
   if (!host) {
     throw new Error(`No known Alchemy provider for chainId ${chainId}`);
   }
 
-  return `https://${host.toLowerCase().replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
+  return `${transport.toLowerCase()}://${host.toLowerCase().replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
 }

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -6,8 +6,11 @@ const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs);
 // Chain-specific overrides for when the Alchemy endpoint does not match the canonical chain name.
 const endpoints: { [chainId: string]: string } = {
   [CHAIN_IDs.ARBITRUM]: "arb",
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: "arb",
   [CHAIN_IDs.MAINNET]: "eth",
+  [CHAIN_IDs.SEPOLIA]: "eth-sepolia",
   [CHAIN_IDs.OPTIMISM]: "opt",
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: "opt-sepolia",
 };
 
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
@@ -21,5 +24,5 @@ export function getURL(chainId: number, apiKey: string, transport: RPCTransport)
   }
   host = host.toLowerCase().replace(" ", "-");
 
-  return `${transport.toLowerCase()}://${host.toLowerCase().replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
+  return `${transport}://${host}.g.alchemy.com/v2/${apiKey}`;
 }

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -6,7 +6,7 @@ const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs);
 // Chain-specific overrides for when the Alchemy endpoint does not match the canonical chain name.
 const endpoints: { [chainId: string]: string } = {
   [CHAIN_IDs.ARBITRUM]: "arb",
-  [CHAIN_IDs.ARBITRUM_SEPOLIA]: "arb",
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: "arb-sepolia",
   [CHAIN_IDs.MAINNET]: "eth",
   [CHAIN_IDs.SEPOLIA]: "eth-sepolia",
   [CHAIN_IDs.OPTIMISM]: "opt",

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -1,0 +1,17 @@
+import { CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+
+// Chain-specific overrides for when the Alchemy endpoint does not match the canonical chain name.
+const endpoints: { [chainId: string]: string } = {
+  [CHAIN_IDs.ARBITRUM]: "arb-mainnet",
+  [CHAIN_IDs.MAINNET]: "eth-mainnet",
+  [CHAIN_IDs.OPTIMISM]: "opt-mainnet",
+};
+
+export function getURL(chainId: number, apiKey: string): string {
+  const host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
+  if (!host) {
+    throw new Error(`No known Alchemy provider for chainId ${chainId}`);
+  }
+
+  return `https://${host.replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
+}

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -13,5 +13,5 @@ export function getURL(chainId: number, apiKey: string): string {
     throw new Error(`No known Alchemy provider for chainId ${chainId}`);
   }
 
-  return `https://${host.replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
+  return `https://${host.toLowerCase().replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
 }

--- a/src/providers/alchemy.ts
+++ b/src/providers/alchemy.ts
@@ -1,18 +1,25 @@
-import { CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+import { CHAIN_IDs, MAINNET_CHAIN_IDs as _MAINNET_CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
 import { RPCTransport } from "./types";
+
+const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs);
 
 // Chain-specific overrides for when the Alchemy endpoint does not match the canonical chain name.
 const endpoints: { [chainId: string]: string } = {
-  [CHAIN_IDs.ARBITRUM]: "arb-mainnet",
-  [CHAIN_IDs.MAINNET]: "eth-mainnet",
-  [CHAIN_IDs.OPTIMISM]: "opt-mainnet",
+  [CHAIN_IDs.ARBITRUM]: "arb",
+  [CHAIN_IDs.MAINNET]: "eth",
+  [CHAIN_IDs.OPTIMISM]: "opt",
 };
 
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
-  const host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
+  let host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
   if (!host) {
     throw new Error(`No known Alchemy provider for chainId ${chainId}`);
   }
+
+  if (MAINNET_CHAIN_IDs.includes(chainId)) {
+    host = `${host}-mainnet`;
+  }
+  host = host.toLowerCase().replace(" ", "-");
 
   return `${transport.toLowerCase()}://${host.toLowerCase().replace(" ", "-")}.g.alchemy.com/v2/${apiKey}`;
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,4 +2,5 @@ export * from "./rateLimitedProvider";
 export * from "./cachedProvider";
 export * from "./retryProvider";
 export * from "./constants";
+export * from "./types";
 export * from "./utils";

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -1,10 +1,12 @@
-import { MAINNET_CHAIN_IDs as _MAINNET_CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+import { CHAIN_IDs, MAINNET_CHAIN_IDs as _MAINNET_CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
 import { RPCTransport } from "./types";
 
 const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs);
 
 // Chain-specific overrides for when the Infura endpoint does not match the canonical chain name.
-const endpoints: { [chainId: string]: string } = {};
+const endpoints: { [chainId: string]: string } = {
+  [CHAIN_IDs.ARBITRUM]: "arbitrum",
+};
 
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
   let host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
@@ -12,10 +14,10 @@ export function getURL(chainId: number, apiKey: string, transport: RPCTransport)
     throw new Error(`No known Infura provider for chainId ${chainId}`);
   }
 
-  if (MAINNET_CHAIN_IDs.includes(chainId)) {
+  if (chainId !== CHAIN_IDs.MAINNET && MAINNET_CHAIN_IDs.includes(chainId)) {
     host = `${host}-mainnet`;
   }
   host = host.toLowerCase().replace(" ", "-");
 
-  return transport === "https" ? `https://${host}.infura.io/v3/${apiKey}` : `wss://${host}.infura.is/ws/v3/${apiKey}`;
+  return transport === "https" ? `https://${host}.infura.io/v3/${apiKey}` : `wss://${host}.infura.io/ws/v3/${apiKey}`;
 }

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -4,7 +4,7 @@ import { PUBLIC_NETWORKS } from "../constants";
 const endpoints: { [chainId: string]: string } = {};
 
 export function getURL(chainId: number, apiKey: string): string {
-  let host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
+  const host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
   if (!host) {
     throw new Error(`No known Infura provider for chainId ${chainId}`);
   }

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -9,6 +9,5 @@ export function getURL(chainId: number, apiKey: string): string {
     throw new Error(`No known Infura provider for chainId ${chainId}`);
   }
 
-  host = host.replace(" ", "-");
-  return `https://${host}.infura.io/v3/${apiKey}`;
+  return `https://${host.toLowerCase().replace(" ", "-")}.infura.io/v3/${apiKey}`;
 }

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -1,0 +1,14 @@
+import { PUBLIC_NETWORKS } from "../constants";
+
+// Chain-specific overrides for when the Infura endpoint does not match the canonical chain name.
+const endpoints: { [chainId: string]: string } = {};
+
+export function getURL(chainId: number, apiKey: string): string {
+  let host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
+  if (!host) {
+    throw new Error(`No known Infura provider for chainId ${chainId}`);
+  }
+
+  host = host.replace(" ", "-");
+  return `https://${host}.infura.io/v3/${apiKey}`;
+}

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -17,5 +17,5 @@ export function getURL(chainId: number, apiKey: string, transport: RPCTransport)
   }
   host = host.toLowerCase().replace(" ", "-");
 
-  return transport === "HTTPS" ? `https://${host}.infura.io/v3/${apiKey}` : `wss://${host}.infura.is/ws/v3/${apiKey}`;
+  return transport === "https" ? `https://${host}.infura.io/v3/${apiKey}` : `wss://${host}.infura.is/ws/v3/${apiKey}`;
 }

--- a/src/providers/infura.ts
+++ b/src/providers/infura.ts
@@ -1,13 +1,21 @@
-import { PUBLIC_NETWORKS } from "../constants";
+import { MAINNET_CHAIN_IDs as _MAINNET_CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+import { RPCTransport } from "./types";
+
+const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs);
 
 // Chain-specific overrides for when the Infura endpoint does not match the canonical chain name.
 const endpoints: { [chainId: string]: string } = {};
 
-export function getURL(chainId: number, apiKey: string): string {
-  const host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
+export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
+  let host = endpoints[chainId] ?? PUBLIC_NETWORKS[chainId]?.name;
   if (!host) {
     throw new Error(`No known Infura provider for chainId ${chainId}`);
   }
 
-  return `https://${host.toLowerCase().replace(" ", "-")}.infura.io/v3/${apiKey}`;
+  if (MAINNET_CHAIN_IDs.includes(chainId)) {
+    host = `${host}-mainnet`;
+  }
+  host = host.toLowerCase().replace(" ", "-");
+
+  return transport === "HTTPS" ? `https://${host}.infura.io/v3/${apiKey}` : `wss://${host}.infura.is/ws/v3/${apiKey}`;
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,2 +1,2 @@
 export type RPCProvider = "INFURA" | "ALCHEMY";
-export type RPCTransport = "HTTPS" | "WSS";
+export type RPCTransport = "https" | "wss";

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,2 @@
+export type RPCProvider = "INFURA" | "ALCHEMY";
+export type RPCTransport = "HTTPS" | "WSS";

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -3,10 +3,10 @@ import assert from "assert";
 import { providers } from "ethers";
 import { isEqual } from "lodash";
 import { isDefined } from "../utils";
+import { RPCProvider, RPCTransport } from "./types";
 import * as alchemy from "./alchemy";
 import * as infura from "./infura";
 
-export type RPCProvider = "INFURA" | "ALCHEMY";
 
 const PROVIDERS = {
   ALCHEMY: alchemy.getURL,
@@ -17,12 +17,15 @@ export function isSupportedProvider(provider: string): provider is RPCProvider {
   return ["ALCHEMY", "INFURA"].includes(provider);
 }
 
-export function getURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
-  assert(apiKey, `API key for ${provider} chain ${chainId} not supplied`);
-
+export function getURL(
+  provider: RPCProvider,
+  chainId: number,
+  apiKey: string,
+  transport: RPCTransport = "HTTPS"
+): string {
   const getURL = PROVIDERS[provider];
   assert(getURL, `Unsupported RPC provider (${provider})`);
-  return getURL(chainId, apiKey);
+  return getURL(chainId, apiKey, transport);
 }
 
 /**

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,8 +1,27 @@
 // The async/queue library has a task-based interface for building a concurrent queue.
-
+import assert from "assert";
 import { providers } from "ethers";
-import { isDefined } from "../utils";
 import { isEqual } from "lodash";
+import { isDefined } from "../utils";
+import * as alchemy from "./alchemy";
+import * as infura from "./infura";
+
+export type RPCProvider = "INFURA" | "ALCHEMY";
+
+const PROVIDERS = {
+  ALCHEMY: alchemy.getURL,
+  INFURA: infura.getURL,
+};
+
+export function getProviderURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
+  if (!apiKey) {
+    throw new Error(`API key for ${provider} chain ${chainId} not supplied`);
+  }
+
+  const getURL = PROVIDERS[provider];
+  assert(getURL, `Unsupported RPC provider (${provider})`);
+  return getURL(chainId, apiKey);
+}
 
 /**
  * Deletes keys from an object and returns new copy of object without ignored keys

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -14,9 +14,7 @@ const PROVIDERS = {
 };
 
 export function getProviderURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
-  if (!apiKey) {
-    throw new Error(`API key for ${provider} chain ${chainId} not supplied`);
-  }
+  assert(apiKey, `API key for ${provider} chain ${chainId} not supplied`);
 
   const getURL = PROVIDERS[provider];
   assert(getURL, `Unsupported RPC provider (${provider})`);

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -37,7 +37,7 @@ export function getURL(
   provider: RPCProvider,
   chainId: number,
   apiKey: string,
-  transport: RPCTransport = "HTTPS"
+  transport: RPCTransport = "https"
 ): string {
   const getURL = PROVIDERS[provider];
   assert(getURL, `Unsupported RPC provider (${provider})`);

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -13,6 +13,10 @@ const PROVIDERS = {
   INFURA: infura.getURL,
 };
 
+export function supportedRPCProvider(provider: string): provider is RPCProvider {
+  return ["ALCHEMY", "INFURA"].includes(provider);
+}
+
 export function getProviderURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
   assert(apiKey, `API key for ${provider} chain ${chainId} not supplied`);
 

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -13,11 +13,11 @@ const PROVIDERS = {
   INFURA: infura.getURL,
 };
 
-export function supportedRPCProvider(provider: string): provider is RPCProvider {
+export function isSupportedProvider(provider: string): provider is RPCProvider {
   return ["ALCHEMY", "INFURA"].includes(provider);
 }
 
-export function getProviderURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
+export function getURL(provider: RPCProvider, chainId: number, apiKey?: string): string {
   assert(apiKey, `API key for ${provider} chain ${chainId} not supplied`);
 
   const getURL = PROVIDERS[provider];

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,16 +7,32 @@ import { RPCProvider, RPCTransport } from "./types";
 import * as alchemy from "./alchemy";
 import * as infura from "./infura";
 
-
+/**
+ * Infura DIN is identified separately to allow it to be configured explicitly.
+ */
 const PROVIDERS = {
   ALCHEMY: alchemy.getURL,
   INFURA: infura.getURL,
+  INFURA_DIN: infura.getURL,
 };
 
+/**
+ * Type predicate for RPCProvider type.
+ * @param provider Provider string (ALCHEMY, INFURA, ...).
+ * @returns True if the provider string is a supported provider.
+ */
 export function isSupportedProvider(provider: string): provider is RPCProvider {
-  return ["ALCHEMY", "INFURA"].includes(provider);
+  return ["ALCHEMY", "INFURA", "INFURA_DIN"].includes(provider);
 }
 
+/**
+ * Produce an RPC for a given RPC provider, chainId API key and transport.
+ * @param provider RPC provider identifier (ALCHEMY, INFURA, ...)
+ * @param chainId Chain ID to obtain a URL for.
+ * @param apiKey API key for provider.
+ * @param transport Optional transport specifier (HTTPS or WSS).
+ * @returns An RPC URL confirming to the specified inputs.
+ */
 export function getURL(
   provider: RPCProvider,
   chainId: number,


### PR DESCRIPTION
Alchemy has recently added support for reusing the same API key across multiple networks. Observing that both Alchemy and Infura use reasonably-predictable symbolic names for their endpoints (with a small number of exceptions), it's fairly advantageous to programatically resolve the endpoint URLs from a chain ID and an API key. This permits a single API key to be defined per provider, rather than the existing requirement of having to define each individual RPC configuration in the environment.

This change deliberately avoids trying to encode an env-var format for reading keys from the environment; that should permit maximum reuse amongst different applications.