### PR TITLE
improve(BundleDataClient): Add comment about not running binary search on "unsafe" deposit ID's

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -899,6 +899,9 @@ export class BundleDataClient {
                 bundleInvalidFillsV3.push(fill);
                 return;
               }
+              // If deposit is using the deterministic relay hash feature, then the following binary search-based
+              // algorithm will not work. However, it is impossible to emit an infinite fill deadline using
+              // the unsafeDepositV3 function so there is no need to catch the special case.
               const historicalDeposit = await queryHistoricalDepositForFill(originClient, fill);
               if (!historicalDeposit.found) {
                 bundleInvalidFillsV3.push(fill);
@@ -1003,6 +1006,10 @@ export class BundleDataClient {
             // older deposit in case the spoke pool client's lookback isn't old enough to find the matching deposit.
             // We can skip this step if the deposit's fill deadline is not infinite, because we can assume that the
             // spoke pool clients have loaded deposits old enough to cover all fills with a non-infinite fill deadline.
+            // We do not need to handle the case where the deposit ID is > uint32 (in which case we wouldn't
+            // want to perform a binary search lookup for it because the deposit ID is "unsafe" and cannot be
+            // found using such a method) because infinite fill deadlines cannot be produced from the unsafeDepositV3()
+            // function.
             if (
               INFINITE_FILL_DEADLINE.eq(slowFillRequest.fillDeadline) &&
               slowFillRequest.blockNumber >= destinationChainBlockRange[0]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,10 @@ export const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 // 2^96 - 1 is a conservative erc20 max allowance.
 export const MAX_SAFE_ALLOWANCE = "79228162514264337593543950335";
 
+// The maximum depositId that can be emitted in a depositV3 method is the maximum uint32 value, so
+// 2^32 - 1.
+export const MAX_SAFE_DEPOSIT_ID = "4294967295";
+
 export const SECONDS_PER_YEAR = 31557600; // 365.25 days per year.
 
 /**

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -4,7 +4,6 @@ import assert from "assert";
 import Decimal from "decimal.js";
 import { ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import { getGasPriceEstimate } from "../gasPriceOracle";
-import { TypedMessage } from "../interfaces/TypedData";
 import { BigNumber, BigNumberish, BN, formatUnits, parseUnits, toBN } from "./BigNumberUtils";
 import { ConvertDecimals } from "./FormattingUtils";
 import { chainIsOPStack } from "./NetworkUtils";
@@ -320,106 +319,6 @@ async function getLineaGasFees(chainId: number, transport: Transport | undefined
     gasLimit: BigNumber.from(gasLimit.toString()),
     baseFeePerGas: BigNumber.from(baseFeePerGas.toString()),
     priorityFeePerGas: BigNumber.from(priorityFeePerGas.toString()),
-  };
-}
-
-export type UpdateDepositDetailsMessageType = {
-  UpdateDepositDetails: [
-    {
-      name: "depositId";
-      type: "uint32";
-    },
-    { name: "originChainId"; type: "uint256" },
-    { name: "updatedRelayerFeePct"; type: "int64" },
-    { name: "updatedRecipient"; type: "address" },
-    { name: "updatedMessage"; type: "bytes" },
-  ];
-};
-
-export type UpdateV3DepositDetailsMessageType = {
-  UpdateDepositDetails: [
-    { name: "depositId"; type: "uint32" },
-    { name: "originChainId"; type: "uint256" },
-    { name: "updatedOutputAmount"; type: "uint256" },
-    { name: "updatedRecipient"; type: "address" },
-    { name: "updatedMessage"; type: "bytes" },
-  ];
-};
-
-/**
- * Utility function to get EIP-712 compliant typed data that can be signed with the JSON-RPC method
- * `eth_signedTypedDataV4` in MetaMask (https://docs.metamask.io/guide/signing-data.html). The resulting signature
- * can then be used to call the method `speedUpDeposit` of a `SpokePool.sol` contract.
- * @param depositId The deposit ID to speed up.
- * @param originChainId The chain ID of the origin chain.
- * @param updatedRelayerFeePct The new relayer fee percentage.
- * @param updatedRecipient The new recipient address.
- * @param updatedMessage The new message that should be provided to the recipient.
- * @return EIP-712 compliant typed data.
- */
-export function getUpdateDepositTypedData(
-  depositId: number,
-  originChainId: number,
-  updatedRelayerFeePct: BigNumber,
-  updatedRecipient: string,
-  updatedMessage: string
-): TypedMessage<UpdateDepositDetailsMessageType> {
-  return {
-    types: {
-      UpdateDepositDetails: [
-        { name: "depositId", type: "uint32" },
-        { name: "originChainId", type: "uint256" },
-        { name: "updatedRelayerFeePct", type: "int64" },
-        { name: "updatedRecipient", type: "address" },
-        { name: "updatedMessage", type: "bytes" },
-      ],
-    },
-    primaryType: "UpdateDepositDetails",
-    domain: {
-      name: "ACROSS-V2",
-      version: "1.0.0",
-      chainId: originChainId,
-    },
-    message: {
-      depositId,
-      originChainId,
-      updatedRelayerFeePct,
-      updatedRecipient,
-      updatedMessage,
-    },
-  };
-}
-
-export function getUpdateV3DepositTypedData(
-  depositId: number,
-  originChainId: number,
-  updatedOutputAmount: BigNumber,
-  updatedRecipient: string,
-  updatedMessage: string
-): TypedMessage<UpdateV3DepositDetailsMessageType> {
-  return {
-    types: {
-      UpdateDepositDetails: [
-        { name: "depositId", type: "uint32" },
-        { name: "originChainId", type: "uint256" },
-        { name: "updatedOutputAmount", type: "uint256" },
-        { name: "updatedRecipient", type: "address" },
-        { name: "updatedMessage", type: "bytes" },
-      ],
-    },
-    primaryType: "UpdateDepositDetails",
-    domain: {
-      name: "ACROSS-V2",
-      version: "1.0.0",
-      chainId: originChainId,
-    },
-    message: {
-      depositId,
-      originChainId,
-      updatedOutputAmount,
-      updatedRecipient,
-      updatedMessage,
-    },
   };
 }
 


### PR DESCRIPTION
I'm combing through the SDK for any functions that will need to change once this contracts  [PR](https://github.com/across-protocol/contracts/pull/583) is merged and here are some changes:
- Added comments to BundleDataClient
- Export useful constant `MAX_SAFE_DEPOSIT_ID`
- Export useful utility `isUnsafeDepositId()`
- Delete unused functions that wouldn't work post spoke pool upgrade because the `V3RelayData.depositId` type will change to uint256
