### PR TITLE
improve: do not force address coercion for spoke events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "3.4.19",
+  "version": "3.4.20",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -90,6 +90,7 @@ export function spreadEvent(args: Result | Record<string, unknown>): { [key: str
       try {
         address = toAddress(address);
       } catch (_e) {
+        // Lint appeasement
         _e;
       }
       returnedObject[field] = address;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -86,7 +86,13 @@ export function spreadEvent(args: Result | Record<string, unknown>): { [key: str
   // Truncate all fields which may be bytes32 into a bytes20 string.
   for (const field of knownExtendedAddressFields) {
     if (isDefined(returnedObject[field])) {
-      returnedObject[field] = toAddress(String(returnedObject[field]));
+      let address = String(returnedObject[field]);
+      try {
+        address = toAddress(address);
+      } catch (_e) {
+        _e;
+      }
+      returnedObject[field] = address;
     }
   }
 

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -89,10 +89,8 @@ export function spreadEvent(args: Result | Record<string, unknown>): { [key: str
       let address = String(returnedObject[field]);
       try {
         address = toAddress(address);
-      } catch (_e) {
-        // Lint appeasement
-        _e;
-      }
+        // eslint-disable-next-line no-empty
+      } catch (_) {}
       returnedObject[field] = address;
     }
   }


### PR DESCRIPTION
While right now, we know that spoke pool events will only emit bytes20 addresses, once the contracts are upgraded, anybody can supply bytes32 addresses to deposit/fill/speedups/etc. functions. This means we should not force these addresses to be bytes20. 