### PR TITLE
fix(GasPriceOracle): Use priorityFeeMultiplier in lineaVm adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/adapters/linea-viem.ts
+++ b/src/gasPriceOracle/adapters/linea-viem.ts
@@ -1,4 +1,4 @@
-import { Address, Hex, PublicClient } from "viem";
+import { PublicClient } from "viem";
 import { estimateGas } from "viem/linea";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS as account } from "../../constants";
 import { InternalGasPriceEstimate } from "../types";

--- a/src/gasPriceOracle/adapters/linea-viem.ts
+++ b/src/gasPriceOracle/adapters/linea-viem.ts
@@ -28,12 +28,17 @@ export async function eip1559(
   provider: PublicClient,
   opts: GasPriceEstimateOptions
 ): Promise<InternalGasPriceEstimate> {
-  const { unsignedTx, baseFeeMultiplier } = opts;
+  const { baseFeeMultiplier } = opts;
+  // TODO: unsignedTx is unused currently because we think there is an issue with the linea_estimateGas endpoint
+  // and passing in this unsignedTx.
   const { baseFeePerGas, priorityFeePerGas: _priorityFeePerGas } = await estimateGas(provider, {
-    account: (unsignedTx?.from as Address) ?? account,
-    to: (unsignedTx?.to as Address) ?? account,
-    value: BigInt(unsignedTx?.value?.toString() ?? "0"),
-    data: (unsignedTx?.data as Hex) ?? "0x",
+    account,
+    // account: (unsignedTx?.from as Address) ?? account,
+    to: account,
+    // to: (unsignedTx?.to as Address) ?? account,
+    value: BigInt(1),
+    // value: BigInt(unsignedTx?.value?.toString() ?? "0"),
+    // data: (unsignedTx?.data as Hex) ?? "0x",
   });
   const priorityFeePerGas =
     (_priorityFeePerGas * BigInt(baseFeeMultiplier.toString())) / BigInt(fixedPointAdjustment.toString());

--- a/src/gasPriceOracle/adapters/linea-viem.ts
+++ b/src/gasPriceOracle/adapters/linea-viem.ts
@@ -27,8 +27,6 @@ export async function eip1559(
   opts: GasPriceEstimateOptions
 ): Promise<InternalGasPriceEstimate> {
   const { unsignedTx, priorityFeeMultiplier } = opts;
-  // TODO: unsignedTx is unused currently because we think there is an issue with the linea_estimateGas endpoint
-  // and passing in this unsignedTx.
   const { baseFeePerGas, priorityFeePerGas: _priorityFeePerGas } = await estimateGas(provider, {
     account: (unsignedTx?.from as Address) ?? account,
     to: (unsignedTx?.to as Address) ?? account,

--- a/test/GasPriceOracle.test.ts
+++ b/test/GasPriceOracle.test.ts
@@ -77,7 +77,7 @@ describe("Gas Price Oracle", function () {
       "priority fee multiplier"
     );
   });
-  it("Linea Viem gas price retrieval with unsignedTx", async function () {
+  it.skip("Linea Viem gas price retrieval with unsignedTx", async function () {
     const chainId = 59144;
     const chainKey = `NEW_GAS_PRICE_ORACLE_${chainId}`;
     process.env[chainKey] = "true";

--- a/test/GasPriceOracle.test.ts
+++ b/test/GasPriceOracle.test.ts
@@ -77,7 +77,7 @@ describe("Gas Price Oracle", function () {
       "priority fee multiplier"
     );
   });
-  it.skip("Linea Viem gas price retrieval with unsignedTx", async function () {
+  it("Linea Viem gas price retrieval with unsignedTx", async function () {
     const chainId = 59144;
     const chainKey = `NEW_GAS_PRICE_ORACLE_${chainId}`;
     process.env[chainKey] = "true";


### PR DESCRIPTION
I purposefully used the baseFeeMultiplier to multiply the priority fee in Linea because the base fee is fixed, but this caused the relayer to set its scalers incorrectly