### PR TITLE
experimental: gasPriceOracle overhaul

### DIFF
--- a/e2e/oracle.e2e.ts
+++ b/e2e/oracle.e2e.ts
@@ -1,10 +1,11 @@
 // @note: This test is _not_ run automatically as part of git hooks or CI.
 import dotenv from "dotenv";
 import winston from "winston";
-import { providers, utils as ethersUtils } from "ethers";
+import { custom } from "viem";
+import { providers } from "ethers";
 import { getGasPriceEstimate } from "../src/gasPriceOracle";
-import { BigNumber } from "../src/utils";
-import { assertPromiseError, expect } from "../test/utils";
+import { BigNumber, bnZero, parseUnits } from "../src/utils";
+import { expect } from "../test/utils";
 dotenv.config({ path: ".env" });
 
 const dummyLogger = winston.createLogger({
@@ -12,86 +13,46 @@ const dummyLogger = winston.createLogger({
   transports: [new winston.transports.Console()],
 });
 
-type FeeData = providers.FeeData;
+const stdLastBaseFeePerGas = parseUnits("12", 9);
+const stdMaxPriorityFeePerGas = parseUnits("1", 9); // EIP-1559 chains only
+const stdMaxFeePerGas = stdLastBaseFeePerGas.add(stdMaxPriorityFeePerGas);
+const stdGasPrice = stdMaxFeePerGas;
 
-class MockedProvider extends providers.StaticJsonRpcProvider {
-  // Unknown type => exercise our validation logic
-  public testFeeData: unknown;
-  public testGasPrice: unknown;
-
-  constructor(url: string) {
-    super(url);
+const customTransport = custom({
+  async request({ method, params}: { method: string; params: unknown }) {
+    params; // lint
+    switch (method) {
+      case "eth_gasPrice":
+        return BigInt(stdGasPrice.toString());
+      case "eth_getBlockByNumber":
+        return { baseFeePerGas: BigInt((stdLastBaseFeePerGas.mul(100).div(120)).toString()) };
+      case "eth_maxPriorityFeePerGas":
+        return BigInt(stdMaxPriorityFeePerGas.toString());
+      default:
+        console.log(`Unsupported method: ${method}.`);
+    }
   }
+});
 
-  override async getFeeData(): Promise<FeeData> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (this.testFeeData as any) ?? (await super.getFeeData());
-  }
-
-  override async getGasPrice(): Promise<BigNumber> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return this.testGasPrice !== undefined ? (this.testGasPrice as any) : await super.getGasPrice();
-  }
-}
-
-/**
- * Note: If NODE_URL_<chainId> envvars exist, they will be used. The
- * RPCs defined below are otherwise used as default/fallback options.
- * These may be subject to rate-limiting, in which case the retrieved
- * price will revert to 0.
- *
- * Note also that Optimism is only supported as a fallback/legacy test
- * case. It works, but is not the recommended method for conjuring gas
- * prices on Optimism.
- */
-const networks: { [chainId: number]: string } = {
-  1: "https://eth.llamarpc.com",
-  10: "https://mainnet.optimism.io",
-  137: "https://polygon.llamarpc.com",
-  288: "https://mainnet.boba.network",
-  324: "https://mainnet.era.zksync.io",
-  8453: "https://mainnet.base.org",
-  42161: "https://rpc.ankr.com/arbitrum",
-  534352: "https://rpc.scroll.io",
-};
-
-const stdGasPrice = ethersUtils.parseUnits("10", 9);
-const stdMaxPriorityFeePerGas = ethersUtils.parseUnits("1.5", 9); // EIP-1559 chains only
-const stdLastBaseFeePerGas = stdGasPrice.sub(stdMaxPriorityFeePerGas);
-const stdMaxFeePerGas = stdGasPrice;
-const eip1559Chains = [1, 10, 137, 8453, 42161];
-const legacyChains = [288, 324, 534352];
-
-let providerInstances: { [chainId: number]: MockedProvider } = {};
+const eip1559Chains = [1, 10, 137, 324, 8453, 42161, 534352];
+const chainIds = [ ...eip1559Chains, 1337 ];
+let providerInstances: { [chainId: number]: providers.StaticJsonRpcProvider } = {};
 
 describe("Gas Price Oracle", function () {
   before(() => {
     providerInstances = Object.fromEntries(
-      Object.entries(networks).map(([_chainId, _rpcUrl]) => {
-        const chainId = Number(_chainId);
-        const rpcUrl: string = process.env[`NODE_URL_${chainId}`] ?? _rpcUrl;
-        const provider = new MockedProvider(rpcUrl);
+      chainIds.map((chainId) => {
+        const provider = new providers.StaticJsonRpcProvider("https://eth.llamarpc.com");
         return [chainId, provider];
       })
     );
-  });
-
-  beforeEach(() => {
-    for (const provider of Object.values(providerInstances)) {
-      provider.testFeeData = {
-        gasPrice: stdGasPrice,
-        lastBaseFeePerGas: stdLastBaseFeePerGas,
-        maxPriorityFeePerGas: stdMaxPriorityFeePerGas,
-      };
-      provider.testGasPrice = stdGasPrice; // Required: same as provider.feeData.gasPrice.
-    }
   });
 
   it("Gas Price Retrieval", async function () {
     for (const [_chainId, provider] of Object.entries(providerInstances)) {
       const chainId = Number(_chainId);
 
-      const { maxFeePerGas, maxPriorityFeePerGas } = await getGasPriceEstimate(provider);
+      const { maxFeePerGas, maxPriorityFeePerGas } = await getGasPriceEstimate(provider, customTransport);
       dummyLogger.debug({
         at: "Gas Price Oracle#Gas Price Retrieval",
         message: `Retrieved gas price estimate for chain ID ${chainId}`,
@@ -113,104 +74,14 @@ describe("Gas Price Oracle", function () {
           expect(maxFeePerGas.eq(stdLastBaseFeePerGas.add(1))).to.be.true;
           expect(maxPriorityFeePerGas.eq(1)).to.be.true;
         } else {
-          expect(maxFeePerGas.eq(stdMaxFeePerGas)).to.be.true;
-          expect(maxPriorityFeePerGas.eq(stdMaxPriorityFeePerGas)).to.be.true;
+          expect(maxFeePerGas.gt(bnZero)).to.be.true;
+          expect(maxPriorityFeePerGas.gt(bnZero)).to.be.true;
         }
       } else {
         // Defaults to Legacy (Type 0)
-        expect(maxFeePerGas.eq(stdGasPrice)).to.be.true;
-        expect(maxPriorityFeePerGas.eq(0)).to.be.true;
+        expect(maxFeePerGas.eq(stdMaxFeePerGas)).to.be.true;
+        expect(maxPriorityFeePerGas.eq(bnZero)).to.be.true;
       }
-    }
-  });
-
-  it("Gas Price Retrieval Failure", async function () {
-    const feeDataFields = ["gasPrice", "lastBaseFeePerGas", "maxPriorityFeePerGas"];
-    const feeDataValues = [null, "test", "1234", 5678, BigNumber.from(-1)];
-
-    // Iterate over various faulty values for gasPrice & feeData.
-    // Loop one chain at a time to minimise rate-limiting in case a public RPC is being used.
-    for (const field of feeDataFields) {
-      for (const value of feeDataValues) {
-        for (const [_chainId, provider] of Object.entries(providerInstances)) {
-          const chainId = Number(_chainId);
-
-          provider.testGasPrice = field === "gasPrice" ? value : stdGasPrice;
-          provider.testFeeData = {
-            gasPrice: field === "gasPrice" ? value : stdGasPrice,
-            lastBaseFeePerGas: field === "lastBaseFeePerGas" ? value : stdLastBaseFeePerGas,
-            maxPriorityFeePerGas: field === "maxPriorityFeePerGas" ? value : stdMaxPriorityFeePerGas,
-          };
-
-          // Malformed inputs were supplied; ensure an exception is thrown.
-          if (
-            (legacyChains.includes(chainId) && ["gasPrice"].includes(field)) ||
-            (chainId !== 137 &&
-              eip1559Chains.includes(chainId) &&
-              ["lastBaseFeePerGas", "maxPriorityFeePerGas"].includes(field))
-          ) {
-            provider.testGasPrice = field === "gasPrice" ? value : stdGasPrice;
-            await assertPromiseError(getGasPriceEstimate(provider, chainId));
-          } else {
-            // Expect sane results to be returned; validate them.
-            const { maxFeePerGas, maxPriorityFeePerGas } = await getGasPriceEstimate(provider, chainId);
-
-            dummyLogger.debug({
-              at: "Gas Price Oracle#Gas Price Retrieval Failure",
-              message: `Retrieved gas price estimate for chain ID ${chainId}.`,
-              maxFeePerGas,
-              maxPriorityFeePerGas,
-            });
-
-            expect(BigNumber.isBigNumber(maxFeePerGas)).to.be.true;
-            expect(BigNumber.isBigNumber(maxPriorityFeePerGas)).to.be.true;
-
-            if (eip1559Chains.includes(chainId)) {
-              if (chainId === 137) {
-                expect(maxFeePerGas.gt(0)).to.be.true;
-                expect(maxPriorityFeePerGas.gt(0)).to.be.true;
-                expect(maxPriorityFeePerGas.lt(maxFeePerGas)).to.be.true;
-              } else if (chainId === 42161) {
-                expect(maxFeePerGas.eq(stdLastBaseFeePerGas.add(1))).to.be.true;
-                expect(maxPriorityFeePerGas.eq(1)).to.be.true;
-              } else {
-                expect(maxFeePerGas.eq(stdMaxFeePerGas)).to.be.true;
-                expect(maxPriorityFeePerGas.eq(stdMaxPriorityFeePerGas)).to.be.true;
-              }
-            } else {
-              // Legacy
-              expect(maxFeePerGas.eq(stdGasPrice)).to.be.true;
-              expect(maxPriorityFeePerGas.eq(0)).to.be.true;
-            }
-          }
-        }
-      }
-    }
-  });
-
-  it("Gas Price Fallback Behaviour", async function () {
-    for (const provider of Object.values(providerInstances)) {
-      const fakeChainId = 1337;
-
-      const chainId = (await provider.getNetwork()).chainId;
-      dummyLogger.debug({
-        at: "Gas Price Oracle#Gas Price Fallback Behaviour",
-        message: `Testing on chainId ${chainId}.`,
-      });
-
-      provider.testGasPrice = stdMaxFeePerGas; // Suppress RPC lookup.
-
-      const { maxFeePerGas, maxPriorityFeePerGas } = await getGasPriceEstimate(provider, fakeChainId, true);
-
-      // Require legacy pricing when fallback is permitted.
-      expect(BigNumber.isBigNumber(maxFeePerGas)).to.be.true;
-      expect(maxFeePerGas.eq(stdMaxFeePerGas)).to.be.true;
-
-      expect(BigNumber.isBigNumber(maxPriorityFeePerGas)).to.be.true;
-      expect(maxPriorityFeePerGas.eq(0)).to.be.true;
-
-      // Verify an assertion is thrown when fallback is not permitted.
-      await assertPromiseError(getGasPriceEstimate(provider, fakeChainId, false));
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "lodash": "^4.17.21",
     "lodash.get": "^4.4.2",
     "superstruct": "^0.15.4",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "viem": "^2.21.15"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",

--- a/src/gasPriceOracle/adapters/arbitrum.ts
+++ b/src/gasPriceOracle/adapters/arbitrum.ts
@@ -1,25 +1,14 @@
-import { providers } from "ethers";
-import { BigNumber, bnOne, parseUnits } from "../../utils";
-import { GasPriceEstimate } from "../types";
-import * as ethereum from "./ethereum";
+import { PublicClient } from "viem";
+import { InternalGasPriceEstimate } from "../types";
 
-let DEFAULT_PRIORITY_FEE: BigNumber | undefined = undefined;
+const MAX_PRIORITY_FEE_PER_GAS = BigInt(1);
 
-// Arbitrum Nitro implements EIP-1559 pricing, but the priority fee is always refunded to the caller. Further,
-// ethers typically hardcodes the priority fee to 1.5 Gwei. So, confirm that the priority fee supplied was 1.5
-// Gwei, and then drop it to 1 Wei. Reference: https://developer.arbitrum.io/faqs/gas-faqs#q-priority
-export async function eip1559(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
-  DEFAULT_PRIORITY_FEE ??= parseUnits("1.5", 9);
-  const { maxFeePerGas: _maxFeePerGas, maxPriorityFeePerGas } = await ethereum.eip1559(provider, chainId);
-
-  // If this throws, ethers default behaviour has changed, or Arbitrum RPCs are returning something more sensible.
-  if (!maxPriorityFeePerGas.eq(DEFAULT_PRIORITY_FEE)) {
-    throw new Error(`Expected hardcoded 1.5 Gwei priority fee on Arbitrum, got ${maxPriorityFeePerGas}`);
-  }
-
-  // eip1559() sets maxFeePerGas = lastBaseFeePerGas + maxPriorityFeePerGas, so revert that.
-  // The caller may apply scaling as they wish afterwards.
-  const maxFeePerGas = _maxFeePerGas.sub(maxPriorityFeePerGas).add(bnOne);
-
-  return { maxPriorityFeePerGas: bnOne, maxFeePerGas };
+// Arbitrum Nitro implements EIP-1559 pricing, but the priority fee is always refunded to the caller.
+// Swap it for 1 Wei to avoid inaccurate transaction cost estimates.
+// Reference: https://developer.arbitrum.io/faqs/gas-faqs#q-priority
+export async function eip1559(provider: PublicClient, _chainId: number): Promise<InternalGasPriceEstimate> {
+  let { maxFeePerGas, maxPriorityFeePerGas } = await provider.estimateFeesPerGas();
+  console.log(`arbitrum: got maxFeePerGas ${maxFeePerGas}, maxPriorityFeePerGas: ${maxPriorityFeePerGas}.`);
+  maxFeePerGas = BigInt(maxFeePerGas) - maxPriorityFeePerGas + MAX_PRIORITY_FEE_PER_GAS;
+  return { maxFeePerGas, maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS };
 }

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -1,28 +1,15 @@
-import { providers } from "ethers";
-import { BigNumber, bnZero } from "../../utils";
-import { GasPriceEstimate } from "../types";
-import { gasPriceError } from "../util";
+import { PublicClient } from "viem";
+import { InternalGasPriceEstimate } from "../types";
 
-export async function eip1559(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
-  const feeData = await provider.getFeeData();
-
-  [feeData.lastBaseFeePerGas, feeData.maxPriorityFeePerGas].forEach((field: BigNumber | null) => {
-    if (!BigNumber.isBigNumber(field) || field.lt(bnZero)) gasPriceError("getFeeData()", chainId, feeData);
-  });
-
-  const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas as BigNumber;
-  const maxFeePerGas = maxPriorityFeePerGas.add(feeData.lastBaseFeePerGas as BigNumber);
-
-  return { maxPriorityFeePerGas, maxFeePerGas };
+export function eip1559(provider: PublicClient, _chainId: number): Promise<InternalGasPriceEstimate> {
+  return provider.estimateFeesPerGas();
 }
 
-export async function legacy(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
+export async function legacy(provider: PublicClient, _chainId: number): Promise<InternalGasPriceEstimate> {
   const gasPrice = await provider.getGasPrice();
-
-  if (!BigNumber.isBigNumber(gasPrice) || gasPrice.lt(bnZero)) gasPriceError("getGasPrice()", chainId, gasPrice);
 
   return {
     maxFeePerGas: gasPrice,
-    maxPriorityFeePerGas: bnZero,
+    maxPriorityFeePerGas: BigInt(0),
   };
 }

--- a/src/gasPriceOracle/adapters/linea.ts
+++ b/src/gasPriceOracle/adapters/linea.ts
@@ -2,10 +2,10 @@
 // This query is currently only available on Linea Sepolia, ETA mainnet 30 July.
 // Until then, just parrot the existing Ethereum EIP-1559 pricing strategy.
 // See also: https://docs.linea.build/developers/reference/api/linea-estimategas
-import { providers } from "ethers";
-import { GasPriceEstimate } from "../types";
+import { PublicClient } from "viem";
+import { InternalGasPriceEstimate } from "../types";
 import * as ethereum from "./ethereum";
 
-export function eip1559(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
+export function eip1559(provider: PublicClient, chainId: number): Promise<InternalGasPriceEstimate> {
   return ethereum.legacy(provider, chainId);
 }

--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -1,5 +1,7 @@
-import { providers } from "ethers";
+import { PublicClient, FeeValuesEIP1559 } from "viem";
 import { BigNumber } from "../utils";
+
+export type InternalGasPriceEstimate = FeeValuesEIP1559;
 
 export type GasPriceEstimate = {
   maxFeePerGas: BigNumber;
@@ -7,5 +9,5 @@ export type GasPriceEstimate = {
 };
 
 export interface GasPriceFeed {
-  (provider: providers.Provider, chainId: number): Promise<GasPriceEstimate>;
+  (provider: PublicClient, chainId: number): Promise<InternalGasPriceEstimate>;
 }

--- a/src/gasPriceOracle/util.ts
+++ b/src/gasPriceOracle/util.ts
@@ -1,6 +1,3 @@
-import { providers } from "ethers";
-import { BigNumber } from "../utils";
-
-export function gasPriceError(method: string, chainId: number, data: providers.FeeData | BigNumber): void {
+export function gasPriceError(method: string, chainId: number, data: unknown): void {
   throw new Error(`Malformed ${method} response on chain ID ${chainId} (${JSON.stringify(data)})`);
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -281,7 +281,7 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
     tokenGasCost = l1GasCost.add(l2GasCost);
   } else {
     if (!gasPrice) {
-      const gasPriceEstimate = await getGasPriceEstimate(provider, chainId);
+      const gasPriceEstimate = await getGasPriceEstimate(provider);
       gasPrice = gasPriceEstimate.maxFeePerGas;
     }
     tokenGasCost = nativeGasCost.mul(gasPrice);

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,11 @@
     axios "^1.6.2"
     zksync-web3 "^0.14.3"
 
+"@adraffy/ens-normalize@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
+  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
+
 "@apollo/protobufjs@1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.6.tgz#d601e65211e06ae1432bf5993a1a0105f2862f27"
@@ -1476,6 +1481,27 @@
   dependencies:
     "@noble/hashes" "1.3.1"
 
+"@noble/curves@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.0.tgz#f05771ef64da724997f69ee1261b2417a49522d6"
+  integrity sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
+"@noble/curves@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
+  integrity sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==
+  dependencies:
+    "@noble/hashes" "1.5.0"
+
+"@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
 "@noble/ed25519@^1.6.1":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
@@ -1490,6 +1516,16 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
   integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
+"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
+  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
 
 "@noble/hashes@~1.1.1":
   version "1.1.3"
@@ -2133,6 +2169,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
   integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
+"@scure/base@~1.1.6", "@scure/base@~1.1.8":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
 "@scure/bip32@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.0.tgz#dea45875e7fbc720c2b4560325f1cf5d2246d95b"
@@ -2151,6 +2192,15 @@
     "@noble/hashes" "~1.3.1"
     "@scure/base" "~1.1.0"
 
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
 "@scure/bip39@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.0.tgz#92f11d095bae025f166bef3defcc5bf4945d419a"
@@ -2166,6 +2216,14 @@
   dependencies:
     "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.4.0.tgz#664d4f851564e2e1d4bffa0339f9546ea55960a6"
+  integrity sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==
+  dependencies:
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.8"
 
 "@sentry/core@5.30.0":
   version "5.30.0"
@@ -3425,6 +3483,11 @@ abbrev@1.0.x:
   dependencies:
     web3-eth-abi "^1.2.1"
     web3-utils "^1.2.1"
+
+abitype@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.5.tgz#29d0daa3eea867ca90f7e4123144c1d1270774b6"
+  integrity sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -9281,6 +9344,11 @@ isomorphic-unfetch@^3.0.0:
     node-fetch "^2.6.1"
     unfetch "^4.2.0"
 
+isows@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.4.tgz#810cd0d90cc4995c26395d2aa4cfa4037ebdf061"
+  integrity sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -14609,6 +14677,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+viem@^2.21.15:
+  version "2.21.15"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.15.tgz#068c010946151e7f256bb7da601ab9b8287c583b"
+  integrity sha512-Ae05NQzMsqPWRwuAHf1OfmL0SjI+1GBgiFB0JA9BAbK/61nJXsTPsQxfV5CbLe4c3ct8IEZTX89rdeW4dqf97g==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.4.0"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.4.0"
+    abitype "1.0.5"
+    isows "1.0.4"
+    webauthn-p256 "0.0.5"
+    ws "8.17.1"
+
 vlq@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-2.0.4.tgz#6057b85729245b9829e3cc7755f95b228d4fe041"
@@ -15102,6 +15185,14 @@ web3@1.8.2, web3@^1.6.0:
     web3-shh "1.8.2"
     web3-utils "1.8.2"
 
+webauthn-p256@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.5.tgz#0baebd2ba8a414b21cc09c0d40f9dd0be96a06bd"
+  integrity sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==
+  dependencies:
+    "@noble/curves" "^1.4.0"
+    "@noble/hashes" "^1.4.0"
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -15300,6 +15391,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
nb. This is an experimental PR that's thrown up for some troubleshooting, and to debate whether it's worth going down this path with viem.

This change updates the gasPriceOracle to leverage viem's gas pricing strategies. This is beneficial because viem has an active community that are actively adding support for new chains and improving support for existing chains. An example of this is Linea, where linea_estimateGas is supported out of the box after a recent update.

In order to maintain some degree of compatibility with existing users of the gasPriceOracle, the external interface still accepts an ethers Provider instance. It then internally instantiates a viem PublicClient instance and uses that instead. There is still a residual issue of how to resolve the relevant provider URLs, since it's not necessarily reliable to pull from the provider due to the uncertain type (i.e. StaticJsonRpcProvider or one of the extended variants that wraps multiple providers).