### PR TITLE
fix(package): Ignore typechain outputs in watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=16.18.0"
   },
   "scripts": {
-    "start": "nodemon -e ts,tsx,json,js,jsx --watch ./src --ignore ./dist --exec 'yarn build'",
+    "start": "nodemon -e ts,tsx,json,js,jsx --watch ./src --ignore ./dist --ignore src/utils/abi/typechain --exec 'yarn build'",
     "build": "yarn run clean && yarn typechain && yarn run build:cjs & yarn run build:esm & yarn run build:types; wait",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",


### PR DESCRIPTION
These files are touched unconditionally by the build process, so if they are not ignored it triggers an infinite loop in the watcher.