### PR TITLE
chore: Update Polygon GasStation implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.35",
+  "version": "3.1.36",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/adapters/polygon.ts
+++ b/src/gasPriceOracle/adapters/polygon.ts
@@ -27,8 +27,6 @@ type GasStationArgs = BaseHTTPAdapterArgs & {
 
 const { POLYGON } = CHAIN_IDs;
 
-// @dev toBNWei() is not imported from ../utils because of a circular dependency loop.
-//      The fix is probably to relocate the function estimateTotalGasRequiredByUnsignedTransaction().
 class PolygonGasStation extends BaseHTTPAdapter {
   readonly chainId: number;
 
@@ -42,7 +40,7 @@ class PolygonGasStation extends BaseHTTPAdapter {
   async getFeeData(strategy: "safeLow" | "standard" | "fast" = "fast"): Promise<GasPriceEstimate> {
     const gas = await this.query("v2", {});
 
-    const gasPrice: Polygon1559GasPrice = (gas as GasStationV2Response)?.[strategy];
+    const gasPrice = (gas as GasStationV2Response)?.[strategy];
     if (!this.isPolygon1559GasPrice(gasPrice)) {
       // @todo: generalise gasPriceError() to accept a reason/cause?
       gasPriceError("getFeeData()", this.chainId, bnZero);
@@ -70,7 +68,7 @@ class PolygonGasStation extends BaseHTTPAdapter {
 }
 
 export function gasStation(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
-  const gasStation = new PolygonGasStation({ chainId: chainId });
+  const gasStation = new PolygonGasStation({ chainId: chainId, timeout: 2000, retries: 0 });
   try {
     return gasStation.getFeeData();
   } catch (err) {

--- a/src/gasPriceOracle/adapters/polygon.ts
+++ b/src/gasPriceOracle/adapters/polygon.ts
@@ -1,6 +1,6 @@
 import { providers } from "ethers";
 import { BaseHTTPAdapter, BaseHTTPAdapterArgs } from "../../priceClient/adapters/baseAdapter";
-import { bnZero, isDefined, parseUnits } from "../../utils";
+import { BigNumber, bnZero, isDefined, parseUnits } from "../../utils";
 import { CHAIN_IDs } from "../../constants";
 import { GasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
@@ -67,12 +67,25 @@ class PolygonGasStation extends BaseHTTPAdapter {
   }
 }
 
-export function gasStation(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
+export async function gasStation(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
   const gasStation = new PolygonGasStation({ chainId: chainId, timeout: 2000, retries: 0 });
+  let maxPriorityFeePerGas: BigNumber;
+  let maxFeePerGas: BigNumber;
   try {
-    return gasStation.getFeeData();
+    ({ maxPriorityFeePerGas, maxFeePerGas } = await gasStation.getFeeData());
   } catch (err) {
     // Fall back to the RPC provider. May be less accurate.
-    return eip1559(provider, chainId);
+    ({ maxPriorityFeePerGas, maxFeePerGas } = await eip1559(provider, chainId));
+
+    // Per the GasStation docs, the minimum priority fee on Polygon is 30 Gwei.
+    // https://docs.polygon.technology/tools/gas/polygon-gas-station/#interpretation
+    const minPriorityFee = parseUnits("30", 9);
+    if (maxPriorityFeePerGas.lt(minPriorityFee)) {
+      const priorityDelta = minPriorityFee.sub(maxPriorityFeePerGas);
+      maxPriorityFeePerGas = minPriorityFee;
+      maxFeePerGas = maxFeePerGas.add(priorityDelta);
+    }
   }
+
+  return { maxPriorityFeePerGas, maxFeePerGas };
 }

--- a/src/priceClient/adapters/baseAdapter.ts
+++ b/src/priceClient/adapters/baseAdapter.ts
@@ -40,6 +40,7 @@ export class BaseHTTPAdapter {
   protected async query(path: string, urlArgs?: object): Promise<unknown> {
     const url = `https://${this.host}/${path ?? ""}`;
     const args = {
+      headers: { "User-Agent": process.env.ACROSS_USER_AGENT ?? "across-protocol" },
       timeout: this.timeout,
       params: urlArgs ?? {},
     };


### PR DESCRIPTION
Changes:
- Bump timeout from 1.5s to 2s.
- Reduce retries from 1 to 0.
- Enforce a minimum of 30 Gwei priority on gas station failure.
- Set HTTP user agent to "across-protocol" and permit overriding via the environment.
- Incidental cleanup.

This change is made on request from the Polygon team to support troubleshooting of repeat timeouts on the GasStation API.