### PR TITLE
nit: remove unneeded constant

### DIFF
--- a/src/providers/constants.ts
+++ b/src/providers/constants.ts
@@ -4,8 +4,3 @@ export const BLOCK_NUMBER_TTL = 60;
 // This is the TTL for the provider cache.
 export const PROVIDER_CACHE_TTL = 3600;
 export const PROVIDER_CACHE_TTL_MODIFIER = 0.15;
-
-/**
- * A default timeout for requests of 60 seconds.
- */
-export const defaultTimeout = 60 * 1000;


### PR DESCRIPTION
Removes the `defaultTimeout` because it's currently only used in the context of the relayer