### PR TITLE
feat(GasPriceOracle): Allow caller to set a priority fee multiplier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/adapters/arbitrum.ts
+++ b/src/gasPriceOracle/adapters/arbitrum.ts
@@ -10,7 +10,7 @@ import { GasPriceEstimateOptions } from "../oracle";
  * Reference: https://docs.arbitrum.io/how-arbitrum-works/gas-fees so we hardcode the priority fee
  * to 1 wei.
  * @param provider Ethers Provider
- * @param {GasPriceEstimateOptions} opts See notes below on specific parameters.
+ * @param opts See notes below on specific parameters.
  * @param baseFeeMultiplier Amount to multiply base fee.
  * @param priorityFeeMultiplier Unused in this function because arbitrum priority fee is hardcoded to 1 wei by this
  * function.

--- a/src/gasPriceOracle/adapters/arbitrum.ts
+++ b/src/gasPriceOracle/adapters/arbitrum.ts
@@ -10,6 +10,10 @@ import { GasPriceEstimateOptions } from "../oracle";
  * Reference: https://docs.arbitrum.io/how-arbitrum-works/gas-fees so we hardcode the priority fee
  * to 1 wei.
  * @param provider Ethers Provider
+ * @param {GasPriceEstimateOptions} opts See notes below on specific parameters.
+ * @param baseFeeMultiplier Amount to multiply base fee.
+ * @param priorityFeeMultiplier Unused in this function because arbitrum priority fee is hardcoded to 1 wei by this
+ * function.
  * @returns GasPriceEstimate
  */
 export async function eip1559(provider: providers.Provider, opts: GasPriceEstimateOptions): Promise<GasPriceEstimate> {

--- a/src/gasPriceOracle/adapters/linea-viem.ts
+++ b/src/gasPriceOracle/adapters/linea-viem.ts
@@ -15,7 +15,7 @@ import { fixedPointAdjustment } from "../../utils";
  * @dev Because the Linea priority fee is more volatile than the base fee, the base fee multiplier will be applied
  * to the priority fee.
  * @param provider Viem PublicClient
- * @param {GasPriceEstimateOptions} opts Relevant options for Linea are baseFeeMultiplier and unsignedTx.
+ * @param opts Relevant options for Linea are baseFeeMultiplier and unsignedTx.
  * @param baseFeeMultiplier Amount to multiply priority fee, since Linea's base fee is hardcoded while its priority
  * fee is dynamic.
  * @param priorityFeeMultiplier Unused in this function because the baseFeeMultiplier is applied to the dynamic

--- a/src/gasPriceOracle/adapters/linea-viem.ts
+++ b/src/gasPriceOracle/adapters/linea-viem.ts
@@ -15,10 +15,12 @@ import { fixedPointAdjustment } from "../../utils";
  * @dev Because the Linea priority fee is more volatile than the base fee, the base fee multiplier will be applied
  * to the priority fee.
  * @param provider Viem PublicClient
- * @param _chainId Unused in this adapter
+ * @param {GasPriceEstimateOptions} opts Relevant options for Linea are baseFeeMultiplier and unsignedTx.
  * @param baseFeeMultiplier Amount to multiply priority fee, since Linea's base fee is hardcoded while its priority
- * fee is dynamic
- * @param _unsignedTx Should contain any params passed to linea_estimateGas, which are listed
+ * fee is dynamic.
+ * @param priorityFeeMultiplier Unused in this function because the baseFeeMultiplier is applied to the dynamic
+ * Linea priority fee while the base fee is hardcoded.
+ * @param unsignedTx Should contain any params passed to linea_estimateGas, which are listed
  * here: https://docs.linea.build/api/reference/linea-estimategas#parameters
  * @returns
  */

--- a/src/gasPriceOracle/adapters/linea.ts
+++ b/src/gasPriceOracle/adapters/linea.ts
@@ -10,7 +10,7 @@ import { GasPriceEstimateOptions } from "../oracle";
 /**
  * Returns Linea gas price using the legacy eth_gasPrice RPC call.
  * @param provider
- * @param {GasPriceEstimateOptions} opts See notes below on specific parameters.
+ * @param opts See notes below on specific parameters.
  * @param baseFeeMultiplier Amount to multiply total fee because this function defaults to legacy gas pricing.
  * @param priorityFeeMultiplier Unused in this function because this defaults to legacy gas computation.
  * @returns

--- a/src/gasPriceOracle/adapters/linea.ts
+++ b/src/gasPriceOracle/adapters/linea.ts
@@ -7,6 +7,14 @@ import { GasPriceEstimate } from "../types";
 import * as ethereum from "./ethereum";
 import { GasPriceEstimateOptions } from "../oracle";
 
+/**
+ * Returns Linea gas price using the legacy eth_gasPrice RPC call.
+ * @param provider
+ * @param {GasPriceEstimateOptions} opts See notes below on specific parameters.
+ * @param baseFeeMultiplier Amount to multiply total fee because this function defaults to legacy gas pricing.
+ * @param priorityFeeMultiplier Unused in this function because this defaults to legacy gas computation.
+ * @returns
+ */
 export function eip1559(provider: providers.Provider, opts: GasPriceEstimateOptions): Promise<GasPriceEstimate> {
   // We use the legacy method to call `eth_gasPrice` which empirically returns a more accurate
   // gas price estimate than `eth_maxPriorityFeePerGas` or ethersProvider.getFeeData in the EIP1559 "raw" or "bad"

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -14,6 +14,8 @@ import * as lineaViem from "./adapters/linea-viem";
 export interface GasPriceEstimateOptions {
   // baseFeeMultiplier Multiplier applied to base fee for EIP1559 gas prices (or total fee for legacy).
   baseFeeMultiplier: BigNumber;
+  // priorityFeeMultiplier Multiplier applied to priority fee for EIP1559 gas prices (ignored for legacy).
+  priorityFeeMultiplier: BigNumber;
   // legacyFallback In the case of an unrecognized chain, fall back to type 0 gas estimation.
   legacyFallback: boolean;
   // chainId The chain ID to query for gas prices. If omitted can be inferred by provider.
@@ -43,10 +45,17 @@ export async function getGasPriceEstimate(
     baseFeeMultiplier.gte(toBNWei("1.0")) && baseFeeMultiplier.lte(toBNWei("5")),
     `Require 1.0 < base fee multiplier (${baseFeeMultiplier}) <= 5.0 for a total gas multiplier within [+1.0, +5.0]`
   );
+  const priorityFeeMultiplier = opts.priorityFeeMultiplier ?? toBNWei("1");
+  assert(
+    priorityFeeMultiplier.gte(toBNWei("1.0")) && priorityFeeMultiplier.lte(toBNWei("5")),
+    `Require 1.0 < priority fee multiplier (${priorityFeeMultiplier}) <= 5.0 for a total gas multiplier within [+1.0, +5.0]`
+  );
+
   const chainId = opts.chainId ?? (await provider.getNetwork()).chainId;
   const optsWithDefaults: GasPriceEstimateOptions = {
     ...GAS_PRICE_ESTIMATE_DEFAULTS,
     baseFeeMultiplier,
+    priorityFeeMultiplier,
     ...opts,
     chainId,
   };


### PR DESCRIPTION
This acts similarly to the baseFeeMultiplier. It is unused for `legacy()` pricing which returns a single gas price so we use the `baseFeeMultiplier` to scale the gas price. It's also unused for the Linea and Arbitrum adapters which only have one component of the gas price that is variable (the priority fee and base fee, respectively) and we use the `baseFeeMultiplier` in both cases.
