### PR TITLE
improve(RelayFeeCalculator): Add parameters to getGasCosts method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.5",
+  "version": "3.4.5-beta.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.5-beta.1",
+  "version": "3.4.5",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -28,6 +28,8 @@ export interface QueryInterface {
       gasPrice: BigNumberish;
       gasUnits: BigNumberish;
       baseFeeMultiplier: BigNumber;
+      priorityFeeMultiplier: BigNumber;
+      opStackL1GasCostMultiplier: BigNumber;
       transport: Transport;
     }>
   ) => Promise<TransactionCostEstimate>;

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -355,6 +355,7 @@ describe("RelayFeeCalculator: Composable Bridging", function () {
         tokenMap,
         undefined,
         undefined,
+        undefined,
         customTransport
       );
   });


### PR DESCRIPTION
Adds `priorityFeeMultiplier` and `opStackL1GasCostMultiplier` parameters to allow caller to further customize queries
