### PR TITLE
feat: return raw `gasUnits` without padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -69,13 +69,15 @@ export class QueryBase implements QueryInterface {
     deposit: Deposit,
     relayer = DEFAULT_SIMULATED_RELAYER_ADDRESS,
     gasPrice = this.fixedGasPrice,
-    gasUnits?: BigNumberish
+    gasUnits?: BigNumberish,
+    omitMarkup?: boolean
   ): Promise<TransactionCostEstimate> {
+    const gasMarkup = omitMarkup ? 0 : this.gasMarkup;
     assert(
-      this.gasMarkup > -1 && this.gasMarkup <= 4,
-      `Require -1.0 < Gas Markup (${this.gasMarkup}) <= 4.0 for a total gas multiplier within (0, +5.0]`
+      gasMarkup > -1 && gasMarkup <= 4,
+      `Require -1.0 < Gas Markup (${gasMarkup}) <= 4.0 for a total gas multiplier within (0, +5.0]`
     );
-    const gasTotalMultiplier = toBNWei(1.0 + this.gasMarkup);
+    const gasTotalMultiplier = toBNWei(1.0 + gasMarkup);
 
     const tx = await populateV3Relay(this.spokePool, deposit, relayer);
     const { nativeGasCost, tokenGasCost } = await estimateTotalGasRequiredByUnsignedTransaction(


### PR DESCRIPTION
Additionally return raw unpadded `gasUnits` in `getGasCosts` method. This allows us to correctly make use of a cached value by caching the unpadded `gasUnits` value and passing that in.