### PR TITLE
fix(test): Correct testing of FilledRelay messageHash

### DIFF
--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -237,7 +237,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       relayer,
       depositor,
       recipient,
-      message,
       relayExecutionInfo: {
         updatedRecipient: fill.relayExecutionInfo?.updatedRecipient ?? recipient,
         updatedMessage,

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -239,8 +239,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       recipient,
       relayExecutionInfo: {
         updatedRecipient: fill.relayExecutionInfo?.updatedRecipient ?? recipient,
-        updatedMessage,
-        updatedMessageHash: getMessageHash(updatedMessage),
         updatedOutputAmount: fill.relayExecutionInfo?.updatedOutputAmount ?? outputAmount,
         fillType: fill.relayExecutionInfo?.fillType ?? FillType.FastFill,
       },

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Contract } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
-import { ZERO_ADDRESS } from "../../constants";
+import { EMPTY_MESSAGE, ZERO_ADDRESS } from "../../constants";
 import {
   Log,
   Deposit,
@@ -214,7 +214,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const relayer = addressModifier(fill.relayer ?? randomAddress());
 
     const topics = [originChainId, depositId, relayer]; // @todo verify
-    const message = fill["message"] ?? "0x";
+    const message = fill.message ?? EMPTY_MESSAGE;
     const updatedMessage = fill.relayExecutionInfo?.updatedMessage ?? message;
 
     const relayExecutionInfo = {
@@ -251,7 +251,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
             messageHash: getMessageHash(message),
             relayExecutionInfo: {
               ...relayExecutionInfo,
-              updatedMessageHash: fill.relayExecutionInfo.updatedMessageHash ?? getMessageHash(fill.message),
+              updatedMessageHash: getMessageHash(updatedMessage),
             },
           }
         : {
@@ -260,7 +260,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
             message,
             relayExecutionInfo: {
               ...relayExecutionInfo,
-              updatedMessage: fill.relayExecutionInfo?.updatedMessage ?? message,
+              updatedMessage,
             },
           };
 

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -52,14 +52,14 @@ describe("SpokePoolClient: Event Filtering", function () {
     inputToken?: string
   ): Log => {
     inputToken ??= randomAddress();
-    const message = EMPTY_MESSAGE;
+    const message = randomBytes(32);
     quoteTimestamp ??= getCurrentTime() - 10;
     return spokePoolClient.depositV3({ destinationChainId, inputToken, message, quoteTimestamp } as DepositWithBlock);
   };
 
   const generateDeposit = (spokePoolClient: MockSpokePoolClient, quoteTimestamp?: number, inputToken?: string): Log => {
     inputToken ??= randomAddress();
-    const message = EMPTY_MESSAGE;
+    const message = randomBytes(32);
     quoteTimestamp ??= getCurrentTime() - 10;
     return spokePoolClient.deposit({ destinationChainId, inputToken, message, quoteTimestamp } as DepositWithBlock);
   };

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { utils as sdkUtils } from "../src";
 import { DEFAULT_CONFIG_STORE_VERSION, GLOBAL_CONFIG_STORE_KEYS } from "../src/clients";
 import { MockConfigStoreClient, MockHubPoolClient, MockSpokePoolClient } from "../src/clients/mocks";
-import { EMPTY_MESSAGE, ZERO_ADDRESS } from "../src/constants";
+import { ZERO_ADDRESS } from "../src/constants";
 import {
   DepositWithBlock,
   FillWithBlock,


### PR DESCRIPTION
This change fixes an issue in the way the MockSpokePoolClient produces FilledRelay events. It incorrectly bundles the deposit message field into the fill. When combined with a separate (already fixed) issue in the SpokePoolClient that was unintentionally overwriting the FilledRelay messageHash field based on the message field, this meant that the messageHash was unintentionally _correctly_ recomputed in test, but not in production.