### PR TITLE
feat(SpokePoolClient): Support fills with messageHash field

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -242,6 +242,15 @@ export class BundleDataClient {
         })
       )
     );
+    Object.values(data.bundleFillsV3).forEach((x) =>
+      Object.values(x).forEach((fills) =>
+        fills.fills.forEach((fill) => {
+          if (fill.messageHash === UNDEFINED_MESSAGE_HASH) {
+            fill.messageHash = getMessageHash(fill.message);
+          }
+        })
+      )
+    );
 
     const bundleData = {
       bundleFillsV3: convertTypedStringRecordIntoNumericRecord(data.bundleFillsV3),

--- a/src/clients/BundleDataClient/utils/SuperstructUtils.ts
+++ b/src/clients/BundleDataClient/utils/SuperstructUtils.ts
@@ -90,12 +90,12 @@ const V3RelayExecutionEventInfoSS = object({
 
 const V3FillSS = {
   ...V3RelayDataSS,
+  messageHash: defaulted(string(), UNDEFINED_MESSAGE_HASH),
   destinationChainId: number(),
   relayer: string(),
   repaymentChainId: number(),
   relayExecutionInfo: V3RelayExecutionEventInfoSS,
   quoteTimestamp: number(),
-  messageHash: optional(string()),
 };
 
 const V3FillWithBlockSS = {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -642,6 +642,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       for (const event of fillEvents) {
         const fill = {
           ...spreadEventWithBlockNumber(event),
+          messageHash: getMessageHash(event.args["message"]),
           destinationChainId: this.chainId,
         } as FillWithBlock;
 

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -247,6 +247,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
   executeV3SlowRelayLeaf(leaf: SlowFillLeaf): Log {
     const fill: Fill = {
       ...leaf.relayData,
+      messageHash: "", // Not used.
       destinationChainId: this.chainId,
       relayer: ZERO_ADDRESS,
       repaymentChainId: 0,

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -57,6 +57,7 @@ export interface RelayExecutionEventInfo {
 }
 
 export interface Fill extends RelayData {
+  messageHash: string;
   destinationChainId: number;
   relayer: string;
   repaymentChainId: number;

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -5,7 +5,7 @@ import { CachingMechanismInterface, Deposit, DepositWithBlock, Fill, SlowFillReq
 import { getNetworkName } from "./NetworkUtils";
 import { getDepositInCache, getDepositKey, setDepositInCache } from "./CachingUtils";
 import { validateFillForDeposit } from "./FlowUtils";
-import { isUnsafeDepositId } from "./SpokeUtils";
+import { getMessageHash, isUnsafeDepositId } from "./SpokeUtils";
 import { getCurrentTime } from "./TimeUtils";
 import { isDefined } from "./TypeGuards";
 import { isDepositFormedCorrectly } from "./ValidatorUtils";
@@ -121,6 +121,8 @@ export async function queryHistoricalDepositForFill(
       await setDepositInCache(deposit, getCurrentTime(), cache, DEFAULT_CACHING_TTL);
     }
   }
+
+  deposit.messageHash ??= getMessageHash(deposit.message);
 
   const match = validateFillForDeposit(fill, deposit);
   if (match.valid) {

--- a/src/utils/FlowUtils.ts
+++ b/src/utils/FlowUtils.ts
@@ -14,13 +14,13 @@ export const RELAYDATA_KEYS = [
   "fillDeadline",
   "exclusivityDeadline",
   "exclusiveRelayer",
-  "message",
+  "messageHash",
 ] as const;
 
 // Ensure that each deposit element is included with the same value in the fill. This includes all elements defined
 // by the depositor as well as destinationToken, which are pulled from other clients.
 export function validateFillForDeposit(
-  relayData: RelayData & { destinationChainId: number },
+  relayData: Omit<RelayData, "message"> & { messageHash: string, destinationChainId: number },
   deposit?: Deposit
 ): { valid: true } | { valid: false; reason: string } {
   if (deposit === undefined) {

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -144,6 +144,7 @@ describe("SpokePoolClient: Fill Validation", function () {
       "relayer",
       "repaymentChainId",
       "relayExecutionInfo",
+      "message"
     ];
 
     // For each RelayData field, toggle the value to produce an invalid fill. Verify that it's rejected.
@@ -259,7 +260,7 @@ describe("SpokePoolClient: Fill Validation", function () {
 
     // Some fields are expected to be dynamically populated by the client, but aren't in this environment.
     // Fill them in manually from the fill struct to get a valid comparison.
-    expect(validateFillForDeposit(fill_1, { ...deposit_1 })).to.deep.equal({ valid: true });
+    expect(validateFillForDeposit(fill_1, deposit_1)).to.deep.equal({ valid: true });
   });
 
   it("Returns deposit matched with fill", async function () {

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -313,27 +313,28 @@ export async function depositV3(
   ]);
 
   const lastEvent = events.at(-1);
-  const args = lastEvent?.args;
+  let args = lastEvent?.args;
   assert.exists(args);
+  args = args!;
 
   const { blockNumber, transactionHash, transactionIndex, logIndex } = lastEvent!;
 
   return {
-    depositId: toBN(args!.depositId),
+    depositId: toBN(args.depositId),
     originChainId: Number(originChainId),
-    destinationChainId: Number(args!.destinationChainId),
-    depositor: args!.depositor,
-    recipient: args!.recipient,
-    inputToken: args!.inputToken,
-    inputAmount: args!.inputAmount,
-    outputToken: args!.outputToken,
-    outputAmount: args!.outputAmount,
-    quoteTimestamp: args!.quoteTimestamp,
-    message: args!.message,
-    messageHash: getMessageHash(args!.message),
-    fillDeadline: args!.fillDeadline,
-    exclusivityDeadline: args!.exclusivityDeadline,
-    exclusiveRelayer: args!.exclusiveRelayer,
+    destinationChainId: Number(args.destinationChainId),
+    depositor: args.depositor,
+    recipient: args.recipient,
+    inputToken: args.inputToken,
+    inputAmount: args.inputAmount,
+    outputToken: args.outputToken,
+    outputAmount: args.outputAmount,
+    quoteTimestamp: args.quoteTimestamp,
+    message: args.message,
+    messageHash: getMessageHash(args.message),
+    fillDeadline: args.fillDeadline,
+    exclusivityDeadline: args.exclusivityDeadline,
+    exclusiveRelayer: args.exclusiveRelayer,
     fromLiteChain: false,
     toLiteChain: false,
     quoteBlockNumber: 0, // @todo
@@ -373,6 +374,7 @@ export async function requestV3SlowFill(
     outputToken: args.outputToken,
     outputAmount: args.outputAmount,
     message: args.message,
+    messageHash: getMessageHash(args.message),
     fillDeadline: args.fillDeadline,
     exclusivityDeadline: args.exclusivityDeadline,
     exclusiveRelayer: args.exclusiveRelayer,
@@ -413,6 +415,7 @@ export async function fillV3Relay(
     outputToken: args.outputToken,
     outputAmount: args.outputAmount,
     message: args.message,
+    messageHash: getMessageHash(args.message),
     fillDeadline: args.fillDeadline,
     exclusivityDeadline: args.exclusivityDeadline,
     exclusiveRelayer: args.exclusiveRelayer,
@@ -498,6 +501,7 @@ export function buildDepositForRelayerFeeTest(
   }
 
   const currentTime = getCurrentTime();
+  const message = EMPTY_MESSAGE;
   return {
     depositId: bnUint32Max,
     originChainId: 1,
@@ -508,7 +512,8 @@ export function buildDepositForRelayerFeeTest(
     inputAmount: toBN(amount),
     outputToken,
     outputAmount: toBN(amount).sub(bnOne),
-    message: EMPTY_MESSAGE,
+    message,
+    messageHash: getMessageHash(message),
     quoteTimestamp: currentTime,
     fillDeadline: currentTime + 7200,
     exclusivityDeadline: 0,


### PR DESCRIPTION
This change also restores the ability to directly compare a deposit with a fill. Instead of comparing messages, their message hashes are compared.