### PR TITLE
improve(ArweaveClient): handle 404 errors

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -175,13 +175,21 @@ export class ArweaveClient {
     });
     const results = await Promise.all(
       entries.map(async (edge) => {
-        const data = await this.get<T>(edge.node.id, validator);
-        return isDefined(data)
-          ? {
-              data,
-              hash: edge.node.id,
-            }
-          : null;
+        try {
+          const data = await this.get<T>(edge.node.id, validator);
+          return isDefined(data)
+            ? {
+                data,
+                hash: edge.node.id,
+              }
+            : null;
+        } catch (e) {
+          this.logger.warn({
+            at: "ArweaveClient:getByTopic",
+            message: `Bad request for Arweave topic ${edge.node.id}: ${e}`,
+          });
+          return null;
+        }
       })
     );
     return results.filter(isDefined);


### PR DESCRIPTION
On rare occasions the Arweave id we query is not yet accessible, leading to temporary 404 errors in the dataworker. This wraps the requests in a try/catch to prevent the dataworker from throwing when these 404 errors happen. As an example:
```
2024-09-04 18:46:59 [warn]: {
  "at": "ArweaveClient:getByTopic",
  "message": "Bad request for Arweave topic KBhB2uBPhQU-mXLOykRUQQQjjKThCLXRq4ncNVUhMJg: AxiosError: Request failed with status code 404",
  "run-identifier": "1819360f-26f0-45ad-9a56-471029fdab8e"
}
```

Closes ACX-2054