### PR TITLE
fix(BlockUtils): Fix averageBlockTime

### DIFF
--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -53,9 +53,9 @@ export async function averageBlockTime(
   // OP stack chains inherit Optimism block times, but can be overridden.
   // prettier-ignore
   const cache = blockTimes[chainId]
-    ?? chainIsOPStack(chainId)
+    ?? (chainIsOPStack(chainId)
       ? blockTimes[CHAIN_IDs.OPTIMISM]
-      : undefined;
+      : undefined);
 
   const now = getCurrentTime();
   if (isDefined(cache) && now < cache.timestamp + cacheTTL) {


### PR DESCRIPTION
I noticed this function is returning 2s average time when passing in a mainnet provider and I think its a simple syntax error. Without these parentheses, the boolean logic is treating `blockTimes[chainId] ?? chainIsOPStack(chainId)` as the LHS to the `?` operator instead of what we want which is `blockTimes[chainId] ?? (chainIsOPStack(chainId) ? ...)`
