### PR TITLE
nit: remove unneeded null coalesce

### DIFF
--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -57,7 +57,7 @@ export function chainIsMatic(chainId: number): boolean {
  * @returns True if chainId is an OP stack, otherwise false.
  */
 export function chainIsOPStack(chainId: number): boolean {
-  return PUBLIC_NETWORKS[chainId]?.family === ChainFamily.OP_STACK ?? false;
+  return PUBLIC_NETWORKS[chainId]?.family === ChainFamily.OP_STACK;
 }
 
 /**


### PR DESCRIPTION
`Right operand of ?? is unreachable because the left operand is never nullish.`