### PR TITLE
improve: Add gasPrice to `TransactionCostEstimate` type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.3.25",
+  "version": "3.3.26",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -89,20 +89,20 @@ export class QueryBase implements QueryInterface {
     const gasTotalMultiplier = toBNWei(1.0 + gasMarkup);
 
     const tx = await populateV3Relay(this.spokePool, deposit, relayer);
-    const { nativeGasCost, tokenGasCost } = await estimateTotalGasRequiredByUnsignedTransaction(
-      tx,
-      relayer,
-      this.provider,
-      {
-        gasPrice,
-        gasUnits,
-        transport,
-      }
-    );
+    const {
+      nativeGasCost,
+      tokenGasCost,
+      gasPrice: impliedGasPrice,
+    } = await estimateTotalGasRequiredByUnsignedTransaction(tx, relayer, this.provider, {
+      gasPrice,
+      gasUnits,
+      transport,
+    });
 
     return {
       nativeGasCost: nativeGasCost.mul(gasTotalMultiplier).div(fixedPointAdjustment),
       tokenGasCost: tokenGasCost.mul(gasTotalMultiplier).div(fixedPointAdjustment),
+      gasPrice: impliedGasPrice,
     };
   }
 

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -126,6 +126,10 @@ export function convertFromWei(weiVal: string, decimals: number): string {
   return formatFunction(weiVal);
 }
 
+export function formatGwei(weiVal: string): string {
+  return convertFromWei(weiVal, 9);
+}
+
 /**
  * Shortens a list of addresses to a shorter version with only the first 10 characters.
  * @param addresses A list of addresses to shorten.

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -236,6 +236,7 @@ export function retry<T>(call: () => Promise<T>, times: number, delayS: number):
 export type TransactionCostEstimate = {
   nativeGasCost: BigNumber; // Units: gas
   tokenGasCost: BigNumber; // Units: wei (nativeGasCost * wei/gas)
+  gasPrice: BigNumber; // Units: wei/gas
 };
 
 /**
@@ -266,6 +267,7 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
 
   // Estimate the Gas units required to submit this transaction.
   const nativeGasCost = gasUnits ? BigNumber.from(gasUnits) : await voidSigner.estimateGas(unsignedTx);
+  assert(nativeGasCost.gt(0), "Gas cost should not be 0");
   let tokenGasCost: BigNumber;
 
   // OP stack is a special case; gas cost is computed by the SDK, without having to query price.
@@ -303,6 +305,7 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   return {
     nativeGasCost, // Units: gas
     tokenGasCost, // Units: wei (nativeGasCost * wei/gas)
+    gasPrice: tokenGasCost.div(nativeGasCost), // Units: wei/gas
   };
 }
 

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -77,9 +77,11 @@ class ExampleQueries implements QueryInterface {
   getGasCosts(): Promise<TransactionCostEstimate> {
     const getGasCost = () => {
       const { defaultGas: gasCost } = this;
+      const gasPrice = toGWei("1");
       return {
         nativeGasCost: toBN(gasCost),
-        tokenGasCost: toBN(gasCost).mul(toGWei("1")),
+        tokenGasCost: toBN(gasCost).mul(gasPrice),
+        gasPrice,
       };
     };
 


### PR DESCRIPTION
gas price for now is easily computed by dividing tokenGasCosts by nativeGasCost. In the future, we could break this down further into base fee and priority fee but each network has a different computation right now making this a bit trickier, so this is a good first step
