### PR TITLE
fix(test): Use less unreliable RPC provider

### DIFF
--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -41,7 +41,7 @@ describe("Utils test", () => {
     const relayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS;
 
     // @todo: Ensure that NODE_URL_1 is always defined in test CI?
-    const rpcUrl = process.env.NODE_URL_1 ?? "https://cloudflare-eth.com";
+    const rpcUrl = process.env.NODE_URL_1 ?? "https://eth-mainnet.g.alchemy.com/v2/demo";
     const provider = new providers.JsonRpcProvider(rpcUrl, 1);
     const spokePool: SpokePool = SpokePool__factory.connect(spokePoolAddress, provider);
 


### PR DESCRIPTION
Seeing lots of "noNetwork" errors on CloudFlare.