### PR TITLE
feat(SpokePoolClient): getter function for speedUps

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -293,6 +293,14 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
+   * Retrieves speed up requests grouped by depositor and depositId.
+   * @returns A mapping of depositor addresses to deposit ids with their corresponding speed up requests.
+   */
+  public getSpeedUps(): { [depositorAddress: string]: { [depositId: number]: SpeedUp[] } } {
+    return this.speedUps;
+  }
+
+  /**
    * Find a corresponding deposit for a given fill.
    * @param fill The fill to find a corresponding deposit for.
    * @returns The corresponding deposit if found, undefined otherwise.

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -94,6 +94,7 @@ export interface RootBundleRelay {
 export interface RootBundleRelayWithBlock extends RootBundleRelay, SortableEvent {}
 
 export interface RelayerRefundExecution extends RelayerRefundLeaf {
+  caller: string;
   rootBundleId: number;
 }
 
@@ -111,6 +112,7 @@ export interface RunningBalances {
 
 export interface TokensBridged extends SortableEvent {
   amountToReturn: BigNumber;
+  caller: string;
   chainId: number;
   leafId: number;
   l2TokenAddress: string;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -94,7 +94,6 @@ export interface RootBundleRelay {
 export interface RootBundleRelayWithBlock extends RootBundleRelay, SortableEvent {}
 
 export interface RelayerRefundExecution extends RelayerRefundLeaf {
-  caller: string;
   rootBundleId: number;
 }
 
@@ -112,7 +111,6 @@ export interface RunningBalances {
 
 export interface TokensBridged extends SortableEvent {
   amountToReturn: BigNumber;
-  caller: string;
   chainId: number;
   leafId: number;
   l2TokenAddress: string;


### PR DESCRIPTION
In order to index 'RequestedSpeedUpV3' events, the indexer needs to get the speedUps map from the SDK.