### PR TITLE
fix(RetryProvider): Avoid unnecessary promise reassignment

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -265,25 +265,17 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     method: string,
     params: Array<unknown>
   ): Promise<unknown> {
-    const loop = true;
-    let promise: Promise<unknown>;
-    let i = 0;
-
-    do {
-      promise = this._sendAndValidate(provider, method, params);
+    let error: unknown;
+    for (let i = 0; i < this.retries; ++i) {
       try {
-        await promise;
-        break;
-      } catch (err: unknown) {
-        if (++i >= this.retries) {
-          throw err;
-        }
-
+        return await this._sendAndValidate(provider, method, params);
+      } catch (_err: unknown) {
+        error = _err;
         await delay(this.delay);
       }
-    } while (loop);
+    }
 
-    return promise;
+    throw error;
   }
 
   _getQuorum(method: string, params: Array<unknown>): number {

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -266,7 +266,6 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     params: Array<unknown>
   ): Promise<unknown> {
     const loop = true;
-
     let promise = this._sendAndValidate(provider, method, params);
     let i = 0;
 

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -266,7 +266,9 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     params: Array<unknown>
   ): Promise<unknown> {
     let { retries } = this;
-    while(true) {
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
       const [settled] = await Promise.allSettled([this._sendAndValidate(provider, method, params)]);
       if (settled.status === "fulfilled") {
         return settled.value;

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -266,10 +266,11 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     params: Array<unknown>
   ): Promise<unknown> {
     const loop = true;
-    let promise = this._sendAndValidate(provider, method, params);
+    let promise: Promise<unknown>;
     let i = 0;
 
     do {
+      promise = this._sendAndValidate(provider, method, params);
       try {
         await promise;
         break;
@@ -279,7 +280,6 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         }
 
         await delay(this.delay);
-        promise = this._sendAndValidate(provider, method, params);
       }
     } while (loop);
 


### PR DESCRIPTION
Debug logging has shown that the existing logic unconditionally completes the for() loop `this.retries` times for each RPC query. This doesn't seem to submit `this.retries` queries but does result in a lot of unnecessary promise reassignment, which _might_ (speculation) be wasting CPU and RAM in a tight loop.

The structure of the change here is made in anticipation of a follow-up commit to introduce some intelligence into the retry loop to avoid retries when the failure was actually "legitimate" (i.e. eth_call revert). Without this change it was proving very difficult to bail out of the retry loop due to the promise chaining that implies the use of closures.