### PR TITLE
feat(BundleDataClient): Support refunds for pre-fills/slow-fill-requests and duplicate deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.13",
+  "version": "4.0.0-beta.14",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.32",
+  "version": "4.0.0-beta.33",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.30",
+  "version": "4.0.0-beta.31",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.22",
+  "version": "4.0.0-beta.23",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.26",
+  "version": "4.0.0-beta.27",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0",
+  "version": "4.0.0-beta.30",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.24",
+  "version": "4.0.0-beta.25",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.20",
+  "version": "4.0.0-beta.21",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.31",
+  "version": "4.0.0-beta.32",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.25",
+  "version": "4.0.0-beta.26",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.34",
+  "version": "4.0.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.27",
+  "version": "4.0.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.19",
+  "version": "4.0.0-beta.20",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.15",
+  "version": "4.0.0-beta.16",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.33",
+  "version": "4.0.0-beta.34",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.12",
+  "version": "4.0.0-beta.13",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-beta.8",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.10",
+  "version": "4.0.0-beta.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.23",
+  "version": "4.0.0-beta.24",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.5",
+  "version": "4.0.0-beta.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.18",
+  "version": "4.0.0-beta.19",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.6",
+  "version": "4.0.0-beta.7",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.16",
+  "version": "4.0.0-beta.17",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.11",
+  "version": "4.0.0-beta.12",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.8",
+  "version": "4.0.0-beta.9",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.21",
+  "version": "4.0.0-beta.22",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.0-beta.17",
+  "version": "4.0.0-beta.18",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -145,6 +145,9 @@ function updateBundleExcessSlowFills(
 }
 
 function updateBundleSlowFills(dict: BundleSlowFills, deposit: V3DepositWithBlock & { lpFeePct: BigNumber }): void {
+  if (chainIsEvm(deposit.destinationChainId) && !isValidEvmAddress(deposit.recipient)) {
+    return;
+  }
   const { destinationChainId, outputToken } = deposit;
   if (!dict?.[destinationChainId]?.[outputToken]) {
     assign(dict, [destinationChainId, outputToken], []);

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1062,10 +1062,7 @@ export class BundleDataClient {
 
         // @todo Only start refunding pre-fills and slow fill requests after a config store version is activated. We
         // should remove this check once we've advanced far beyond the version bump block.
-        if (
-          versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION ||
-          process.env.FORCE_PRE_FILL_REFUNDS === "true"
-        ) {
+        if (versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION) {
           await mapAsync(
             bundleDepositHashes.filter((depositHash) => {
               const { deposit } = v3RelayHashes[depositHash];

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -50,6 +50,7 @@ import {
   getRefundsFromBundle,
   getWidestPossibleExpectedBlockRange,
   isChainDisabled,
+  isEvmRepaymentValid,
   PoolRebalanceRoot,
   prettyPrintV3SpokePoolEvents,
   V3DepositWithBlock,
@@ -92,10 +93,11 @@ function updateBundleFillsV3(
   repaymentToken: string,
   repaymentAddress: string
 ): void {
-  // It is impossible to refund a deposit if the repayment chain is EVM and the relayer is a non-evm address.
-  if (chainIsEvm(repaymentChainId) && !isValidEvmAddress(repaymentAddress)) {
-    return;
-  }
+  // We shouldn't pass any unrepayable fills into this function, so we perform an extra safety check.
+  assert(
+    chainIsEvm(repaymentChainId) && isEvmRepaymentValid(fill, repaymentChainId),
+    "validatedBundleV3Fills dictionary should only contain fills with valid repayment information"
+  );
   if (!dict?.[repaymentChainId]?.[repaymentToken]) {
     assign(dict, [repaymentChainId, repaymentToken], {
       fills: [],

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1104,6 +1104,8 @@ export class BundleDataClient {
             );
           }),
           async (depositHash) => {
+            // We don't need to call verifyFillRepayment() here to replace the fill.relayer because this value should already
+            // be overwritten because the deposit and fill both exist.
             const { deposit, fill, slowFillRequest } = v3RelayHashes[depositHash];
             if (!deposit) throw new Error("Deposit should exist in relay hash dictionary.");
 

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -994,7 +994,7 @@ export class BundleDataClient {
                   // historical deposit query is not working as expected.
                   assert(this.getRelayHashFromEvent(matchedDeposit) === relayDataHash, "Relay hashes should match.");
                   validatedBundleV3Fills.push({
-                    ...fill,
+                    ...fillToRefund,
                     quoteTimestamp: matchedDeposit.quoteTimestamp,
                   });
                   v3RelayHashes[relayDataHash].fill = fillToRefund;

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1163,7 +1163,13 @@ export class BundleDataClient {
                 destinationClient.deploymentBlock,
                 destinationClient.latestBlockSearched
               )) as unknown as FillWithBlock;
-              if (canRefundPrefills && !isSlowFill(prefill)) {
+              const verifiedFill = await verifyFillRepayment(
+                prefill,
+                destinationClient.spokePool.provider,
+                deposit,
+                allChainIds
+              );
+              if (canRefundPrefills && isDefined(verifiedFill) && !isSlowFill(prefill)) {
                 validatedBundleV3Fills.push({
                   ...prefill,
                   quoteTimestamp: deposit.quoteTimestamp,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -918,6 +918,8 @@ export class BundleDataClient {
                     allChainIds
                   );
                   if (!isDefined(fillToRefund)) {
+                    // We won't repay the fill but the depositor has received funds so we don't need to make a
+                    // payment.
                     bundleUnrepayableFillsV3.push(fill);
                     // We don't return here yet because we still need to mark unexecutable slow fill leaves
                     // or duplicate deposits. However, we won't issue a fast fill refund.

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1184,10 +1184,12 @@ export class BundleDataClient {
                 // If fill is in the current bundle then we can assume there is already a refund for it, so only
                 // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
                 // we won't consider it, following the previous treatment of fills after the bundle block range.
-                validatedBundleV3Fills.push({
-                  ...fill,
-                  quoteTimestamp: deposit.quoteTimestamp,
-                });
+                if (!isSlowFill(fill)) {
+                  validatedBundleV3Fills.push({
+                    ...fill,
+                    quoteTimestamp: deposit.quoteTimestamp,
+                  });
+                }
               }
             }
             return;
@@ -1239,7 +1241,7 @@ export class BundleDataClient {
               );
               if (!isDefined(verifiedFill)) {
                 bundleUnrepayableFillsV3.push(prefill!);
-              } else if (canRefundPrefills) {
+              } else if (canRefundPrefills && !isSlowFill(verifiedFill)) {
                 validatedBundleV3Fills.push({
                   ...verifiedFill!,
                   quoteTimestamp: deposit.quoteTimestamp,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -320,6 +320,12 @@ export class BundleDataClient {
         continue;
       }
       const chainIndex = chainIds.indexOf(chainId);
+
+      // @todo This function does not account for pre-fill refunds as it is optimized for speed. The way to detect
+      // pre-fill refunds is to load all deposits that are unmatched by fills in the spoke pool client's memory
+      // and then query the FillStatus on-chain, but that might slow this function down too much. For now, we
+      // will live with this expected inaccuracy as it should be small. The pre-fill would have to precede the deposit
+      // by more than the caller's event lookback window which is expected to be unlikely.
       this.spokePoolClients[chainId]
         .getFills()
         .filter((fill) => {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1184,12 +1184,10 @@ export class BundleDataClient {
                 // If fill is in the current bundle then we can assume there is already a refund for it, so only
                 // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
                 // we won't consider it, following the previous treatment of fills after the bundle block range.
-                if (!isSlowFill(fill)) {
-                  validatedBundleV3Fills.push({
-                    ...fill,
-                    quoteTimestamp: deposit.quoteTimestamp,
-                  });
-                }
+                validatedBundleV3Fills.push({
+                  ...fill,
+                  quoteTimestamp: deposit.quoteTimestamp,
+                });
               }
             }
             return;
@@ -1241,7 +1239,7 @@ export class BundleDataClient {
               );
               if (!isDefined(verifiedFill)) {
                 bundleUnrepayableFillsV3.push(prefill!);
-              } else if (canRefundPrefills && !isSlowFill(verifiedFill)) {
+              } else if (canRefundPrefills) {
                 validatedBundleV3Fills.push({
                   ...verifiedFill!,
                   quoteTimestamp: deposit.quoteTimestamp,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -323,7 +323,7 @@ export class BundleDataClient {
         continue;
       }
       const chainIndex = chainIds.indexOf(chainId);
-      // @todo This function does not account for pre-fill refunds as it is optimized for speed. The way to detect
+      // @dev This function does not account for pre-fill refunds as it is optimized for speed. The way to detect
       // pre-fill refunds is to load all deposits that are unmatched by fills in the spoke pool client's memory
       // and then query the FillStatus on-chain, but that might slow this function down too much. For now, we
       // will live with this expected inaccuracy as it should be small. The pre-fill would have to precede the deposit
@@ -1122,9 +1122,6 @@ export class BundleDataClient {
         // - Or, has the deposit expired in this bundle? If so, then we need to issue an expiry refund.
         // - And finally, has the deposit been slow filled? If so, then we need to issue a slow fill leaf
         //   for this "pre-slow-fill-request" if this request took place in a previous bundle.
-
-        // @todo Only start refunding pre-fills and slow fill requests after a config store version is activated. We
-        // should remove this check once we've advanced far beyond the version bump block.
         await mapAsync(bundleDepositHashes, async (depositHash) => {
           // We don't need to call verifyFillRepayment() here to replace the fill.relayer because this value should already
           // be overwritten because the deposit and fill both exist.

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -937,7 +937,7 @@ export class BundleDataClient {
                     // Pre-fill refunds only happen when deposits are sent in this bundle and the
                     // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
                     // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
-                    // a current bundle fill. If the fill is a slow fill,
+                    // a current bundle fill.
                     const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
                     duplicateDeposits.forEach((duplicateDeposit) => {
                       // If fill is a slow fill, refund deposit to depositor, otherwise refund to filler.
@@ -1001,7 +1001,7 @@ export class BundleDataClient {
                 bundleInvalidFillsV3.push(fill);
               } else {
                 const matchedDeposit = historicalDeposit.deposit;
-                // If deposit is in a following bundle, then this fill will have to refunded once that deposit
+                // If deposit is in a following bundle, then this fill will have to be refunded once that deposit
                 // is in the current bundle.
                 if (matchedDeposit.blockNumber > originChainBlockRange[1]) {
                   bundleInvalidFillsV3.push(fill);
@@ -1031,9 +1031,8 @@ export class BundleDataClient {
                   });
                   v3RelayHashes[relayDataHash].fill = fillToRefund;
 
-                  // No need to check for duplicate deposits here since we would have seen them in memory if they
-                  // had a non-infinite fill deadline, and duplicate deposits with infinite deadlines are impossible
-                  // to send.
+                  // No need to check for duplicate deposits here since duplicate deposits with
+                  // infinite deadlines are impossible to send via unsafeDeposit().
                 }
 
                 // slow fill requests for deposits from or to lite chains are considered invalid

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -884,36 +884,39 @@ export class BundleDataClient {
             .filter(
               (fill) => fill.blockNumber <= destinationChainBlockRange[1] && !isZeroValueFillOrSlowFillRequest(fill)
             ),
-          async (_fill) => {
+          async (fill) => {
             fillCounter++;
-            const relayDataHash = this.getRelayHashFromEvent(_fill);
+            const relayDataHash = this.getRelayHashFromEvent(fill);
             if (v3RelayHashes[relayDataHash]) {
               if (!v3RelayHashes[relayDataHash].fill) {
                 assert(
                   isDefined(v3RelayHashes[relayDataHash].deposit),
                   "Deposit should exist in relay hash dictionary."
                 );
-                // `fill` will only possibly differ from `_fill` in the `relayer` field, which does not affect the
-                // relay hash, so it is safe to modify.
-                const fill = await verifyFillRepayment(
-                  _fill,
-                  destinationClient.spokePool.provider,
-                  v3RelayHashes[relayDataHash].deposit!,
-                  allChainIds
-                );
-                if (!isDefined(fill)) {
-                  bundleInvalidFillsV3.push(_fill);
-                  return;
-                }
-
                 // At this point, the v3RelayHashes entry already existed meaning that there is a matching deposit,
-                // so this fill is validated.
+                // so this fill can no longer be filled on-chain.
                 v3RelayHashes[relayDataHash].fill = fill;
                 if (fill.blockNumber >= destinationChainBlockRange[0]) {
-                  validatedBundleV3Fills.push({
-                    ...fill,
-                    quoteTimestamp: v3RelayHashes[relayDataHash].deposit!.quoteTimestamp, // ! due to assert above
-                  });
+                  // `fill` will only possibly differ from `_fill` in the `relayer` field, which does not affect the
+                  // relay hash, so it is safe to modify.
+                  const fillToRefund = await verifyFillRepayment(
+                    fill,
+                    destinationClient.spokePool.provider,
+                    v3RelayHashes[relayDataHash].deposit!,
+                    allChainIds
+                  );
+                  if (!isDefined(fillToRefund)) {
+                    bundleInvalidFillsV3.push(fill);
+                    // We don't return here yet because we still need to mark unexecutable slow fill leaves
+                    // or duplicate deposits. However, we won't issue a fast fill refund.
+                  } else {
+                    v3RelayHashes[relayDataHash].fill = fillToRefund;
+                    validatedBundleV3Fills.push({
+                      ...fillToRefund,
+                      quoteTimestamp: v3RelayHashes[relayDataHash].deposit!.quoteTimestamp, // ! due to assert above
+                    });
+                  }
+
                   // If fill replaced a slow fill request, then mark it as one that might have created an
                   // unexecutable slow fill. We can't know for sure until we check the slow fill request
                   // events.
@@ -924,7 +927,18 @@ export class BundleDataClient {
                   ) {
                     fastFillsReplacingSlowFills.push(relayDataHash);
                   }
+                  // Now that know this deposit has been filled on-chain, identify any duplicate deposits sent for this fill and refund
+                  // them, because they would not be refunded otherwise. These deposits can no longer expire and get
+                  // refunded as an expired deposit, and they won't trigger a pre-fill refund because the fill is
+                  // in this bundle. Pre-fill refunds only happen when deposits are sent in this bundle and the
+                  // fill is from a prior bundle.
+                  const duplicateDeposits = originClient.getDuplicateDeposits(v3RelayHashes[relayDataHash].deposit!);
+                  duplicateDeposits.forEach((duplicateDeposit) => {
+                    updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
+                  });
                 }
+              } else {
+                throw new Error("Duplicate fill detected.");
               }
               return;
             }
@@ -933,7 +947,7 @@ export class BundleDataClient {
             // instantiate the entry. We won't modify the fill.relayer until we match it with a deposit.
             v3RelayHashes[relayDataHash] = {
               deposit: undefined,
-              fill: _fill,
+              fill,
               slowFillRequest: undefined,
             };
 
@@ -945,44 +959,47 @@ export class BundleDataClient {
             // older deposit in case the spoke pool client's lookback isn't old enough to find the matching deposit.
             // We can skip this step if the fill's fill deadline is not infinite, because we can assume that the
             // spoke pool clients have loaded deposits old enough to cover all fills with a non-infinite fill deadline.
-            if (_fill.blockNumber >= destinationChainBlockRange[0]) {
+            if (fill.blockNumber >= destinationChainBlockRange[0]) {
               // Fill has a non-infinite expiry, and we can assume our spoke pool clients have old enough deposits
               // to conclude that this fill is invalid if we haven't found a matching deposit in memory, so
               // skip the historical query.
-              if (!INFINITE_FILL_DEADLINE.eq(_fill.fillDeadline)) {
-                bundleInvalidFillsV3.push(_fill);
+              if (!INFINITE_FILL_DEADLINE.eq(fill.fillDeadline)) {
+                bundleInvalidFillsV3.push(fill);
                 return;
               }
               // If deposit is using the deterministic relay hash feature, then the following binary search-based
               // algorithm will not work. However, it is impossible to emit an infinite fill deadline using
               // the unsafeDepositV3 function so there is no need to catch the special case.
-              const historicalDeposit = await queryHistoricalDepositForFill(originClient, _fill);
+              const historicalDeposit = await queryHistoricalDepositForFill(originClient, fill);
               if (!historicalDeposit.found) {
-                bundleInvalidFillsV3.push(_fill);
+                bundleInvalidFillsV3.push(fill);
               } else {
                 const matchedDeposit = historicalDeposit.deposit;
-                const fill = await verifyFillRepayment(
-                  _fill,
+                v3RelayHashes[relayDataHash].deposit = matchedDeposit;
+
+                const fillToRefund = await verifyFillRepayment(
+                  fill,
                   destinationClient.spokePool.provider,
                   matchedDeposit,
                   allChainIds
                 );
-                if (!isDefined(fill)) {
-                  bundleInvalidFillsV3.push(_fill);
-                  return;
+                if (!isDefined(fillToRefund)) {
+                  bundleInvalidFillsV3.push(fill);
+                  // Don't return yet as we still need to mark down any unexecutable slow fill leaves
+                  // in case this fast fill replaced a slow fill request.
+                } else {
+                  // @dev Since queryHistoricalDepositForFill validates the fill by checking individual
+                  // object property values against the deposit's, we
+                  // sanity check it here by comparing the full relay hashes. If there's an error here then the
+                  // historical deposit query is not working as expected.
+                  assert(this.getRelayHashFromEvent(matchedDeposit) === relayDataHash, "Relay hashes should match.");
+                  validatedBundleV3Fills.push({
+                    ...fill,
+                    quoteTimestamp: matchedDeposit.quoteTimestamp,
+                  });
+                  v3RelayHashes[relayDataHash].fill = fillToRefund;
                 }
-                v3RelayHashes[relayDataHash].fill = fill;
 
-                // @dev Since queryHistoricalDepositForFill validates the fill by checking individual
-                // object property values against the deposit's, we
-                // sanity check it here by comparing the full relay hashes. If there's an error here then the
-                // historical deposit query is not working as expected.
-                assert(this.getRelayHashFromEvent(matchedDeposit) === relayDataHash, "Relay hashes should match.");
-                validatedBundleV3Fills.push({
-                  ...fill,
-                  quoteTimestamp: matchedDeposit.quoteTimestamp,
-                });
-                v3RelayHashes[relayDataHash].deposit = matchedDeposit;
                 // slow fill requests for deposits from or to lite chains are considered invalid
                 if (
                   fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
@@ -990,6 +1007,10 @@ export class BundleDataClient {
                 ) {
                   fastFillsReplacingSlowFills.push(relayDataHash);
                 }
+
+                // No need to check for duplicate deposits here since we would have seen them in memory if they
+                // had a non-infinite fill deadline, and duplicate deposits with infinite deadlines are impossible
+                // to send.
               }
             }
           }
@@ -1014,7 +1035,9 @@ export class BundleDataClient {
                 v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
                 if (v3RelayHashes[relayDataHash].fill) {
                   // If there is a fill matching the relay hash, then this slow fill request can't be used
-                  // to create a slow fill for a filled deposit.
+                  // to create a slow fill for a filled deposit. This takes advantage of the fact that
+                  // slow fill requests must precede fills, so if there is a matching fill for this request's
+                  // relay data, then this slow fill will be unexecutable.
                   return;
                 }
                 assert(
@@ -1037,6 +1060,8 @@ export class BundleDataClient {
                   // so this slow fill request relay data is correct.
                   validatedBundleSlowFills.push(matchedDeposit);
                 }
+              } else {
+                throw new Error("Duplicate slow fill request detected.");
               }
               return;
             }
@@ -1132,6 +1157,11 @@ export class BundleDataClient {
                   ...fill,
                   quoteTimestamp: deposit.quoteTimestamp,
                 });
+
+                // We don't refund duplicate deposits for pre-fill refunds because we are refunding the pre-fill instead
+                // using the duplicate deposited funds. We make an assumption that duplicate deposits for pre-fills
+                // are highly unlikely because deposits for pre-fills are designed to be sent by the pre-filler,
+                // so the depositor's approval should protect them from the pre-filler sending multiple deposits.
               }
               return;
             }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1424,6 +1424,7 @@ export class BundleDataClient {
       if (validatedBundleSlowFills.slice(0, idx).some((d) => this.getRelayHashFromEvent(d) === relayDataHash)) {
         return;
       }
+      assert(!_depositIsExpired(deposit), "Cannot create slow fill leaf for expired deposit.");
       updateBundleSlowFills(bundleSlowFillsV3, { ...deposit, lpFeePct });
     });
     v3UnexecutableSlowFillLpFees.forEach(({ realizedLpFeePct: lpFeePct }, idx) => {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1438,12 +1438,7 @@ export class BundleDataClient {
           // will usually be called in production with block ranges that were validated by
           // DataworkerUtils.blockRangesAreInvalidForSpokeClients.
           const startBlockForChain = Math.min(_startBlockForChain, spokePoolClient.latestBlockSearched);
-          // @dev Add 1 to the bundle end block. The thinking here is that there can be a gap between
-          // block timestamps in subsequent blocks. The bundle data client assumes that fill deadlines expire
-          // in exactly one bundle, therefore we must make sure that the bundle block timestamp for one bundle's
-          // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
-          // there are no gaps in block timestamps between bundles.
-          const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
+          const endBlockForChain = Math.min(_endBlockForChain, spokePoolClient.latestBlockSearched);
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
             await spokePoolClient.getTimestampForBlock(endBlockForChain),

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1239,7 +1239,9 @@ export class BundleDataClient {
                 deposit,
                 allChainIds
               );
-              if (canRefundPrefills && isDefined(verifiedFill) && !isSlowFill(verifiedFill)) {
+              if (!isDefined(verifiedFill)) {
+                bundleUnrepayableFillsV3.push(prefill!);
+              } else if (canRefundPrefills && !isSlowFill(verifiedFill)) {
                 validatedBundleV3Fills.push({
                   ...verifiedFill!,
                   quoteTimestamp: deposit.quoteTimestamp,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1055,8 +1055,8 @@ export class BundleDataClient {
             // found using such a method) because infinite fill deadlines cannot be produced from the unsafeDepositV3()
             // function.
             if (
-              slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
-              INFINITE_FILL_DEADLINE.eq(slowFillRequest.fillDeadline)
+              INFINITE_FILL_DEADLINE.eq(slowFillRequest.fillDeadline) &&
+              slowFillRequest.blockNumber >= destinationChainBlockRange[0]
             ) {
               const historicalDeposit = await queryHistoricalDepositForFill(originClient, slowFillRequest);
               if (!historicalDeposit.found) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -66,10 +66,10 @@ type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
 // V3 dictionary helper functions
 function updateExpiredDepositsV3(dict: ExpiredDepositsToRefundV3, deposit: V3DepositWithBlock): void {
-  // A deposit refund for a deposit is invalid if the depositor has a bytes32 address input for an EVM chain. It is valid otherwise.
-  if (chainIsEvm(deposit.originChainId) && !isValidEvmAddress(deposit.depositor)) {
-    return;
-  }
+  assert(
+    chainIsEvm(deposit.originChainId) && isValidEvmAddress(deposit.depositor),
+    "expired depositor cannot be refunded"
+  );
   const { originChainId, inputToken } = deposit;
   if (!dict?.[originChainId]?.[inputToken]) {
     assign(dict, [originChainId, inputToken], []);
@@ -147,9 +147,10 @@ function updateBundleExcessSlowFills(
 }
 
 function updateBundleSlowFills(dict: BundleSlowFills, deposit: V3DepositWithBlock & { lpFeePct: BigNumber }): void {
-  if (chainIsEvm(deposit.destinationChainId) && !isValidEvmAddress(deposit.recipient)) {
-    return;
-  }
+  assert(
+    chainIsEvm(deposit.destinationChainId) && isValidEvmAddress(deposit.recipient),
+    "slow fill recipient cannot be paid"
+  );
   const { destinationChainId, outputToken } = deposit;
   if (!dict?.[destinationChainId]?.[outputToken]) {
     assign(dict, [destinationChainId, outputToken], []);

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1438,12 +1438,18 @@ export class BundleDataClient {
           // will usually be called in production with block ranges that were validated by
           // DataworkerUtils.blockRangesAreInvalidForSpokeClients.
           const startBlockForChain = Math.min(_startBlockForChain, spokePoolClient.latestBlockSearched);
-          const endBlockForChain = Math.min(_endBlockForChain, spokePoolClient.latestBlockSearched);
+          // @dev Add 1 to the bundle end block. The thinking here is that there can be a gap between
+          // block timestamps in subsequent blocks. The bundle data client assumes that fill deadlines expire
+          // in exactly one bundle, therefore we must make sure that the bundle block timestamp for one bundle's
+          // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
+          // there are no gaps in block timestamps between bundles.
+          const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
+          // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
+          // no overlap, subtract 1 from the end time.
+          const endBlockDelta = endBlockForChain > startBlockForChain ? 1 : 0;
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
-            // no overlap, subtract 1 from the end time.
-            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - 1,
+            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - endBlockDelta,
           ];
           // Sanity checks:
           assert(endTime >= startTime, "End time should be greater than start time.");

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1441,7 +1441,9 @@ export class BundleDataClient {
           const endBlockForChain = Math.min(_endBlockForChain, spokePoolClient.latestBlockSearched);
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            await spokePoolClient.getTimestampForBlock(endBlockForChain),
+            // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
+            // no overlap, subtract 1 from the end time.
+            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - 1,
           ];
           // Sanity checks:
           assert(endTime >= startTime, "End time should be greater than start time.");

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -66,10 +66,10 @@ type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
 // V3 dictionary helper functions
 function updateExpiredDepositsV3(dict: ExpiredDepositsToRefundV3, deposit: V3DepositWithBlock): void {
-  assert(
-    chainIsEvm(deposit.originChainId) && isValidEvmAddress(deposit.depositor),
-    "expired depositor cannot be refunded"
-  );
+  // A deposit refund for a deposit is invalid if the depositor has a bytes32 address input for an EVM chain. It is valid otherwise.
+  if (chainIsEvm(deposit.originChainId) && !isValidEvmAddress(deposit.depositor)) {
+    return;
+  }
   const { originChainId, inputToken } = deposit;
   if (!dict?.[originChainId]?.[inputToken]) {
     assign(dict, [originChainId, inputToken], []);
@@ -147,10 +147,9 @@ function updateBundleExcessSlowFills(
 }
 
 function updateBundleSlowFills(dict: BundleSlowFills, deposit: V3DepositWithBlock & { lpFeePct: BigNumber }): void {
-  assert(
-    chainIsEvm(deposit.destinationChainId) && isValidEvmAddress(deposit.recipient),
-    "slow fill recipient cannot be paid"
-  );
+  if (chainIsEvm(deposit.destinationChainId) && !isValidEvmAddress(deposit.recipient)) {
+    return;
+  }
   const { destinationChainId, outputToken } = deposit;
   if (!dict?.[destinationChainId]?.[outputToken]) {
     assign(dict, [destinationChainId, outputToken], []);

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1217,7 +1217,8 @@ export class BundleDataClient {
             } else if (
               canRefundPrefills &&
               slowFillRequest.blockNumber < destinationChainBlockRange[0] &&
-              _canCreateSlowFillLeaf(deposit)
+              _canCreateSlowFillLeaf(deposit) &&
+              validatedBundleSlowFills.every((d) => this.getRelayHashFromEvent(d) !== relayDataHash)
             ) {
               validatedBundleSlowFills.push(deposit);
             }
@@ -1271,7 +1272,10 @@ export class BundleDataClient {
             updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
           }
           // If slow fill requested, then issue a slow fill leaf for the deposit.
-          else if (fillStatus === FillStatus.RequestedSlowFill) {
+          else if (
+            fillStatus === FillStatus.RequestedSlowFill &&
+            validatedBundleSlowFills.every((d) => this.getRelayHashFromEvent(d) !== relayDataHash)
+          ) {
             // Input and Output tokens must be equivalent on the deposit for this to be slow filled.
             // Slow fill requests for deposits from or to lite chains are considered invalid
             if (canRefundPrefills && _canCreateSlowFillLeaf(deposit)) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1062,100 +1062,106 @@ export class BundleDataClient {
 
         // @todo Only start refunding pre-fills and slow fill requests after a config store version is activated. We
         // should remove this check once we've advanced far beyond the version bump block.
-        if (versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION) {
-          await mapAsync(
-            bundleDepositHashes.filter((depositHash) => {
-              const { deposit } = v3RelayHashes[depositHash];
-              return (
-                deposit && deposit.originChainId === originChainId && deposit.destinationChainId === destinationChainId
-              );
-            }),
-            async (depositHash) => {
-              const { deposit, fill, slowFillRequest } = v3RelayHashes[depositHash];
-              if (!deposit) throw new Error("Deposit should exist in relay hash dictionary.");
+        await mapAsync(
+          bundleDepositHashes.filter((depositHash) => {
+            const { deposit } = v3RelayHashes[depositHash];
+            return (
+              deposit && deposit.originChainId === originChainId && deposit.destinationChainId === destinationChainId
+            );
+          }),
+          async (depositHash) => {
+            const { deposit, fill, slowFillRequest } = v3RelayHashes[depositHash];
+            if (!deposit) throw new Error("Deposit should exist in relay hash dictionary.");
 
-              // We are willing to refund a pre-fill multiple times for each duplicate deposit.
-              // This is because a duplicate deposit for a pre-fill cannot get
-              // refunded to the depositor anymore because its fill status on-chain has changed to Filled. Therefore
-              // any duplicate deposits result in a net loss of funds for the depositor and effectively pay out
-              // the pre-filler.
+            // We are willing to refund a pre-fill multiple times for each duplicate deposit.
+            // This is because a duplicate deposit for a pre-fill cannot get
+            // refunded to the depositor anymore because its fill status on-chain has changed to Filled. Therefore
+            // any duplicate deposits result in a net loss of funds for the depositor and effectively pay out
+            // the pre-filler.
 
-              // If fill exists in memory, then the only case in which we need to create a refund is if the
-              // the fill occurred in a previous bundle. There are no expiry refunds for filled deposits.
-              if (fill) {
-                if (fill.blockNumber < destinationChainBlockRange[0] && !isSlowFill(fill)) {
-                  // If fill is in the current bundle then we can assume there is already a refund for it, so only
-                  // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
-                  // we won't consider it, following the previous treatment of fills after the bundle block range.
-                  validatedBundleV3Fills.push({
-                    ...fill,
-                    quoteTimestamp: deposit.quoteTimestamp,
-                  });
-                }
-                return;
+            // If fill exists in memory, then the only case in which we need to create a refund is if the
+            // the fill occurred in a previous bundle. There are no expiry refunds for filled deposits.
+            if (fill) {
+              if (
+                versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION &&
+                fill.blockNumber < destinationChainBlockRange[0] &&
+                !isSlowFill(fill)
+              ) {
+                // If fill is in the current bundle then we can assume there is already a refund for it, so only
+                // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
+                // we won't consider it, following the previous treatment of fills after the bundle block range.
+                validatedBundleV3Fills.push({
+                  ...fill,
+                  quoteTimestamp: deposit.quoteTimestamp,
+                });
               }
+              return;
+            }
 
-              // If a slow fill request exists in memory, then we know the deposit has not been filled because fills
-              // must follow slow fill requests and we would have seen the fill already if it existed. Therefore,
-              // we can conclude that either the deposit has expired and we need to create a deposit expiry refund, or
-              // we need to create a slow fill leaf for the deposit. The latter should only happen if the slow fill request
-              // took place in a prior bundle otherwise we would have already created a slow fill leaf for it.
-              if (slowFillRequest) {
-                if (_depositIsExpired(deposit)) {
-                  updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
-                } else if (
-                  slowFillRequest.blockNumber < destinationChainBlockRange[0] &&
-                  _canCreateSlowFillLeaf(deposit)
-                ) {
-                  validatedBundleSlowFills.push(deposit);
-                }
-                return;
-              }
-
-              // So at this point in the code, there is no fill or slow fill request in memory for this deposit.
-              // We need to check its fill status on-chain to figure out whether to issue a refund or a slow fill leaf.
-              // We can assume at this point that all fills or slow fill requests, if found, were in previous bundles
-              // because the spoke pool client lookback would have returned this entire bundle of events and stored
-              // them into the relay hash dictionary.
-              const fillStatus = await _getFillStatusForDeposit(deposit, destinationChainBlockRange[1]);
-
-              // If deposit was filled, then we need to issue a refund for it.
-              if (fillStatus === FillStatus.Filled) {
-                // We need to find the fill event to issue a refund to the right relayer and repayment chain,
-                // or msg.sender if relayer address is invalid for the repayment chain.
-                const prefill = (await findFillEvent(
-                  destinationClient.spokePool,
-                  deposit,
-                  destinationClient.deploymentBlock,
-                  destinationClient.latestBlockSearched
-                )) as unknown as FillWithBlock;
-                if (!isSlowFill(prefill)) {
-                  validatedBundleV3Fills.push({
-                    ...prefill,
-                    quoteTimestamp: deposit.quoteTimestamp,
-                  });
-                }
-              }
-              // If deposit is not filled and its newly expired, we can create a deposit refund for it.
-              // We don't check that fillDeadline >= bundleBlockTimestamps[destinationChainId][0] because
-              // that would eliminate any deposits in this bundle with a very low fillDeadline like equal to 0
-              // for example. Those should be included in this bundle of refunded deposits.
-              else if (_depositIsExpired(deposit)) {
+            // If a slow fill request exists in memory, then we know the deposit has not been filled because fills
+            // must follow slow fill requests and we would have seen the fill already if it existed. Therefore,
+            // we can conclude that either the deposit has expired and we need to create a deposit expiry refund, or
+            // we need to create a slow fill leaf for the deposit. The latter should only happen if the slow fill request
+            // took place in a prior bundle otherwise we would have already created a slow fill leaf for it.
+            if (slowFillRequest) {
+              if (_depositIsExpired(deposit)) {
                 updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
+              } else if (
+                versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION &&
+                slowFillRequest.blockNumber < destinationChainBlockRange[0] &&
+                _canCreateSlowFillLeaf(deposit)
+              ) {
+                validatedBundleSlowFills.push(deposit);
               }
-              // If slow fill requested, then issue a slow fill leaf for the deposit.
-              else if (fillStatus === FillStatus.RequestedSlowFill) {
-                // Input and Output tokens must be equivalent on the deposit for this to be slow filled.
-                // Slow fill requests for deposits from or to lite chains are considered invalid
-                if (_canCreateSlowFillLeaf(deposit)) {
-                  // If deposit newly expired, then we can't create a slow fill leaf for it but we can
-                  // create a deposit refund for it.
-                  validatedBundleSlowFills.push(deposit);
-                }
+              return;
+            }
+
+            // So at this point in the code, there is no fill or slow fill request in memory for this deposit.
+            // We need to check its fill status on-chain to figure out whether to issue a refund or a slow fill leaf.
+            // We can assume at this point that all fills or slow fill requests, if found, were in previous bundles
+            // because the spoke pool client lookback would have returned this entire bundle of events and stored
+            // them into the relay hash dictionary.
+            const fillStatus = await _getFillStatusForDeposit(deposit, destinationChainBlockRange[1]);
+
+            // If deposit was filled, then we need to issue a refund for it.
+            if (fillStatus === FillStatus.Filled && versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION) {
+              // We need to find the fill event to issue a refund to the right relayer and repayment chain,
+              // or msg.sender if relayer address is invalid for the repayment chain.
+              const prefill = (await findFillEvent(
+                destinationClient.spokePool,
+                deposit,
+                destinationClient.deploymentBlock,
+                destinationClient.latestBlockSearched
+              )) as unknown as FillWithBlock;
+              if (!isSlowFill(prefill)) {
+                validatedBundleV3Fills.push({
+                  ...prefill,
+                  quoteTimestamp: deposit.quoteTimestamp,
+                });
               }
             }
-          );
-        }
+            // If deposit is not filled and its newly expired, we can create a deposit refund for it.
+            // We don't check that fillDeadline >= bundleBlockTimestamps[destinationChainId][0] because
+            // that would eliminate any deposits in this bundle with a very low fillDeadline like equal to 0
+            // for example. Those should be included in this bundle of refunded deposits.
+            else if (_depositIsExpired(deposit)) {
+              updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
+            }
+            // If slow fill requested, then issue a slow fill leaf for the deposit.
+            else if (
+              fillStatus === FillStatus.RequestedSlowFill &&
+              versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION
+            ) {
+              // Input and Output tokens must be equivalent on the deposit for this to be slow filled.
+              // Slow fill requests for deposits from or to lite chains are considered invalid
+              if (_canCreateSlowFillLeaf(deposit)) {
+                // If deposit newly expired, then we can't create a slow fill leaf for it but we can
+                // create a deposit refund for it.
+                validatedBundleSlowFills.push(deposit);
+              }
+            }
+          }
+        );
 
         // For all fills that came after a slow fill request, we can now check if the slow fill request
         // was a valid one and whether it was created in a previous bundle. If so, then it created a slow fill

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1180,9 +1180,9 @@ export class BundleDataClient {
               duplicateDepositsInBundle.forEach((duplicateDeposit) => {
                 updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
               });
-                // If fill is in the current bundle then we can assume there is already a refund for it, so only
-                // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
-                // we won't consider it, following the previous treatment of fills after the bundle block range.
+              // If fill is in the current bundle then we can assume there is already a refund for it, so only
+              // include this pre fill if the fill is in an older bundle. If fill is after this current bundle, then
+              // we won't consider it, following the previous treatment of fills after the bundle block range.
               if (!isSlowFill(fill)) {
                 validatedBundleV3Fills.push({
                   ...fill,

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -1,4 +1,4 @@
-import _, { get } from "lodash";
+import _ from "lodash";
 import { providers } from "ethers";
 import { Deposit, DepositWithBlock, Fill, FillWithBlock } from "../../../interfaces";
 import { getBlockRangeForChain, isSlowFill, chainIsEvm, isValidEvmAddress, isDefined } from "../../../utils";

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -1,6 +1,6 @@
-import _ from "lodash";
+import _, { get } from "lodash";
 import { providers } from "ethers";
-import { DepositWithBlock, Fill, FillWithBlock } from "../../../interfaces";
+import { Deposit, DepositWithBlock, Fill, FillWithBlock } from "../../../interfaces";
 import { getBlockRangeForChain, isSlowFill, chainIsEvm, isValidEvmAddress, isDefined } from "../../../utils";
 import { HubPoolClient } from "../../HubPoolClient";
 
@@ -47,34 +47,51 @@ export function getRefundInformationFromFill(
   };
 }
 
+export function getRepaymentChainId(fill: Fill, matchedDeposit: Deposit): number {
+  // Lite chain deposits force repayment on origin chain.
+  return matchedDeposit.fromLiteChain ? fill.originChainId : fill.repaymentChainId;
+}
+
+export function isEvmRepaymentValid(
+  fill: Fill,
+  repaymentChainId: number,
+  possibleRepaymentChainIds: number[] = []
+): boolean {
+  // Slow fills don't result in repayments so they're always valid.
+  if (isSlowFill(fill)) {
+    return true;
+  }
+  // Return undefined if the requested repayment chain ID is not in a passed in set of eligible chains. This can
+  // be used by the caller to narrow the chains to those that are not disabled in the config store.
+  if (possibleRepaymentChainIds.length > 0 && !possibleRepaymentChainIds.includes(repaymentChainId)) {
+    return false;
+  }
+  return chainIsEvm(repaymentChainId) && isValidEvmAddress(fill.relayer);
+}
+
 // Verify that a fill sent to an EVM chain has a 20 byte address. If the fill does not, then attempt
 // to repay the `msg.sender` of the relay transaction. Otherwise, return undefined.
 export async function verifyFillRepayment(
-  fill: FillWithBlock,
+  _fill: FillWithBlock,
   destinationChainProvider: providers.Provider,
   matchedDeposit: DepositWithBlock,
-  possibleRepaymentChainIds: number[]
+  possibleRepaymentChainIds: number[] = []
 ): Promise<FillWithBlock | undefined> {
-  // Slow fills don't result in repayments so they're always valid.
-  if (isSlowFill(fill)) {
+  const fill = _.cloneDeep(_fill);
+
+  const repaymentChainId = getRepaymentChainId(fill, matchedDeposit);
+  const validEvmRepayment = isEvmRepaymentValid(fill, repaymentChainId, possibleRepaymentChainIds);
+
+  // Case 1: Repayment chain is EVM and repayment address is valid EVM address.
+  if (validEvmRepayment) {
     return fill;
   }
-  // Lite chain deposits force repayment on origin chain.
-  const repaymentChainId = matchedDeposit.fromLiteChain ? fill.originChainId : fill.repaymentChainId;
-  // Return undefined if the requested repayment chain ID is not recognized by the hub pool.
-  if (!possibleRepaymentChainIds.includes(repaymentChainId)) {
-    return undefined;
-  }
-  const updatedFill = _.cloneDeep(fill);
-
-  // If the fill requests repayment on a chain where the repayment address is not valid, attempt to find a valid
-  // repayment address, otherwise return undefined.
-
-  // Case 1: repayment chain is an EVM chain but repayment address is not a valid EVM address.
-  if (chainIsEvm(repaymentChainId) && !isValidEvmAddress(updatedFill.relayer)) {
+  // Case 2: Repayment chain is EVM but repayment address is not a valid EVM address. Attempt to switch repayment
+  // address to msg.sender of relay transaction.
+  else if (chainIsEvm(repaymentChainId) && !isValidEvmAddress(fill.relayer)) {
     // TODO: Handle case where fill was sent on non-EVM chain, in which case the following call would fail
     // or return something unexpected. We'd want to return undefined here.
-    const fillTransaction = await destinationChainProvider.getTransaction(updatedFill.transactionHash);
+    const fillTransaction = await destinationChainProvider.getTransaction(fill.transactionHash);
     const destinationRelayer = fillTransaction?.from;
     // Repayment chain is still an EVM chain, but the msg.sender is a bytes32 address, so the fill is invalid.
     if (!isDefined(destinationRelayer) || !isValidEvmAddress(destinationRelayer)) {
@@ -83,9 +100,11 @@ export async function verifyFillRepayment(
     // Otherwise, assume the relayer to be repaid is the msg.sender. We don't need to modify the repayment chain since
     // the getTransaction() call would only succeed if the fill was sent on an EVM chain and therefore the msg.sender
     // is a valid EVM address and the repayment chain is an EVM chain.
-    updatedFill.relayer = destinationRelayer;
+    fill.relayer = destinationRelayer;
+    return fill;
   }
-
-  // Case 2: TODO repayment chain is an SVM chain and repayment address is not a valid SVM address.
-  return updatedFill;
+  // Case 3: Repayment chain is not an EVM chain, must be invalid.
+  else {
+    return undefined;
+  }
 }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -142,7 +142,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns A list of duplicate deposits. Does NOT include the original deposit
    * unless the original deposit is a duplicate.
    */
-  public getDuplicateDeposits(deposit: DepositWithBlock): DepositWithBlock[] {
+  private _getDuplicateDeposits(deposit: DepositWithBlock): DepositWithBlock[] {
     const depositHash = this.getDepositHash(deposit);
     return this.duplicateDepositHashes[depositHash] ?? [];
   }
@@ -157,7 +157,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   public getDepositsForDestinationChainWithDuplicates(destinationChainId: number): DepositWithBlock[] {
     const deposits = this.getDepositsForDestinationChain(destinationChainId);
     const duplicateDeposits = deposits.reduce((acc, deposit) => {
-      const duplicates = this.getDuplicateDeposits(deposit);
+      const duplicates = this._getDuplicateDeposits(deposit);
       return acc.concat(duplicates);
     }, [] as DepositWithBlock[]);
     return sortEventsAscendingInPlace(deposits.concat(duplicateDeposits.flat()));

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -122,7 +122,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const { blockNumber, transactionIndex } = deposit;
     let { depositId, depositor, destinationChainId, inputToken, inputAmount, outputToken, outputAmount } = deposit;
     depositId ??= this.numberOfDeposits;
-    assert(depositId.gte(this.numberOfDeposits), `${depositId.toString()} < ${this.numberOfDeposits}`);
     this.numberOfDeposits = depositId.add(bnOne);
 
     destinationChainId ??= random(1, 42161, false);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,8 +57,6 @@ export const DEFAULT_ARWEAVE_STORAGE_ADDRESS = "Z6hjBM8FHu90lYWB8o5jR1dfX92FlV2W
 
 export const EMPTY_MESSAGE = "0x";
 
-export const EMPTY_MESSAGE_HASH = ethersConstants.HashZero;
-
 export const BRIDGED_USDC_SYMBOLS = [
   TOKEN_SYMBOLS_MAP["USDC.e"].symbol,
   TOKEN_SYMBOLS_MAP.USDbC.symbol,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,8 +26,10 @@ export const SECONDS_PER_YEAR = 31557600; // 365.25 days per year.
  */
 export const HUBPOOL_CHAIN_ID = 1;
 
-// List of versions where certain UMIP features were deprecated
+// List of versions where certain UMIP features were deprecated or activated
 export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
+
+export const PRE_FILL_MIN_CONFIG_STORE_VERSION = 5;
 
 // A hardcoded identifier used, by default, to tag all Arweave records.
 export const ARWEAVE_TAG_APP_NAME = "across-protocol";

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { SpokePoolClient } from "../clients";
-import { DEFAULT_CACHING_TTL, EMPTY_MESSAGE, EMPTY_MESSAGE_HASH } from "../constants";
+import { DEFAULT_CACHING_TTL, EMPTY_MESSAGE, ZERO_BYTES } from "../constants";
 import { CachingMechanismInterface, Deposit, DepositWithBlock, Fill, SlowFillRequest } from "../interfaces";
 import { getNetworkName } from "./NetworkUtils";
 import { getDepositInCache, getDepositKey, setDepositInCache } from "./CachingUtils";
@@ -160,7 +160,7 @@ export function isMessageEmpty(message = EMPTY_MESSAGE): boolean {
 }
 
 export function isFillOrSlowFillRequestMessageEmpty(message: string): boolean {
-  return isMessageEmpty(message) || message === EMPTY_MESSAGE_HASH;
+  return isMessageEmpty(message) || message === ZERO_BYTES;
 }
 
 /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -412,7 +412,6 @@ export async function findFillEvent(
   // In production the chainId returned from the provider matches 1:1 with the actual chainId. Querying the provider
   // object saves an RPC query becasue the chainId is cached by StaticJsonRpcProvider instances. In hre, the SpokePool
   // may be configured with a different chainId than what is returned by the provider.
-  // @todo Sub out actual chain IDs w/ CHAIN_IDs constants
   const destinationChainId = Object.values(CHAIN_IDs).includes(relayData.originChainId)
     ? (await spokePool.provider.getNetwork()).chainId
     : Number(await spokePool.chainId());

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -215,13 +215,13 @@ describe("SpokePoolClient: SpeedUp", function () {
     // attributed to the existing deposit.
     for (const field of ["originChainId", "depositId", "depositor"]) {
       const testOriginChainId = field !== "originChainId" ? originChainId : originChainId + 1;
-      const testDepositId = field !== "depositId" ? depositId : depositId + 1;
+      const testDepositId = field !== "depositId" ? depositId : depositId.add(1);
       const testDepositor = field !== "depositor" ? depositor : (await ethers.getSigners())[0];
       assert.isTrue(field !== "depositor" || testDepositor.address !== depositor.address); // Sanity check
 
       const signature = await getUpdatedV3DepositSignature(
         testDepositor,
-        testDepositId,
+        testDepositId.toNumber(),
         testOriginChainId,
         updatedOutputAmount,
         updatedRecipient,

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -615,7 +615,7 @@ describe("SpokePoolClient: Fill Validation", function () {
 
     // Override the first spoke pool deposit ID that the client thinks is available in the contract.
     await spokePoolClient1.update();
-    spokePoolClient1.firstDepositIdForSpokePool = deposit.depositId + 1;
+    spokePoolClient1.firstDepositIdForSpokePool = deposit.depositId.add(1);
     expect(fill.depositId < spokePoolClient1.firstDepositIdForSpokePool).is.true;
     const search = await queryHistoricalDepositForFill(spokePoolClient1, fill);
 


### PR DESCRIPTION
### Definitions

- "pre-fill": any fill that is in a bundle that precedes the bundle containing the matched deposit
- "pre-slow-fill-request": a mouthful, and any slow fill request in a bundle that precedes the bundle containing the matched deposit
- "duplicate deposit": a deposit with the same relay hash as an existing one

## Core logic for refunding pre-fills:

Evaluate all deposits in the current bundle that were not filled in the current bundle. Figure out whether the deposit was filled, by either:
- Finding the fill in the spoke pool client's memory, or
- Querying the fill status on-chain

If there is a fill for this deposit then we need to issue a refund for this fill because the fill occurred in a previous bundle where it might not have been refunded.

We need to use a similar algorithm for creating slow fill leaves for pre-slow-fill-requests with the caveat that we cannot create slow fill leaves for deposits that have expired

## Non-determinism for refunding pre-fills

We don't deterministically know whether this pre-fill was refunded in the prior bundle because we don't know for certain what kind of event search window the proposer of the prior bundle used when constructing the bundle.

To illustrate this problem, imagine if a fill and a deposit are sent 10 minutes apart such that the fill is at the end of the current bundle and the deposit is at the beginning of the next. The prior bundle proposer probably would have issued a refund for this fill, but we don't know for certain.

So, one way around this non-determinism is to introduce a new rule to the UMIP:

### Do not issue refunds for fills or slow fill leaves where the matched deposit is later than the current bundle block range

This rule makes it always apparent which bundle should include a refund or slow fill leaf for a pre-fill or pre-slow-fill-request.

This will require a UMIP change to [this PR](https://github.com/UMAprotocol/UMIPs/pull/611)

### findFillEvents

When we need to query `fillStatuses()` on-chain  to detect whether a deposit corresponds to a very old pre-fill, then we also need to locate that old fill. We assume this is rare and will use the relatively expensive `findFillEvents()` function which is built off of the existing `findFillBlock()` function to locate that event.

## Duplicate deposits

This PR also adds support for duplicate deposits that are possible to create with unsafeDeposit. Duplicate deposits are added to `bundleDeposits` for they should be included in `runningBalances`. Duplicate deposits can be refunded upon expiry but for all deposits, expiry refunds cannot occur once the deposit has been filled. 

Due to the presence of pre-fills, we can now no longer instantly include that a deposit submitted in the current bundle that has expired is due a refund. We now need to check its relay status in the case where we don't see a matching fill in our memory.

## Unit tests

Can be found here: https://github.com/across-protocol/relayer/pull/2010
