### PR TITLE
improve(BundleDataClient): Simplify key used to store bundle data on Arweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.2.15",
+  "version": "3.2.16",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -171,8 +171,16 @@ export class BundleDataClient {
     this.bundleTimestampCache[key] = timestamps;
   }
 
-  private getArweaveClientKey(blockRangesForChains: number[][]): string {
-    return `bundles-${blockRangesForChains}`;
+  static getArweaveClientKey(blockRangesForChains: number[][]): string {
+    // As a unique key for this bundle, use the bundle mainnet end block, which should
+    // never be duplicated between bundles as long as thebundle block range
+    // always progresses forwards, which I think is a safe assumption. Other chains might pause
+    // but mainnet should never pause.
+    return blockRangesForChains[0][1].toString();
+  }
+
+  private getArweaveBundleDataClientKey(blockRangesForChains: number[][]): string {
+    return `bundles-${BundleDataClient.getArweaveClientKey(blockRangesForChains)}`;
   }
 
   private async loadPersistedDataFromArweave(
@@ -183,7 +191,7 @@ export class BundleDataClient {
     }
     const start = performance.now();
     const persistedData = await this.clients.arweaveClient.getByTopic(
-      this.getArweaveClientKey(blockRangesForChains),
+      this.getArweaveBundleDataClientKey(blockRangesForChains),
       BundleDataSS
     );
     // If there is no data or the data is empty, return undefined because we couldn't
@@ -579,7 +587,7 @@ export class BundleDataClient {
   }
 
   private async loadArweaveData(blockRangesForChains: number[][]): Promise<LoadDataReturnValue> {
-    const arweaveKey = this.getArweaveClientKey(blockRangesForChains);
+    const arweaveKey = this.getArweaveBundleDataClientKey(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.arweaveDataCache[arweaveKey]) {
       this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);

--- a/src/clients/BundleDataClient/utils/SuperstructUtils.ts
+++ b/src/clients/BundleDataClient/utils/SuperstructUtils.ts
@@ -123,7 +123,7 @@ const nestedV3BundleFillsSS = record(
 );
 
 export const BundleDataSS = object({
-  bundleBlockRanges: array(array(number())),
+  bundleBlockRanges: record(PositiveIntegerStringSS, array(number())),
   bundleDepositsV3: nestedV3DepositRecordSS,
   expiredDepositsToRefundV3: nestedV3DepositRecordSS,
   unexecutableSlowFills: nestedV3DepositRecordWithLpFeePctSS,


### PR DESCRIPTION
https://github.com/across-protocol/relayer/issues/1916 Changed the structure of the Arweve data, so update the SDK's `bundleDataClient` to be aware of changed strucutre.

Also simplifies the arweave key used to store the data and expose the function `getKey` as a static function so that the relayer's instance of the `bundleDataClient` can use the function
