### PR TITLE
fix: include tx hash in `l1TokensToDestinationTokensWithBlock`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -922,6 +922,7 @@ export class HubPoolClient extends BaseAbstractClient {
               blockNumber: args.blockNumber,
               transactionIndex: args.transactionIndex,
               logIndex: args.logIndex,
+              transactionHash: args.transactionHash,
             },
           ]
         );


### PR DESCRIPTION
The variable `l1TokensToDestinationTokensWithBlock` is a nested record of `DestinationTokenWithBlock[]` which includes a `transactionHash` field from the `SortableEvent` interface.

We were not assigning `transactionHash` in the hub pool client's `update()` function. This was uncovered during work on the indexer.