### PR TITLE
feat(GasPriceAdapter): Allow caller to set a minimum priority fee for eip1559Raw adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -5,6 +5,10 @@ import { GasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
 import { GasPriceEstimateOptions } from "../oracle";
 
+const DEFAULT_MIN_PRIORITY_FEE: { [chainId: number]: string } = {
+  1: "0.5",
+};
+
 // TODO: We intend to remove `eip1559Bad()` as an option and make eip1559Raw the only option eventually. The reason
 // they both exist currently is because eip1559Raw is new and untested on production so we will slowly roll it out
 // by using the convenient environment variable safety guard.
@@ -44,7 +48,10 @@ export async function eip1559Raw(
     (provider as providers.JsonRpcProvider).send("eth_maxPriorityFeePerGas", []),
   ]);
   let maxPriorityFeePerGas = BigNumber.from(_maxPriorityFeePerGas);
-  const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || "0", 9);
+  const flooredPriorityFeePerGas = parseUnits(
+    process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || DEFAULT_MIN_PRIORITY_FEE[chainId] || "0",
+    9
+  );
   if (maxPriorityFeePerGas.lt(flooredPriorityFeePerGas)) {
     maxPriorityFeePerGas = BigNumber.from(flooredPriorityFeePerGas);
   }

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -5,10 +5,6 @@ import { GasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
 import { GasPriceEstimateOptions } from "../oracle";
 
-const DEFAULT_MIN_PRIORITY_FEE: { [chainId: number]: string } = {
-  1: "0.5",
-};
-
 // TODO: We intend to remove `eip1559Bad()` as an option and make eip1559Raw the only option eventually. The reason
 // they both exist currently is because eip1559Raw is new and untested on production so we will slowly roll it out
 // by using the convenient environment variable safety guard.
@@ -48,10 +44,7 @@ export async function eip1559Raw(
     (provider as providers.JsonRpcProvider).send("eth_maxPriorityFeePerGas", []),
   ]);
   let maxPriorityFeePerGas = BigNumber.from(_maxPriorityFeePerGas);
-  const flooredPriorityFeePerGas = parseUnits(
-    process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || DEFAULT_MIN_PRIORITY_FEE[chainId] || "0",
-    9
-  );
+  const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || "0", 9);
   if (maxPriorityFeePerGas.lt(flooredPriorityFeePerGas)) {
     maxPriorityFeePerGas = BigNumber.from(flooredPriorityFeePerGas);
   }


### PR DESCRIPTION
Can floor the priority fee returned by eth_maxPriorityFeePerGas by using a new environment variable `MIN_PRIORITY_FEE_PER_GAS_`