### PR TITLE
improve: add robustness to fallback price feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/priceClient/adapters/acrossApi.ts
+++ b/src/priceClient/adapters/acrossApi.ts
@@ -39,6 +39,8 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
 
   private validateResponse(response: unknown): response is AcrossPrice {
     if (typeof response !== "object") return false;
-    return response !== null && typeof (response as { [key: string]: unknown }).price === "number";
+    const responseMapped = response as { price: number } | null;
+    const priceMapped = Number(responseMapped?.price);
+    return response !== null && !isNaN(priceMapped) && priceMapped > 0;
   }
 }


### PR DESCRIPTION
This PR allows AlephZero to be queried even if the API call fails. It also validates that the API call returning price zero is an erroneous response.