### PR TITLE
improve(SpokePoolClient): Multicall latestBlock updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [


### PR DESCRIPTION
The SpokePoolClient is currently throwing semi-regular errors on update. This seems to be particularly occurring against Polygon. The underlying reason for this is that the RPC quroum system is performing an eth_call against multiple providers, tagged at the latest block number as resolved by only one of them. Some providers may not have resolved that block number yet, in which case the query fails.

The instance of this can presumably be reduced by bundling the two calls where this occurs into a single SpokePool multicall. As a side-benefit, it will reduce RPC consumption.