### PR TITLE
improve(hubpool): integrate relayer work into sdk

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -40,6 +40,9 @@ import {
   spreadEvent,
   spreadEventWithBlockNumber,
   toBN,
+  getTokenInfo,
+  getUsdcSymbol,
+  getL1TokenInfo,
 } from "../utils";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "./AcrossConfigStoreClient/AcrossConfigStoreClient";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
@@ -258,6 +261,33 @@ export class HubPoolClient extends BaseAbstractClient {
 
   l2TokenEnabledForL1Token(l1Token: string, destinationChainId: number): boolean {
     return this.l1TokensToDestinationTokens?.[l1Token]?.[destinationChainId] != undefined;
+  }
+
+  /**
+   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
+   * @param tokenAddress Token address on `chain`
+   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
+   * @returns Token info for the given token address on the L2 chain including symbol and decimal.
+   */
+  getTokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
+    const tokenInfo = getTokenInfo(tokenAddress, chain);
+    // @dev Temporarily handle case where an L2 token for chain ID can map to more than one TOKEN_SYMBOLS_MAP
+    // entry. For example, L2 Bridged USDC maps to both the USDC and USDC.e/USDbC entries in TOKEN_SYMBOLS_MAP.
+    if (tokenInfo.symbol.toLowerCase() === "usdc" && chain !== this.chainId) {
+      tokenInfo.symbol = getUsdcSymbol(tokenAddress, chain) ?? "UNKNOWN";
+    }
+    return tokenInfo;
+  }
+
+  /**
+   * @dev If tokenAddress + chain do not exist in TOKEN_SYMBOLS_MAP then this will throw.
+   * @dev if the token matched in TOKEN_SYMBOLS_MAP does not have an L1 token address then this will throw.
+   * @param tokenAddress Token address on `chain`
+   * @param chain Chain where the `tokenAddress` exists in TOKEN_SYMBOLS_MAP.
+   * @returns Token info for the given token address on the Hub chain including symbol and decimal and L1 address.
+   */
+  getL1TokenInfoForAddress(tokenAddress: string, chain: number): L1Token {
+    return getL1TokenInfo(tokenAddress, chain);
   }
 
   getBlockNumber(timestamp: number): Promise<number | undefined> {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -16,3 +16,10 @@ export async function isContractDeployedToAddress(address: string, provider: pro
   // If the code is not empty, then there is a contract at this address
   return code !== "0x";
 }
+
+export function compareAddressesSimple(addressA?: string, addressB?: string): boolean {
+  if (addressA === undefined || addressB === undefined) {
+    return false;
+  }
+  return addressA.toLowerCase() === addressB.toLowerCase();
+}


### PR DESCRIPTION
We have existing logic in the relayer's hubpool client that we should integrate into the SDK. This will assist with migrating the BundleDataClient.