### PR TITLE
fix: allow collisions for deposit to fill mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -364,7 +364,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns A valid fill for the deposit, or undefined.
    */
   public getFillForDeposit(deposit: Deposit): FillWithBlock | undefined {
-    const fills = this.depositHashesToFills[getRelayEventKey(deposit)];
+    const fills = this.depositHashesToFills[this.getDepositHash(deposit)];
     return fills?.find((fill) => validateFillForDeposit(fill, deposit));
   }
 
@@ -381,8 +381,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     invalidFills: Fill[];
   } {
     const { outputAmount } = deposit;
-    const fillsForDeposit = this.depositHashesToFills[getRelayEventKey(deposit)];
-
+    const fillsForDeposit = this.depositHashesToFills[this.getDepositHash(deposit)];
     // If no fills then the full amount is remaining.
     if (fillsForDeposit === undefined || fillsForDeposit.length === 0) {
       return { unfilledAmount: outputAmount, fillCount: 0, invalidFills: [] };
@@ -748,7 +747,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         }
 
         assign(this.fills, [fill.originChainId], [fill]);
-        assign(this.depositHashesToFills, [getRelayEventKey(fill)], [fill]);
+        assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);
       }
     };
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -358,14 +358,8 @@ export class SpokePoolClient extends BaseAbstractClient {
     return;
   }
 
-  /**
-   * Find a valid fill for a given deposit.
-   * @param deposit A deposit event.
-   * @returns A valid fill for the deposit, or undefined.
-   */
-  public getFillForDeposit(deposit: Deposit): FillWithBlock | undefined {
-    const fills = this.depositHashesToFills[this.getDepositHash(deposit)];
-    return fills?.find((fill) => validateFillForDeposit(fill, deposit));
+  public getFillsForDeposit(deposit: Deposit): FillWithBlock[] {
+    return this.depositHashesToFills[this.getDepositHash(deposit)];
   }
 
   /**


### PR DESCRIPTION
This is needed so that we can find duplicate fills (i.e. fills with different relay data but with the same deposit ID). E.g. we need to have collisions here so that we can determine invalid fills https://github.com/across-protocol/sdk/blob/2a10e145d028f9c3c6f47ed0c65fc16256c5aa42/src/clients/SpokePoolClient.ts#L384