### PR TITLE
fix(BundleDataClient): Make sure bundle block timestamps have no gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1401,10 +1401,10 @@ export class BundleDataClient {
           // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
           // there are no gaps in block timestamps between bundles.
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
-          const [startTime, _endTime] = await Promise.all([
-            spokePoolClient.getTimestampForBlock(startBlockForChain),
-            spokePoolClient.getTimestampForBlock(endBlockForChain),
-          ]);
+          const [startTime, _endTime] = [
+            await spokePoolClient.getTimestampForBlock(startBlockForChain),
+            await spokePoolClient.getTimestampForBlock(endBlockForChain),
+          ];
           // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
           // no overlap, subtract 1 from the end time.
           const endBlockDelta = endBlockForChain > startBlockForChain ? 1 : 0;

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1401,15 +1401,20 @@ export class BundleDataClient {
           // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
           // there are no gaps in block timestamps between bundles.
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
+          const [startTime, _endTime] = await Promise.all([
+            spokePoolClient.getTimestampForBlock(startBlockForChain),
+            spokePoolClient.getTimestampForBlock(endBlockForChain),
+          ]);
           // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
           // no overlap, subtract 1 from the end time.
           const endBlockDelta = endBlockForChain > startBlockForChain ? 1 : 0;
-          const [startTime, endTime] = [
-            await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - endBlockDelta,
-          ];
+          const endTime = Math.max(0, _endTime - endBlockDelta);
+
           // Sanity checks:
-          assert(endTime >= startTime, "End time should be greater than start time.");
+          assert(
+            endTime >= startTime,
+            `End time for block ${endBlockForChain} should be greater than start time for block ${startBlockForChain}: ${endTime} >= ${startTime}.`
+          );
           assert(
             startBlockForChain === 0 || startTime > 0,
             "Start timestamp must be greater than 0 if the start block is greater than 0."

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1395,7 +1395,12 @@ export class BundleDataClient {
           // will usually be called in production with block ranges that were validated by
           // DataworkerUtils.blockRangesAreInvalidForSpokeClients.
           const startBlockForChain = Math.min(_startBlockForChain, spokePoolClient.latestBlockSearched);
-          const endBlockForChain = Math.min(_endBlockForChain, spokePoolClient.latestBlockSearched);
+          // @dev Add 1 to the bundle end block. The thinking here is that there can be a gap between
+          // block timestamps in subsequent blocks. The bundle data client assumes that fill deadlines expire
+          // in exactly one bundle, therefore we must make sure that the bundle block timestamp for one bundle's
+          // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
+          // there are no gaps in block timestamps between bundles.
+          const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
             await spokePoolClient.getTimestampForBlock(endBlockForChain),

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1401,11 +1401,12 @@ export class BundleDataClient {
           // end block is exactly equal to the bundle block timestamp for the next bundle's start block. This way
           // there are no gaps in block timestamps between bundles.
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
+          // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
+          // no overlap, subtract 1 from the end time.
+          const endBlockDelta = endBlockForChain > startBlockForChain ? 1 : 0;
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
-            // no overlap, subtract 1 from the end time.
-            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - 1,
+            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - endBlockDelta,
           ];
           // Sanity checks:
           assert(endTime >= startTime, "End time should be greater than start time.");

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1403,7 +1403,9 @@ export class BundleDataClient {
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
           const [startTime, endTime] = [
             await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            await spokePoolClient.getTimestampForBlock(endBlockForChain),
+            // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
+            // no overlap, subtract 1 from the end time.
+            (await spokePoolClient.getTimestampForBlock(endBlockForChain)) - 1,
           ];
           // Sanity checks:
           assert(endTime >= startTime, "End time should be greater than start time.");


### PR DESCRIPTION
Currently there is a small chance that a fill deadline can fall between block ranges

inspired by @bmzig 's comment here https://github.com/across-protocol/sdk/pull/835#discussion_r1934742099
