### PR TITLE
improve(clients): Add "NotReady" failure cause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.33",
+  "version": "3.1.34",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -3,6 +3,7 @@ import { CachingMechanismInterface } from "../interfaces";
 import { EventSearchConfig, isDefined, MakeOptional } from "../utils";
 
 export enum UpdateFailureReason {
+  NotReady,
   AlreadyUpdated,
   BadRequest,
   RPCError,

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -4,7 +4,7 @@ export {
   AcrossConfigStoreClient,
   ConfigStoreUpdate,
 } from "./AcrossConfigStoreClient";
-export { UpdateFailureReason } from "./BaseAbstractClient"
+export { UpdateFailureReason } from "./BaseAbstractClient";
 export { HubPoolClient, LpFeeRequest } from "./HubPoolClient";
 export { SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
 export * as BundleDataClient from "./BundleDataClient";

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -4,6 +4,7 @@ export {
   AcrossConfigStoreClient,
   ConfigStoreUpdate,
 } from "./AcrossConfigStoreClient";
+export { UpdateFailureReason } from "./BaseAbstractClient"
 export { HubPoolClient, LpFeeRequest } from "./HubPoolClient";
 export { SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
 export * as BundleDataClient from "./BundleDataClient";


### PR DESCRIPTION
This is useful in the looping model where some SpokePoolClient instances will be updated faster than others. The looping model doesn't wait for the SpokePoolClient to be ready, so it's useful to signal that update did not occur, rather than assuming that it did.