### PR TITLE
improve(PriceClient): Add default price adapter

### DIFF
--- a/src/priceClient/adapters/default.ts
+++ b/src/priceClient/adapters/default.ts
@@ -20,7 +20,7 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
     return price[0];
   }
 
-  async getPricesByAddress(addresses: string[], _currency: string): Promise<TokenPrice[]> {
-    return addresses.map((address) => ({ address, price: 0, timestamp: 0 }));
+  getPricesByAddress(addresses: string[], _currency: string): Promise<TokenPrice[]> {
+    return Promise.resolve(addresses.map((address) => ({ address, price: 0, timestamp: 0 })));
   }
 }

--- a/src/priceClient/adapters/default.ts
+++ b/src/priceClient/adapters/default.ts
@@ -12,7 +12,7 @@ import { BaseHTTPAdapter } from "./baseAdapter";
  */
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
   constructor() {
-    super("Zero Adapter", "127.0.0.1", {});
+    super("Default Adapter", "127.0.0.1", {});
   }
 
   async getPriceByAddress(address: string, currency: string): Promise<TokenPrice> {

--- a/src/priceClient/adapters/default.ts
+++ b/src/priceClient/adapters/default.ts
@@ -1,0 +1,26 @@
+import { PriceFeedAdapter, TokenPrice } from "../priceClient";
+import { BaseHTTPAdapter } from "./baseAdapter";
+
+/**
+ * Fallback price adapter to unconditionally return 0 on all input addresses.
+ * This adapter can be used as a last-resort to default to a token price of 0
+ * in case all other adapters fail to resolve a token price.
+ *
+ * Note: This adapter could be augmented to permit returning a custom price on a per-token bsis.
+ * This would allow the caller to peg token prices, which has been a use cases in the Across API.
+ * That's left as an open possibility for now.
+ */
+export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
+  constructor() {
+    super("Zero Adapter", "127.0.0.1", {});
+  }
+
+  async getPriceByAddress(address: string, currency: string): Promise<TokenPrice> {
+    const price = await this.getPricesByAddress([address], currency);
+    return price[0];
+  }
+
+  async getPricesByAddress(addresses: string[], _currency: string): Promise<TokenPrice[]> {
+    return addresses.map((address) => ({ address, price: 0, timestamp: 0 }));
+  }
+}

--- a/src/priceClient/adapters/index.ts
+++ b/src/priceClient/adapters/index.ts
@@ -1,3 +1,4 @@
 export * as acrossApi from "./acrossApi";
 export * as coingecko from "./coingecko";
+export * as defaultAdapter from "./default";
 export * as defiLlama from "./defiLlama";

--- a/src/priceClient/priceClient.ts
+++ b/src/priceClient/priceClient.ts
@@ -50,7 +50,7 @@ export class PriceClient implements PriceFeedAdapter {
     assert(priceFeeds.length > 0, "No price feeds supplied.");
 
     if (!throwOnFailure) {
-      priceFeeds.push(new defaultAdapter.PriceFeed);
+      priceFeeds.push(new defaultAdapter.PriceFeed());
     }
   }
 


### PR DESCRIPTION
This adapter can be instantiated by the caller to permit the PriceClient to default to a price of 0 for any token that it was unable to resolve via the preceding adapters. It can additionally be automatically instantiated by the PriceClient based on an input option being set. This therefore provides the caller with a simple way of controlling whether a token price resolution failure should throw or not. It additionally provides a pathway for the caller to be able to specify fixed prices for one or more tokens.