### PR TITLE
feat: Forwards-compatible getRelayDataHash()

### DIFF
--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -226,11 +226,11 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
     ethersUtils.defaultAbiCoder.encode(
       [
         "tuple(" +
-          "address depositor," +
-          "address recipient," +
-          "address exclusiveRelayer," +
-          "address inputToken," +
-          "address outputToken," +
+          "bytes32 depositor," +
+          "bytes32 recipient," +
+          "bytes32 exclusiveRelayer," +
+          "bytes32 inputToken," +
+          "bytes32 outputToken," +
           "uint256 inputAmount," +
           "uint256 outputAmount," +
           "uint256 originChainId," +

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -234,7 +234,7 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
           "uint256 inputAmount," +
           "uint256 outputAmount," +
           "uint256 originChainId," +
-          "uint32 depositId," +
+          "uint256 depositId," +
           "uint32 fillDeadline," +
           "uint32 exclusivityDeadline," +
           "bytes message" +

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -222,6 +222,14 @@ export async function getDepositIdAtBlock(contract: Contract, blockTag: number):
  * @returns The corresponding RelayData hash.
  */
 export function getRelayDataHash(relayData: RelayData, destinationChainId: number): string {
+  const _relayData = {
+    ...relayData,
+    depositor: ethersUtils.hexZeroPad(relayData.depositor, 32),
+    recipient: ethersUtils.hexZeroPad(relayData.recipient, 32),
+    inputToken: ethersUtils.hexZeroPad(relayData.inputToken, 32),
+    outputToken: ethersUtils.hexZeroPad(relayData.outputToken, 32),
+    exclusiveRelayer: ethersUtils.hexZeroPad(relayData.exclusiveRelayer, 32),
+  };
   return ethersUtils.keccak256(
     ethersUtils.defaultAbiCoder.encode(
       [
@@ -241,7 +249,7 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
           ")",
         "uint256 destinationChainId",
       ],
-      [relayData, destinationChainId]
+      [_relayData, destinationChainId]
     )
   );
 }


### PR DESCRIPTION
Promoting address (bytes20) -> bytes32 and uint32 -> uint256 still produces the same RelayData hashes. This is verified by the existing tests passing (they are verified against the existing SpokePool deployments with address and uint32 in RelayData).