### PR TITLE
improve(BundleDataClient): Support pre-fills

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -869,6 +869,13 @@ export class BundleDataClient {
                 // At this point, the v3RelayHashes entry already existed meaning that there is a matching deposit,
                 // so this fill is validated.
                 v3RelayHashes[relayDataHash].fill = fill;
+                // TODO: Add a buffer here to check for fills that preceded deposits. Need to somehow check that
+                // fill is not getting double-refunded. We might need to recompute previous bundle or load it
+                // from arweave to check on fill refund status...
+                // Another way to handle this is to only consider fills when they are X number of blocks behind HEAD,
+                // so you can add a buffer to all fill blocks here before considering whether they are in "this" bundle
+                // block range
+
                 if (fill.blockNumber >= destinationChainBlockRange[0]) {
                   validatedBundleV3Fills.push({
                     ...fill,


### PR DESCRIPTION
## Motivation

Support use case that will become frequent once deterministic relay hashes go live where a fill precedes a deposit in real world time.

### Update #1:

I'm not even sure there is a problem with refunding pre fills that occur near the end of a bundle (that precede a deposit at the beginning of the following bundle) because bundle end blocks are currently set to lag HEAD on all chains. Additionally, the bundle data client takes into account all deposits, even those right near HEAD, when validating fills. So unless the fill precedes the deposit by more than the [bundle end block buffer](https://github.com/across-protocol/relayer/blob/master/src/common/Constants.ts#L135) then there should be no issue. 

## Problem

This opens up the possibility that even with a [SpokePoolClient.query lag](https://github.com/across-protocol/sdk/blob/40888c405db19f1860f0d3f22e26cc5dc541306f/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts#L28) applied on all chains, there is a very unlucky situation where a fill is sent at the end of one bundle block range and a deposit is one of the first events in the next bundle block range. Currently, the dataworker would never issue a refund for the fill.

There are two ways around this I think and one is very complex to implement while the other is simple but increases relayer repayment latency and puts responsibility of how early to-prefill on the relayer:

1. BundleDataClient will need to "remember" which refunds it has already issued. It can do this easily using the arweave client though this increases dependencies on Arweave. Additionally, it will be quite complex to implement the most efficient data structure. I don't love this approach because of the tradeoffs of the following approach.
2. Increase the buffer that a fill must follow its destination chain HEAD block before the dataworker attempts to repay it. This additional buffer converted to seconds becomes the maximum amount of time that a fill can precede a deposit. I think this can be to something reasonable like 10 minutes assuming that pre-fills are only used by fillers who can guarantee somehow that a deposit lands on-chain when they want it to. Therefore the filler should be able to send a deposit after a fill in under 10 minutes in all cases.