### PR TITLE
fix: do not pass gasPrice to estimateGas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -261,12 +261,7 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   const voidSigner = new VoidSigner(senderAddress, provider);
 
   // Estimate the Gas units required to submit this transaction.
-  let nativeGasCost = gasUnits
-    ? BigNumber.from(gasUnits)
-    : await voidSigner.estimateGas({
-        ...unsignedTx,
-        gasPrice,
-      });
+  let nativeGasCost = gasUnits ? BigNumber.from(gasUnits) : await voidSigner.estimateGas(unsignedTx);
   let tokenGasCost: BigNumber;
 
   // OP stack is a special case; gas cost is computed by the SDK, without having to query price.


### PR DESCRIPTION
When passing cached gas prices into the relay fee calculator in the API, `estimateGas` was erroring. I think this is due to the reason that we provided the value into the estimate method as well. 