### PR TITLE
refactor(QueryBase): Remove constructors in derived classes 

### DIFF
--- a/src/relayFeeCalculator/chain-queries/alephZero.ts
+++ b/src/relayFeeCalculator/chain-queries/alephZero.ts
@@ -1,36 +1,10 @@
-import assert from "assert";
-import { getDeployedAddress } from "../../utils/DeploymentUtils";
-import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
-import { providers } from "ethers";
-import { CHAIN_IDs, DEFAULT_SIMULATED_RELAYER_ADDRESS, TOKEN_SYMBOLS_MAP } from "../../constants";
+import { CHAIN_IDs } from "../../constants";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { isDefined } from "../../utils";
 import { QueryBase } from "./baseQuery";
 
 // @dev This class only exists because querying the native token price for this network is not the standard
 // CoinGecko query because the native token symbol is not ETH.
 export class AlephZeroQueries extends QueryBase {
-  constructor(
-    provider: providers.Provider,
-    symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.ALEPH_ZERO),
-    simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
-    coingeckoProApiKey?: string,
-    logger: Logger = DEFAULT_LOGGER
-  ) {
-    assert(isDefined(spokePoolAddress));
-    super(
-      provider,
-      symbolMapping,
-      spokePoolAddress,
-      simulatedRelayerAddress,
-      logger,
-      coingeckoProApiKey,
-      undefined,
-      "usd"
-    );
-  }
-
   override async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
     const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);

--- a/src/relayFeeCalculator/chain-queries/factory.ts
+++ b/src/relayFeeCalculator/chain-queries/factory.ts
@@ -37,8 +37,10 @@ export class QueryBase__factory {
         symbolMapping,
         spokePoolAddress,
         simulatedRelayerAddress,
+        logger,
         coingeckoProApiKey,
-        logger
+        fixedGasPrice[chainId],
+        "usd"
       );
     }
 
@@ -48,8 +50,10 @@ export class QueryBase__factory {
         symbolMapping,
         spokePoolAddress,
         simulatedRelayerAddress,
+        logger,
         coingeckoProApiKey,
-        logger
+        fixedGasPrice[chainId],
+        "usd"
       );
     }
 

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -1,36 +1,10 @@
-import assert from "assert";
-import { getDeployedAddress } from "../../utils/DeploymentUtils";
-import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
-import { providers } from "ethers";
-import { CHAIN_IDs, DEFAULT_SIMULATED_RELAYER_ADDRESS, TOKEN_SYMBOLS_MAP } from "../../constants";
+import { CHAIN_IDs } from "../../constants";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { isDefined } from "../../utils";
 import { QueryBase } from "./baseQuery";
 
 // @dev This class only exists because querying the native token price for this network is not the standard
 // CoinGecko query because the native token symbol is not ETH.
 export class PolygonQueries extends QueryBase {
-  constructor(
-    provider: providers.Provider,
-    symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.POLYGON),
-    simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
-    coingeckoProApiKey?: string,
-    logger: Logger = DEFAULT_LOGGER
-  ) {
-    assert(isDefined(spokePoolAddress));
-    super(
-      provider,
-      symbolMapping,
-      spokePoolAddress,
-      simulatedRelayerAddress,
-      logger,
-      coingeckoProApiKey,
-      undefined,
-      "usd"
-    );
-  }
-
   override async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
     const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);


### PR DESCRIPTION
The constructor calls in AlephZeroQueries and PolygonQueries are not useful since the `getTokenPrice()` class function is the main changed logic from the parent `QueryBase` class. We can reduce LOC in the repo by removing these constructors. Additionally, we should be able to just use the parent `QueryBase`'s `constructor` directly.

This was partially motivated by work on https://github.com/across-protocol/sdk/pull/801 where I had to modify these constructors because the `QueryBase` constructor changed