### PR TITLE
improve(retryProvider): Fine-tune polling logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.3.23",
+  "version": "3.3.24",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -1,5 +1,6 @@
 import { ethers, logger } from "ethers";
 import { CachingMechanismInterface } from "../interfaces";
+import { CHAIN_IDs } from "../constants";
 import { delay, isDefined, isPromiseFulfilled, isPromiseRejected } from "../utils";
 import { getOriginFromURL } from "../utils/NetworkUtils";
 import { CacheProvider } from "./cachedProvider";
@@ -43,18 +44,10 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         )
     );
 
-    // This is added for interim testing to see whether relayer fill performance improves.
-    this.providers.forEach((provider) => {
-      const url = getOriginFromURL(provider.connection.url);
-      const { pollingInterval } = provider;
-      provider.pollingInterval = 1000;
-      logger?.debug({
-        at: "RetryProvider",
-        message: `Dropped ${url} pollingInterval ${pollingInterval} -> ${provider.pollingInterval}.`,
-      });
-    });
-
-    this.pollingInterval = 1000;
+    if (chainId !== CHAIN_IDs.MAINNET) {
+      this.pollingInterval = 1000;
+      this.providers.forEach((provider) => provider.pollingInterval = this.pollingInterval);
+    }
 
     if (this.nodeQuorumThreshold < 1 || !Number.isInteger(this.nodeQuorumThreshold)) {
       throw new Error(

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -46,7 +46,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
 
     if (chainId !== CHAIN_IDs.MAINNET) {
       this.pollingInterval = 1000;
-      this.providers.forEach((provider) => provider.pollingInterval = this.pollingInterval);
+      this.providers.forEach((provider) => (provider.pollingInterval = this.pollingInterval));
     }
 
     if (this.nodeQuorumThreshold < 1 || !Number.isInteger(this.nodeQuorumThreshold)) {


### PR DESCRIPTION
Don't adjust the pollingInterval on mainnet because the relatively high block times will result in a lot of unnecessary calls. Additionally, remove the log about dropping the pollingInterval because it's quite noisy in production.