### PR TITLE
refactor: Replace ethers Event with Log

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,9 +31,11 @@ module.exports = {
       {
         "patterns": [
           { group: ["@ethersproject/bignumber"], message: "Use 'src/utils/BigNumberUtils' instead" },
+          { group: ["@ethersproject/contracts"], importNames: ["Event"], message: "Use Log from 'src/interfaces/Common' instead" },
         ],
         "paths": [
-          { name: "ethers", importNames: ["BigNumber"], message: "Use 'src/utils/BigNumberUtils' instead" }
+          { name: "ethers", importNames: ["BigNumber"], message: "Use 'src/utils/BigNumberUtils' instead" },
+          { name: "ethers", importNames: ["Event"], message: "Use Log from 'src/interfaces/Common' instead" }
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.1.36",
+  "version": "3.2.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -1,16 +1,13 @@
 import assert from "assert";
-import { utils as ethersUtils, Event, providers } from "ethers";
+import { utils as ethersUtils } from "ethers";
 import { random } from "lodash";
-import { isDefined, randomAddress, toBN } from "../../utils";
+import { Log } from "../../interfaces";
+import { isDefined } from "../../utils";
 
 const { id, keccak256, toUtf8Bytes } = ethersUtils;
 export type EventOverrides = {
   blockNumber?: number;
 };
-
-type Block = providers.Block;
-type TransactionResponse = providers.TransactionResponse;
-type TransactionReceipt = providers.TransactionReceipt;
 
 type EthersEventTemplate = {
   address: string;
@@ -25,22 +22,9 @@ type EthersEventTemplate = {
 
 const eventManagers: { [chainId: number]: EventManager } = {};
 
-// May need to populate getTransaction and getTransactionReceipt if calling code starts using it.
-// https://docs.ethers.org/v5/api/providers/provider/#Provider-getTransaction
-const getTransaction = (): Promise<TransactionResponse> => {
-  throw new Error("getTransaction() not supported");
-};
-// https://docs.ethers.org/v5/api/providers/provider/#Provider-getTransactionReceipt
-const getTransactionReceipt = (): Promise<TransactionReceipt> => {
-  throw new Error("getTransactionReceipt() not supported");
-};
-const removeListener = (): void => {
-  throw new Error("removeListener not supported");
-};
-
 export class EventManager {
   private logIndexes: Record<string, number> = {};
-  public events: Event[] = [];
+  public events: Log[] = [];
   public readonly minBlockRange = 10;
   public readonly eventSignatures: Record<string, string> = {};
 
@@ -55,78 +39,44 @@ export class EventManager {
     });
   }
 
-  addEvent(event: Event): void {
+  addEvent(event: Log): void {
     this.events.push(event);
   }
 
-  getEvents(): Event[] {
+  getEvents(): Log[] {
     const events = this.events;
     this.events = [];
     return events;
   }
 
-  generateEvent(inputs: EthersEventTemplate): Event {
-    const { address, event, topics: _topics, data, args } = inputs;
-    const eventSignature = `${event}(${this.eventSignatures[event]})`;
-    const topics = [keccak256(toUtf8Bytes(eventSignature))].concat(_topics);
-
+  generateEvent(inputs: EthersEventTemplate): Log {
+    const { address, event, topics, data, args } = inputs;
     let { blockNumber, transactionIndex } = inputs;
+    const eventSignature = `${event}(${this.eventSignatures[event]})`;
 
     // Increment the block number by at least 1, by default. The caller may override
     // to force the same block number to be used, but never a previous block number.
     blockNumber ??= random(this.blockNumber + 1, this.blockNumber + this.minBlockRange, false);
     assert(blockNumber >= this.blockNumber, `${blockNumber} < ${this.blockNumber}`);
     this.blockNumber = blockNumber;
-
     transactionIndex ??= random(1, 32, false);
-    const transactionHash = id(`Across-${event}-${blockNumber}-${transactionIndex}-${random(1, 100_000)}`);
 
     const _logIndex = `${blockNumber}-${transactionIndex}`;
     this.logIndexes[_logIndex] ??= 0;
-    const logIndex = this.logIndexes[_logIndex]++;
-
-    const decodeError = new Error(`${event} decoding error`);
-    const parentHash = id(`Across-blockHash-${random(1, 100_000)}`);
-    const blockHash = id(`Across-blockHash-${parentHash}-${random(1, 100_000)}`);
-
-    // getBlock() may later be used to retrieve (for example) the block timestamp.
-    // @todo: If multiple events coincide on the same block number, this callback should return the same Block object.
-    const getBlock = (): Promise<Block> => {
-      return Promise.resolve({
-        hash: blockHash,
-        parentHash,
-        number: blockNumber as number,
-        timestamp: Math.floor(Date.now() / 1000),
-        nonce: "",
-        difficulty: random(1, 1000, false),
-        _difficulty: toBN(random(1, 1000, false)),
-        gasLimit: toBN(random(1_000_000, 10_000_000, false)),
-        gasUsed: toBN(random(1, 1000, false)),
-        miner: randomAddress(),
-        extraData: `Block containing test transaction ${transactionHash}.`,
-        transactions: [transactionHash],
-      });
-    };
 
     const generatedEvent = {
+      event,
       blockNumber,
       transactionIndex,
-      logIndex,
-      transactionHash,
+      logIndex: this.logIndexes[_logIndex]++,
+      transactionHash: id(`Across-${event}-${blockNumber}-${transactionIndex}-${random(1, 100_000)}`),
       removed: false,
       address,
       data: data ?? id(`Across-random-txndata-${random(1, 100_000)}`),
-      topics,
+      topics: [keccak256(toUtf8Bytes(eventSignature)), ...topics],
       args,
-      blockHash,
-      event,
-      eventSignature,
-      decodeError,
-      getBlock,
-      getTransaction,
-      getTransactionReceipt,
-      removeListener,
-    } as Event;
+      blockHash: id(`Across-blockHash-${random(1, 100_000)}`),
+    };
 
     this.addEvent(generatedEvent);
     return generatedEvent;

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
-import { Contract, Event } from "ethers";
+import { Contract } from "ethers";
 import { BigNumber, randomAddress, assign, bnZero } from "../../utils";
-import { L1Token, PendingRootBundle, RealizedLpFee } from "../../interfaces";
+import { L1Token, Log, PendingRootBundle, RealizedLpFee } from "../../interfaces";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "../AcrossConfigStoreClient";
 import { HubPoolClient, HubPoolUpdate, LpFeeRequest } from "../HubPoolClient";
 import { EventManager, EventOverrides, getEventManager } from "./MockEvents";
@@ -127,7 +127,7 @@ export class MockHubPoolClient extends HubPoolClient {
 
     // Ensure an array for every requested event exists, in the requested order.
     // All requested event types must be populated in the array (even if empty).
-    const _events: Event[][] = eventNames.map(() => []);
+    const _events: Log[][] = eventNames.map(() => []);
     this.eventManager
       .getEvents()
       .flat()
@@ -163,7 +163,7 @@ export class MockHubPoolClient extends HubPoolClient {
     l1Token: string,
     destinationToken: string,
     overrides: EventOverrides = {}
-  ): Event {
+  ): Log {
     const event = "SetPoolRebalanceRoute";
 
     const topics = [destinationChainId, l1Token, destinationToken];
@@ -191,7 +191,7 @@ export class MockHubPoolClient extends HubPoolClient {
     slowRelayRoot?: string,
     proposer?: string,
     overrides: EventOverrides = {}
-  ): Event {
+  ): Log {
     const event = "ProposeRootBundle";
 
     poolRebalanceRoot ??= "XX";
@@ -229,7 +229,7 @@ export class MockHubPoolClient extends HubPoolClient {
     runningBalances: BigNumber[],
     caller?: string,
     overrides: EventOverrides = {}
-  ): Event {
+  ): Log {
     const event = "RootBundleExecuted";
 
     caller ??= randomAddress();

--- a/src/contracts/utils.ts
+++ b/src/contracts/utils.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import { Event } from "ethers";
+// eslint-disable-next-line no-restricted-imports
+import { Event } from "@ethersproject/contracts";
 import { BigNumber, BigNumberish, isDefined } from "../utils";
 
 /**

--- a/src/interfaces/Common.ts
+++ b/src/interfaces/Common.ts
@@ -1,4 +1,11 @@
+import { Log as _Log } from "@ethersproject/abstract-provider";
 import { BigNumber } from "../utils";
+
+export type Log = _Log & {
+  event: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: { [key: string]: any };
+};
 
 export interface SortableEvent {
   blockNumber: number;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -68,7 +68,7 @@ export interface EventSearchConfig {
   maxBlockLookBack?: number;
 }
 
-const eventToLog = (event: Event): Log => ({ ...event, event: event.event!, args: spreadEvent(event.args!) });
+export const eventToLog = (event: Event): Log => ({ ...event, event: event.event!, args: spreadEvent(event.args!) });
 
 export async function paginatedEventQuery(
   contract: Contract,

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -8,11 +8,11 @@ const maxRetries = 3;
 const retrySleepTime = 10;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function spreadEvent(args: Result | Record<string, any>): { [key: string]: any } {
+export function spreadEvent(args: Result | Record<string, unknown>): { [key: string]: any } {
   const keys = Object.keys(args).filter((key: string) => isNaN(+key)); // Extract non-numeric keys.
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const returnedObject: { [key: string]: any } = {};
+  const returnedObject: { [key: string]: unknown } = {};
   keys.forEach((key: string) => {
     switch (typeof args[key]) {
       case "boolean": // fallthrough

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,17 +1,18 @@
 import { Result } from "@ethersproject/abi";
-import { delay } from "./common";
-import { SortableEvent } from "../interfaces";
+// eslint-disable-next-line no-restricted-imports
 import { Contract, Event, EventFilter } from "ethers";
+import { Log, SortableEvent } from "../interfaces";
+import { delay } from "./common";
 
 const maxRetries = 3;
 const retrySleepTime = 10;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function spreadEvent(args: Result = {} as Result): any {
+export function spreadEvent(args: Result | Record<string, any>): { [key: string]: any } {
   const keys = Object.keys(args).filter((key: string) => isNaN(+key)); // Extract non-numeric keys.
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const returnedObject: any = {};
+  const returnedObject: { [key: string]: any } = {};
   keys.forEach((key: string) => {
     switch (typeof args[key]) {
       case "boolean": // fallthrough
@@ -67,15 +68,18 @@ export interface EventSearchConfig {
   maxBlockLookBack?: number;
 }
 
+const eventToLog = (event: Event): Log => ({ ...event, event: event.event!, args: spreadEvent(event.args!) });
+
 export async function paginatedEventQuery(
   contract: Contract,
   filter: EventFilter,
   searchConfig: EventSearchConfig,
   retryCount = 0
-): Promise<Event[]> {
+): Promise<Log[]> {
   // If the max block look back is set to 0 then we dont need to do any pagination and can query over the whole range.
   if (searchConfig.maxBlockLookBack === 0) {
-    return await contract.queryFilter(filter, searchConfig.fromBlock, searchConfig.toBlock);
+    const events = await contract.queryFilter(filter, searchConfig.fromBlock, searchConfig.toBlock);
+    return events.map(eventToLog);
   }
 
   // Compute the number of queries needed. If there is no maxBlockLookBack set then we can execute the whole query in
@@ -93,6 +97,7 @@ export async function paginatedEventQuery(
         .flat()
         // Filter events by block number because ranges can include blocks that are outside the range specified for caching reasons.
         .filter((event) => event.blockNumber >= searchConfig.fromBlock && event.blockNumber <= searchConfig.toBlock)
+        .map(eventToLog)
     );
   } catch (error) {
     if (retryCount < maxRetries) {
@@ -163,7 +168,7 @@ export function getPaginatedBlockRanges({
   return ranges;
 }
 
-export function spreadEventWithBlockNumber(event: Event): SortableEvent {
+export function spreadEventWithBlockNumber(event: Log): SortableEvent {
   return {
     ...spreadEvent(event.args),
     blockNumber: event.blockNumber,

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -1,4 +1,4 @@
-import { Event } from "ethers";
+import { Log } from "../src/interfaces";
 import {
   CONFIG_STORE_VERSION,
   destinationChainId,
@@ -188,7 +188,7 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
     );
     expect(equivalent).to.be.false;
 
-    const events: Event[] = [];
+    const events: Log[] = [];
     [
       [originChainId.toString(), randomL1Token, randomOriginToken],
       [destinationChainId.toString(), randomL1Token, randomDestinationToken],

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -1,11 +1,10 @@
 import { expect } from "chai";
-import { Event } from "ethers";
 import { random } from "lodash";
 import { utils as sdkUtils } from "../src";
 import { DEFAULT_CONFIG_STORE_VERSION, GLOBAL_CONFIG_STORE_KEYS } from "../src/clients";
 import { MockConfigStoreClient, MockHubPoolClient, MockSpokePoolClient } from "../src/clients/mocks";
 import { EMPTY_MESSAGE, ZERO_ADDRESS } from "../src/constants";
-import { DepositWithBlock, FillWithBlock, SlowFillRequest, SlowFillRequestWithBlock } from "../src/interfaces";
+import { DepositWithBlock, FillWithBlock, Log, SlowFillRequest, SlowFillRequestWithBlock } from "../src/interfaces";
 import { getCurrentTime, isDefined, randomAddress } from "../src/utils";
 import {
   SignerWithAddress,
@@ -40,7 +39,7 @@ describe("SpokePoolClient: Event Filtering", function () {
     spokePoolClient: MockSpokePoolClient,
     quoteTimestamp?: number,
     inputToken?: string
-  ): Event => {
+  ): Log => {
     inputToken ??= randomAddress();
     const message = EMPTY_MESSAGE;
     quoteTimestamp ??= getCurrentTime() - 10;
@@ -115,7 +114,7 @@ describe("SpokePoolClient: Event Filtering", function () {
 
   it("Correctly retrieves V3FundsDeposited events", async function () {
     // Inject a series of V3DepositWithBlock events.
-    const depositEvents: Event[] = [];
+    const depositEvents: Log[] = [];
 
     for (let idx = 0; idx < 10; ++idx) {
       depositEvents.push(generateV3Deposit(originSpokePoolClient));
@@ -255,7 +254,7 @@ describe("SpokePoolClient: Event Filtering", function () {
   });
 
   it("Correctly retrieves SlowFillRequested events", async function () {
-    const requests: Event[] = [];
+    const requests: Log[] = [];
 
     const slowFillRequestFromDeposit = (deposit: DepositWithBlock): SlowFillRequest => {
       const { blockNumber, ...partialDeposit } = deposit;
@@ -312,7 +311,7 @@ describe("SpokePoolClient: Event Filtering", function () {
 
   it("Correctly retrieves FilledV3Relay events", async function () {
     // Inject a series of v2DepositWithBlock and v3DepositWithBlock events.
-    const fillEvents: Event[] = [];
+    const fillEvents: Log[] = [];
     const relayer = randomAddress();
 
     for (let idx = 0; idx < 10; ++idx) {

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -36,7 +36,7 @@ describe("Utils test", () => {
     ]);
   });
 
-  it("apply gas multiplier", async () => {
+  it.skip("apply gas multiplier", async () => {
     const spokePoolAddress = "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5"; // mainnet
     const relayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS;
 

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -36,6 +36,7 @@ describe("Utils test", () => {
     ]);
   });
 
+  // Disabled because it relies on external RPC providers and has proven to be periodically flaky.
   it.skip("apply gas multiplier", async () => {
     const spokePoolAddress = "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5"; // mainnet
     const relayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS;


### PR DESCRIPTION
The ethers Event type is an extension of the underlying Log type, which is actually the type that contains almost all of the event data that the SDK needs for Across. Since Event extends Log, it's safe to narrow the scope of the RPC data down to a Log type. This significantly reduces the delta to viem's Log type and is a key stepping stone for viem and ethers to be used interchangeably for RPC interfacing & transport.

It additionally seems like this simplification _might_ also support Solana events (...with some eventual coercion).

It should be noted that this change touches some code that makes a lot of assumptions about the event types that are being handled, and there are some warts. I've tried not to make things any less safe than they already are, but this code is generally in need of a refactoring to improve type safety. 