### PR TITLE
feat(BundleDataClient): Support duplicate expired deposit refunds

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -778,7 +778,7 @@ export class BundleDataClient {
         if (originChainId === destinationChainId) {
           continue;
         }
-        originClient.getDepositsForDestinationChain(destinationChainId).forEach((deposit) => {
+        originClient.getDepositsForDestinationChainWithDuplicates(destinationChainId).forEach((deposit) => {
           if (isZeroValueDeposit(deposit)) {
             return;
           }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1205,7 +1205,8 @@ export class BundleDataClient {
     // Add any newly expired deposits to the list of expired deposits to refund.
     // For these refunds, we need to check whether there was a slow fill created for it in a previous bundle
     // that is now unexecutable and replaced by a new expired deposit refund.
-    await forEachAsync(olderDepositHashes.concat(expiredBundleDepositHashes), async (relayDataHash) => {
+    const possibleExpiredDeposits =olderDepositHashes.concat(expiredBundleDepositHashes);
+    await forEachAsync(possibleExpiredDeposits, async (relayDataHash) => {
       const { deposit, slowFillRequest, fill } = v3RelayHashes[relayDataHash];
       assert(isDefined(deposit), "Deposit should exist in relay hash dictionary.");
       const { destinationChainId } = deposit!;

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1076,6 +1076,8 @@ export class BundleDataClient {
         // yet been refunded. These fills are also known as "pre-fills" from here on.
         const originBlockRange = getBlockRangeForChain(blockRangesForChains, originChainId, chainIds);
 
+        // We don't iterate through deposits again here because we only need to consider unique deposit hashes
+        // to look for pre-fills. Duplicate deposits could only have been pre-filled once.
         await mapAsync(
           Object.values(v3RelayHashes).filter(
             ({ deposit }) =>

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1043,12 +1043,6 @@ export class BundleDataClient {
             // any duplicate deposits result in a net loss of funds for the depositor and effectively pay out
             // the pre-filler.
 
-            // We don't check here that this deposit is a duplicate because we are willing to refund a pre-fill
-            // even if this deposit is a duplicate. This is because a duplicate deposit for a pre-fill cannot get
-            // refunded to the depositor anymore because its fill status on-chain has changed to Filled. Therefore
-            // any duplicate deposits result in a net loss of funds for the depositor and effectively payout
-            // the pre-filler.
-
             // If fill exists in memory, then the only case in which we need to create a refund is if the
             // the fill occurred in a previous bundle. There are no expiry refunds for filled deposits.
             if (fill) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1095,6 +1095,12 @@ export class BundleDataClient {
             // If a pre-fill gets refunded and its deposit expired and gets refunded as well, then there is no net loss
             // to the protocol.
 
+            // We don't check here that this deposit is a duplicate because we are willing to refund a pre-fill
+            // even if this deposit is a duplicate. This is because a duplicate deposit for a pre-fill cannot get
+            // refunded to the depositor anymore because its fill status on-chain has changed to Filled. Therefore
+            // any duplicate deposits result in a net loss of funds for the depositor and effectively payout
+            // the pre-filler.
+
             // If fill exists in memory, then the only case in which we need to create a refund is if the
             // the fill occurred in a previous bundle.
             if (fill) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -849,8 +849,7 @@ export class BundleDataClient {
             updateBundleDepositsV3(bundleDepositsV3, deposit);
             // We don't check that fillDeadline >= bundleBlockTimestamps[destinationChainId][0] because
             // that would eliminate any deposits in this bundle with a very low fillDeadline like equal to 0
-            // for example. Those should be impossible to create but technically should be included in this
-            // bundle of refunded deposits.
+            // for example. Those should be included in this bundle of refunded deposits.
             if (deposit.fillDeadline < bundleBlockTimestamps[destinationChainId][1]) {
               expiredBundleDepositHashes.push(relayDataHash);
             }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -137,7 +137,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * Returns a list of all deposits including any duplicate ones. Designed only to be used in use cases where
    * all deposits are required, regardless of duplicates. For example, the Dataworker can use this to refund
    * expired deposits including for duplicates.
-   * @param destinationChainId 
+   * @param destinationChainId
    * @returns A list of deposits
    */
   public getDepositsForDestinationChainWithDuplicates(destinationChainId: number): DepositWithBlock[] {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -142,7 +142,10 @@ export class SpokePoolClient extends BaseAbstractClient {
    */
   public getDepositsForDestinationChainWithDuplicates(destinationChainId: number): DepositWithBlock[] {
     const deposits = this.getDepositsForDestinationChain(destinationChainId);
-    return sortEventsAscendingInPlace(deposits.concat(Object.values(this.duplicateDepositHashes).flat()));
+    const duplicateDeposits = Object.values(this.duplicateDepositHashes).filter(
+      (deposits) => deposits.length > 0 && deposits[0].destinationChainId === destinationChainId
+    );
+    return sortEventsAscendingInPlace(deposits.concat(duplicateDeposits.flat()));
   }
 
   /**
@@ -588,7 +591,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         }
 
         if (this.depositHashes[this.getDepositHash(deposit)] !== undefined) {
-          assign(this.duplicateDepositHashes, [this.getDepositHash(deposit)], deposit);
+          assign(this.duplicateDepositHashes, [this.getDepositHash(deposit)], [deposit]);
           continue;
         }
         assign(this.depositHashes, [this.getDepositHash(deposit)], deposit);

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -122,7 +122,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const { blockNumber, transactionIndex } = deposit;
     let { depositId, depositor, destinationChainId, inputToken, inputAmount, outputToken, outputAmount } = deposit;
     depositId ??= this.numberOfDeposits;
-    assert(depositId >= this.numberOfDeposits, `${depositId} < ${this.numberOfDeposits}`);
     this.numberOfDeposits = depositId + 1;
 
     destinationChainId ??= random(1, 42161, false);

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -334,7 +334,7 @@ export async function findFillBlock(
 ): Promise<number | undefined> {
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
-  assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} > ${highBlockNumber})`);
+  assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} >= ${highBlockNumber})`);
 
   // In production the chainId returned from the provider matches 1:1 with the actual chainId. Querying the provider
   // object saves an RPC query becasue the chainId is cached by StaticJsonRpcProvider instances. In hre, the SpokePool


### PR DESCRIPTION
I think these are the changes needed but I need to consider more the impact if two deposits expire and they both create slow fill excesses, for example, or other weird edge cases.
