### PR TITLE
hotfix(SpokePoolClient): Temporarily query legacy TokensBridged event signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -598,6 +598,19 @@ export class SpokePoolClient extends BaseAbstractClient {
     const { events: queryResults, currentTime, oldestTime, searchEndBlock } = update;
 
     if (eventsToQuery.includes("TokensBridged")) {
+      // Temporarily query old spoke pool events as well to ease migration:
+      const legacySpokePoolAbi = [
+        "event TokensBridged(uint256 amountToReturn,uint256 indexed chainId,uint32 indexed leafId,address indexed l2TokenAddress,address caller)",
+      ];
+      const prevSpoke = new Contract(this.spokePool.address, legacySpokePoolAbi, this.spokePool.signer);
+      const legacyQueryResults = await paginatedEventQuery(
+        prevSpoke,
+        prevSpoke.filters.TokensBridged(),
+        (await this.updateSearchConfig(this.spokePool.provider)) as EventSearchConfig
+      );
+      for (const event of legacyQueryResults) {
+        this.tokensBridged.push(spreadEventWithBlockNumber(event) as TokensBridged);
+      }
       for (const event of queryResults[eventsToQuery.indexOf("TokensBridged")]) {
         this.tokensBridged.push(spreadEventWithBlockNumber(event) as TokensBridged);
       }


### PR DESCRIPTION
To clean up leftover finalizations from before the upgrade where this event signature changed
