### PR TITLE
fix(retryProvider): Don't log entire RPC responses

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -135,18 +135,16 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     }
 
     const getMismatchedProviders = (values: [ethers.providers.StaticJsonRpcProvider, unknown][]) => {
-      return Object.fromEntries(
-        values
-          .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
-          .map(([provider]) => [provider.connection.url])
-      );
+      return values
+        .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
+        .map(([provider]) => provider.connection.url);
     };
 
     const logQuorumMismatchOrFailureDetails = (
       method: string,
       params: Array<unknown>,
       quorumProviders: string[],
-      mismatchedProviders: { [k: string]: unknown },
+      mismatchedProviders: string[],
       errors: [ethers.providers.StaticJsonRpcProvider, string][]
     ) => {
       logger.warn({
@@ -232,7 +230,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     const quorumProviders = [...values, ...fallbackValues]
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => provider.connection.url);
-    if (Object.keys(mismatchedProviders).length > 0 || errors.length > 0) {
+    if (mismatchedProviders.length > 0 || errors.length > 0) {
       logQuorumMismatchOrFailureDetails(method, params, quorumProviders, mismatchedProviders, errors);
     }
 

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -138,7 +138,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       return Object.fromEntries(
         values
           .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
-          .map(([provider, result]) => [provider.connection.url, result])
+          .map(([provider]) => [provider.connection.url])
       );
     };
 
@@ -156,7 +156,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         method,
         params: JSON.stringify(params),
         quorumProviders,
-        mismatchedProviders: JSON.stringify(mismatchedProviders),
+        mismatchedProviders,
         erroringProviders: errors.map(([provider, errorText]) => formatProviderError(provider, errorText)),
       });
     };


### PR DESCRIPTION
In case of a quorum issue, don't try to log the entire response from the mismatched provider. This may be causing the logger to fall over.

This is currently a suspicion and will be confirmed first in production.