### PR TITLE
chore(multicall3): Drop explicit OP stack entries

### DIFF
--- a/src/utils/Multicall.ts
+++ b/src/utils/Multicall.ts
@@ -21,20 +21,15 @@ const NON_DETERMINISTIC_MULTICALL_ADDRESSES = {
   [CHAIN_IDs.ZK_SYNC]: "0xF9cda624FBC7e059355ce98a31693d299FACd963",
 };
 
-// Multicall3 is an OP stack predeploy, so don't specify it here.
+// @notice Multicall3 is an OP stack preinstall, so don't specify it here.
 const DETERMINISTIC_MULTICALL_CHAINS = [
   CHAIN_IDs.ALEPH_ZERO,
   CHAIN_IDs.ARBITRUM,
-  CHAIN_IDs.INK,
   CHAIN_IDs.LINEA,
   CHAIN_IDs.MAINNET,
   CHAIN_IDs.POLYGON,
   CHAIN_IDs.SCROLL,
-  CHAIN_IDs.ZORA,
   // Testnet:
-  CHAIN_IDs.BASE_SEPOLIA,
-  CHAIN_IDs.BLAST_SEPOLIA,
-  CHAIN_IDs.INK_SEPOLIA,
   CHAIN_IDs.POLYGON_AMOY,
   CHAIN_IDs.SCROLL_SEPOLIA,
   CHAIN_IDs.SEPOLIA,


### PR DESCRIPTION
OP stack entries are not required here because Multicall3 is assumed to be deployed at the standard address.

https://specs.optimism.io/protocol/preinstalls.html#multicall3