### PR TITLE
improve(spokeclient): allow disabling quote block lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.12",
+  "version": "3.4.13",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [


### PR DESCRIPTION
Resolving mainnet block numbers from quote timestamps is a required action in the bots' usage of the SpokePoolClient. However, we don't need this resolution in the spoke client for the indexer.

This change adds an opt-in flag to disable the lookup