### PR TITLE
refactor(SpokePoolClient): Remove _getDepositIdAtBlock

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -35,9 +35,8 @@ import {
   SpeedUpWithBlock,
   TokensBridged,
 } from "../interfaces";
-import { SpokePool } from "../typechain";
 import { getNetworkName } from "../utils/NetworkUtils";
-import { getBlockRangeForDepositId, getDepositIdAtBlock, relayFillStatus } from "../utils/SpokeUtils";
+import { getBlockRangeForDepositId, relayFillStatus } from "../utils/SpokeUtils";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
 import { HubPoolClient } from "./HubPoolClient";
 import { AcrossConfigStoreClient } from "./AcrossConfigStoreClient";

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -401,15 +401,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
-   * Finds the deposit id at a specific block number.
-   * @param blockTag The block number to search for the deposit ID at.
-   * @returns The deposit ID.
-   */
-  public _getDepositIdAtBlock(blockTag: number): Promise<number> {
-    return getDepositIdAtBlock(this.spokePool as SpokePool, blockTag);
-  }
-
-  /**
    * @notice Return maximum of fill deadline buffer at start and end of block range. This is a contract
    * immutable state variable so we can't query other events to find its updates.
    * @dev V3 deposits have a fill deadline which can be set to a maximum of fillDeadlineBuffer + deposit.block.timestamp.

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -71,9 +71,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       lastDepositId = _depositIds[i];
     }
   }
-  _getDepositIdAtBlock(blockTag: number): Promise<number> {
-    return Promise.resolve(this.depositIdAtBlock[blockTag]);
-  }
 
   _update(eventsToQuery: string[]): Promise<SpokePoolUpdate> {
     // Generate new "on chain" responses.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -116,7 +116,7 @@ export async function getBlockRangeForDepositId(
   // make an eth_call request to get the deposit ID at the block number. It will then cache the deposit ID
   // in the queriedIds cache.
   const _getDepositIdAtBlock = async (blockNumber: number): Promise<number> => {
-    queriedIds[blockNumber] ??= await spokePool._getDepositIdAtBlock(blockNumber);
+    queriedIds[blockNumber] ??= await getDepositIdAtBlock(spokePool.spokePool, blockNumber);
     return queriedIds[blockNumber];
   };
 


### PR DESCRIPTION
This function only seems to be used once in a `SpokeUtils.getBlockRangeForDepositId()` function but it can just as easily be replaced with a call to `getDepositIdAtBlock`
