### PR TITLE
improve(BundleDataClient): Remove conditional canRefundPrefills

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -57,7 +57,6 @@ import {
   V3FillWithBlock,
   verifyFillRepayment,
 } from "./utils";
-import { PRE_FILL_MIN_CONFIG_STORE_VERSION } from "../../constants";
 
 // max(uint256) - 1
 export const INFINITE_FILL_DEADLINE = bnUint32Max;
@@ -799,22 +798,6 @@ export class BundleDataClient {
       return { relayDataHash, index: Number(i) };
     };
 
-    // We use the following toggle to aid with the migration to pre-fills. The first bundle proposed using this
-    // pre-fill logic can double refund pre-fills that have already been filled in the last bundle, because the
-    // last bundle did not recognize a fill as a pre-fill. Therefore the developer should ensure that the version
-    // is bumped to the PRE_FILL_MIN_CONFIG_STORE_VERSION version before the first pre-fill bundle is proposed.
-    // To test the following bundle after this, the developer can set the FORCE_REFUND_PREFILLS environment variable
-    // to "true" simulate the bundle with pre-fill refunds.
-    // @todo Remove this logic once we have advanced sufficiently past the pre-fill migration.
-    const startBlockForMainnet = getBlockRangeForChain(
-      blockRangesForChains,
-      this.clients.hubPoolClient.chainId,
-      this.chainIdListForBundleEvaluationBlockNumbers
-    )[0];
-    const versionAtProposalBlock = this.clients.configStoreClient.getConfigStoreVersionForBlock(startBlockForMainnet);
-    const canRefundPrefills =
-      versionAtProposalBlock >= PRE_FILL_MIN_CONFIG_STORE_VERSION || process.env.FORCE_REFUND_PREFILLS === "true";
-
     // Prerequisite step: Load all deposit events from the current or older bundles into the v3RelayHashes dictionary
     // for convenient matching with fills.
     for (const originChainId of allChainIds) {
@@ -1182,7 +1165,7 @@ export class BundleDataClient {
           // If fill is in the current bundle then we can assume there is already a refund for it, so only
           // include this pre fill if the fill is in an older bundle.
           if (fill) {
-            if (canRefundPrefills && fill.blockNumber < destinationChainBlockRange[0]) {
+            if (fill.blockNumber < destinationChainBlockRange[0]) {
               const fillToRefund = await verifyFillRepayment(
                 fill,
                 destinationClient.spokePool.provider,
@@ -1213,7 +1196,6 @@ export class BundleDataClient {
             if (_depositIsExpired(deposit)) {
               updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
             } else if (
-              canRefundPrefills &&
               slowFillRequest.blockNumber < destinationChainBlockRange[0] &&
               _canCreateSlowFillLeaf(deposit) &&
               validatedBundleSlowFills.every((d) => this.getRelayHashFromEvent(d) !== relayDataHash)
@@ -1236,23 +1218,21 @@ export class BundleDataClient {
             const prefill = await this.findMatchingFillEvent(deposit, destinationClient);
             assert(isDefined(prefill), `findFillEvent# Cannot find prefill: ${relayDataHash}`);
             assert(this.getRelayHashFromEvent(prefill!) === relayDataHash, "Relay hashes should match.");
-            if (canRefundPrefills) {
-              const verifiedFill = await verifyFillRepayment(
-                prefill!,
-                destinationClient.spokePool.provider,
-                deposit,
-                allChainIds
-              );
-              if (!isDefined(verifiedFill)) {
-                bundleUnrepayableFillsV3.push(prefill!);
-              } else if (!isSlowFill(verifiedFill)) {
-                validatedBundleV3Fills.push({
-                  ...verifiedFill!,
-                  quoteTimestamp: deposit.quoteTimestamp,
-                });
-              } else {
-                updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
-              }
+            const verifiedFill = await verifyFillRepayment(
+              prefill!,
+              destinationClient.spokePool.provider,
+              deposit,
+              allChainIds
+            );
+            if (!isDefined(verifiedFill)) {
+              bundleUnrepayableFillsV3.push(prefill!);
+            } else if (!isSlowFill(verifiedFill)) {
+              validatedBundleV3Fills.push({
+                ...verifiedFill!,
+                quoteTimestamp: deposit.quoteTimestamp,
+              });
+            } else {
+              updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
             }
           } else if (_depositIsExpired(deposit)) {
             updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
@@ -1261,7 +1241,7 @@ export class BundleDataClient {
             // Don't create duplicate slow fill requests for the same deposit.
             validatedBundleSlowFills.every((d) => this.getRelayHashFromEvent(d) !== relayDataHash)
           ) {
-            if (canRefundPrefills && _canCreateSlowFillLeaf(deposit)) {
+            if (_canCreateSlowFillLeaf(deposit)) {
               validatedBundleSlowFills.push(deposit);
             }
           }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1243,12 +1243,12 @@ export class BundleDataClient {
             // then we wouldn't be in this branch of the code.
             const prefill = await this.findMatchingFillEvent(deposit, destinationClient);
             assert(isDefined(prefill), `findFillEvent# Cannot find prefill: ${relayDataHash}`);
-            assert(this.getRelayHashFromEvent(prefill!) === relayDataHash, "Relay hashes should match.");
+            assert(getRelayEventKey(prefill!) === relayDataHash, "Relay hashes should match.");
             const verifiedFill = await verifyFillRepayment(
               prefill!,
               destinationClient.spokePool.provider,
               deposit,
-              allChainIds
+              this.clients.hubPoolClient
             );
             if (!isDefined(verifiedFill)) {
               bundleUnrepayableFillsV3.push(prefill!);

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1259,23 +1259,7 @@ export class BundleDataClient {
               });
             } else {
               updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
-            assert(getRelayEventKey(prefill!) === relayDataHash, "Relay hashes should match.");
-              const verifiedFill = await verifyFillRepayment(
-                prefill!,
-                destinationClient.spokePool.provider,
-                deposit,
-                this.clients.hubPoolClient
-              );
-              if (!isDefined(verifiedFill)) {
-                bundleUnrepayableFillsV3.push(prefill!);
-              } else if (!isSlowFill(verifiedFill)) {
-                validatedBundleV3Fills.push({
-                  ...verifiedFill!,
-                  quoteTimestamp: deposit.quoteTimestamp,
-                });
-              } else {
-                updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
-              }
+            }
           } else if (_depositIsExpired(deposit)) {
             updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
           } else if (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,8 +29,6 @@ export const HUBPOOL_CHAIN_ID = 1;
 // List of versions where certain UMIP features were deprecated or activated
 export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
 
-export const PRE_FILL_MIN_CONFIG_STORE_VERSION = 5;
-
 // A hardcoded identifier used, by default, to tag all Arweave records.
 export const ARWEAVE_TAG_APP_NAME = "across-protocol";
 


### PR DESCRIPTION
Can merge this in to reduce code once we have confidence that the version 5 bundle data client works well and we won't need to look up any version <= 4 bundles again. If we wanted to do the latter, we could just checkout old code
