### PR TITLE
improve(retryProvider): Skip quorum on pending blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.3.30",
+  "version": "3.3.31",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -320,7 +320,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     }
 
     // getBlockByNumber should only use the quorum if it's not asking for the latest block.
-    if (method === "eth_getBlockByNumber" && params[0] !== "latest") {
+    if (method === "eth_getBlockByNumber" && params[0] !== "latest" && params[0] !== "pending") {
       return this.nodeQuorumThreshold;
     }
 


### PR DESCRIPTION
The relayer is currently using the pending block to determine the current base fee. This is inherently incompatible with quorum because some chains will typically not return a consistent pending block.