### PR TITLE
fix(RelayFeeCalculator): Return maxFeePerGas rather than tokenGasCost / nativeGasCost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -155,7 +155,7 @@ export class QueryBase implements QueryInterface {
     return {
       nativeGasCost, // Units: gas
       tokenGasCost, // Units: wei (nativeGasCost * wei/gas)
-      gasPrice: tokenGasCost.div(nativeGasCost), // Units: wei/gas
+      gasPrice: BigNumber.from(gasPrice.toString()), // Units: wei/gas, does not include l1GasCost for OP stack chains
     };
   }
 


### PR DESCRIPTION
If we divide `tokenGasCost / nativeGasCost` then we'll get the L1GasCost + L2GasPrice components for the gas price for OpStack, because OpStack adds this L1GasCost component to the full total gas cost.

The SDK should return the `gasPrice = baseFee + priorityFee` to help with debugging against the API, for example against this PR https://github.com/across-protocol/frontend/pull/1335
