### PR TITLE
feat: truncate select bytes32 values in events to bytes20 addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.18",
+  "version": "3.4.19",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -13,6 +13,7 @@ import {
   FillWithBlock,
   SlowFillLeaf,
   SpeedUp,
+  TokensBridged,
 } from "../../interfaces";
 import { toBN, toBNWei, getCurrentTime, randomAddress, BigNumber, bnZero, bnOne, bnMax } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
@@ -216,6 +217,19 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const event = "RequestedSpeedUpV3Deposit";
     const topics = [speedUp.depositId, speedUp.depositor];
     const args = { ...speedUp };
+
+    return this.eventManager.generateEvent({
+      event,
+      address: this.spokePool.address,
+      topics: topics.map((topic) => topic.toString()),
+      args,
+    });
+  }
+
+  setTokensBridged(tokensBridged: TokensBridged): Log {
+    const event = "TokensBridged";
+    const topics = [tokensBridged.chainId, tokensBridged.leafId, tokensBridged.l2TokenAddress];
+    const args = { ...tokensBridged };
 
     return this.eventManager.generateEvent({
       event,

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -39,6 +39,16 @@ export function compareAddressesSimple(addressA?: string, addressB?: string): bo
   return addressA.toLowerCase() === addressB.toLowerCase();
 }
 
+// Converts an input (assumed to be) bytes32 string into a bytes20 string.
+// If the input is not a bytes32 but is less than type(uint160).max, then this function
+// will still succeed.
+// Throws an error if the string as an unsigned integer is greater than type(uint160).max.
+export function toAddress(hexString: string): string {
+  // rawAddress is the address which is not properly checksummed.
+  const rawAddress = utils.hexZeroPad(utils.hexStripZeros(hexString), 20);
+  return utils.getAddress(rawAddress);
+}
+
 export function isValidEvmAddress(address: string): boolean {
   if (utils.isAddress(address)) {
     return true;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -3,10 +3,26 @@ import { Result } from "@ethersproject/abi";
 import { Contract, Event, EventFilter } from "ethers";
 import { Log, SortableEvent } from "../interfaces";
 import { delay } from "./common";
-import { isDefined, toBN, BigNumberish } from "./";
+import { isDefined, toBN, BigNumberish, toAddress } from "./";
 
 const maxRetries = 3;
 const retrySleepTime = 10;
+
+// Event fields which changed from an `address` to `bytes32` after the SVM contract upgrade.
+const knownExtendedAddressFields = [
+  // TokensBridged
+  "l2TokenAddress",
+  // FundsDeposited/FilledRelay/RequestedSlowFill
+  "inputToken",
+  "outputToken",
+  "depositor",
+  "recipient",
+  "exclusiveRelayer",
+  // FilledRelay
+  "relayer",
+  // RequestedSpeedUpDeposit
+  "updatedRecipient",
+];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function spreadEvent(args: Result | Record<string, unknown>): { [key: string]: any } {
@@ -65,6 +81,13 @@ export function spreadEvent(args: Result | Record<string, unknown>): { [key: str
     // Assuming a numeric output, we can safely cast the unknown to BigNumberish since the depositId will either be a uint32 (and therefore a TypeScript `number`),
     // or a uint256 (and therefore an ethers BigNumber).
     returnedObject.depositId = toBN(returnedObject.depositId as BigNumberish);
+  }
+
+  // Truncate all fields which may be bytes32 into a bytes20 string.
+  for (const field of knownExtendedAddressFields) {
+    if (isDefined(returnedObject[field])) {
+      returnedObject[field] = toAddress(String(returnedObject[field]));
+    }
   }
 
   return returnedObject;

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -5,7 +5,7 @@ import { DEFAULT_CONFIG_STORE_VERSION, GLOBAL_CONFIG_STORE_KEYS } from "../src/c
 import { MockConfigStoreClient, MockHubPoolClient, MockSpokePoolClient } from "../src/clients/mocks";
 import { EMPTY_MESSAGE, ZERO_ADDRESS } from "../src/constants";
 import { DepositWithBlock, FillWithBlock, Log, SlowFillRequest, SlowFillRequestWithBlock } from "../src/interfaces";
-import { getCurrentTime, isDefined, randomAddress } from "../src/utils";
+import { getCurrentTime, isDefined, randomAddress, toAddress, toBN } from "../src/utils";
 import {
   SignerWithAddress,
   createSpyLogger,
@@ -341,5 +341,101 @@ describe("SpokePoolClient: Event Filtering", function () {
       expect(fillEvent.destinationChainId).to.equal(destinationChainId);
       expect(fillEvent.outputToken).to.equal(expectedFill.args!.outputToken);
     });
+  });
+
+  it("Correctly truncates events with bytes32 address fields: TokensBridged", async function () {
+    for (let i = 0; i < 10; ++i) {
+      const l2TokenAddress = ethers.utils.hexZeroPad(randomAddress(), 32);
+      originSpokePoolClient.setTokensBridged({ l2TokenAddress, chainId: i, leafId: i + 1 } as TokensBridged);
+      await originSpokePoolClient.update(["TokensBridged"]);
+      const tokensBridged = originSpokePoolClient.getTokensBridged().at(-1);
+      expect(tokensBridged.l2TokenAddress).to.equal(toAddress(l2TokenAddress));
+    }
+  });
+
+  it("Correctly truncates events with bytes32 address fields: FundsDeposited", async function () {
+    for (let _i = 0; _i < 10; ++_i) {
+      const [depositor, recipient, inputToken, outputToken, exclusiveRelayer] = Array(5)
+        .fill(0)
+        .map((_) => ethers.utils.hexZeroPad(randomAddress(), 32));
+      originSpokePoolClient.depositV3({
+        depositor,
+        recipient,
+        inputToken,
+        outputToken,
+        exclusiveRelayer,
+      } as DepositWithBlock);
+      await originSpokePoolClient.update(["V3FundsDeposited"]);
+      const deposit = originSpokePoolClient.getDeposits().at(-1);
+      expect(deposit.depositor).to.equal(toAddress(depositor));
+      expect(deposit.recipient).to.equal(toAddress(recipient));
+      expect(deposit.inputToken).to.equal(toAddress(inputToken));
+      expect(deposit.outputToken).to.equal(toAddress(outputToken));
+      expect(deposit.exclusiveRelayer).to.equal(toAddress(exclusiveRelayer));
+    }
+  });
+  it("Correctly truncates events with bytes32 address fields: RequestedSpeedUpDeposit", async function () {
+    for (let i = 0; i < 10; ++i) {
+      const [depositor, updatedRecipient] = Array(2)
+        .fill(0)
+        .map((_) => ethers.utils.hexZeroPad(randomAddress(), 32));
+      originSpokePoolClient.speedUpV3Deposit({ depositor, updatedRecipient, depositId: toBN(i) } as SpeedUp);
+      await originSpokePoolClient.update(["RequestedSpeedUpV3Deposit"]);
+      const speedUp = originSpokePoolClient.getSpeedUps()[toAddress(depositor)][toBN(i)].at(-1);
+      expect(speedUp.depositor).to.equal(toAddress(depositor));
+      expect(speedUp.updatedRecipient).to.equal(toAddress(updatedRecipient));
+    }
+  });
+  it("Correctly truncates events with bytes32 address fields: FilledRelay", async function () {
+    for (let i = 0; i < 10; ++i) {
+      const [depositor, recipient, inputToken, outputToken, exclusiveRelayer, relayer] = Array(6)
+        .fill(0)
+        .map((_) => ethers.utils.hexZeroPad(randomAddress(), 32));
+      originSpokePoolClient.fillV3Relay({
+        depositor,
+        recipient,
+        inputToken,
+        outputToken,
+        exclusiveRelayer,
+        relayer,
+        depositId: toBN(i),
+      } as FillWithBlock);
+      await originSpokePoolClient.update(["FilledV3Relay"]);
+      const relay = originSpokePoolClient.getFills().at(-1);
+      expect(relay.depositor).to.equal(toAddress(depositor));
+      expect(relay.recipient).to.equal(toAddress(recipient));
+      expect(relay.inputToken).to.equal(toAddress(inputToken));
+      expect(relay.outputToken).to.equal(toAddress(outputToken));
+      expect(relay.exclusiveRelayer).to.equal(toAddress(exclusiveRelayer));
+      expect(relay.relayer).to.equal(toAddress(relayer));
+    }
+  });
+  it("Correctly truncates events with bytes32 address fields: RequestedSlowFill", async function () {
+    for (let i = 0; i < 10; ++i) {
+      const [depositor, recipient, inputToken, outputToken, exclusiveRelayer] = Array(5)
+        .fill(0)
+        .map((_) => ethers.utils.hexZeroPad(randomAddress(), 32));
+      originSpokePoolClient.requestV3SlowFill({
+        depositor,
+        recipient,
+        inputToken,
+        outputToken,
+        exclusiveRelayer,
+        depositId: toBN(i),
+        originChainId: 1,
+        inputAmount: toBN(i),
+        outputAmount: toBN(i),
+        message: "0x",
+        fillDeadline: 0,
+        exclusivityDeadline: 0,
+      } as SlowFillRequestWithBlock);
+      await originSpokePoolClient.update(["RequestedV3SlowFill"]);
+      const slowFill = originSpokePoolClient.getSlowFillRequestsForOriginChain(1).at(-1);
+      expect(slowFill.depositor).to.equal(toAddress(depositor));
+      expect(slowFill.recipient).to.equal(toAddress(recipient));
+      expect(slowFill.inputToken).to.equal(toAddress(inputToken));
+      expect(slowFill.outputToken).to.equal(toAddress(outputToken));
+      expect(slowFill.exclusiveRelayer).to.equal(toAddress(exclusiveRelayer));
+    }
   });
 });


### PR DESCRIPTION
For now, select input fields on events should be automatically truncated to bytes20 evm addresses. This is so that all clients which use the spoke pool client to get deposit/relay/etc. information do not need to handle bytes32 addresses.

Draft until unit tests are made