### PR TITLE
fix(BundleDataClient): Do not create unexecutable slow fills for pre-slow-fill requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1311,11 +1311,20 @@ export class BundleDataClient {
             "fastFillsReplacingSlowFills should contain only deposits that can be slow filled"
           );
           const destinationBlockRange = getBlockRangeForChain(blockRangesForChains, destinationChainId, chainIds);
+          const originBlockRange = getBlockRangeForChain(blockRangesForChains, originChainId, chainIds);
+          const matchedDeposit = deposits[0];
+          // For a slow fill leaf to have been created (and subsequently create an excess), the deposit matching the
+          // slow fill request must have been included in a previous bundle AND the slow fill request should not
+          // be included in this bundle. This is because a slow fill request is only valid once its deposit
+          // has been mined, so if the deposit is not in a prior bundle to the fill, then no slow fill leaf could
+          // have been created. Secondly, the slow fill request itself must have occurred in an older bundle than the 
+          // fill otherwise the slow fill leaf be unexecutable for an already-filled deposit..
           if (
+            matchedDeposit.blockNumber < originBlockRange[0] &&
             // If there is a slow fill request in this bundle that matches the relay hash, then there was no slow fill
             // created that would be considered excess.
-            !slowFillRequest ||
-            slowFillRequest.blockNumber < destinationBlockRange[0]
+            (!slowFillRequest ||
+            slowFillRequest.blockNumber < destinationBlockRange[0])
           ) {
             validatedBundleUnexecutableSlowFills.push(deposits[0]);
           }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1317,14 +1317,13 @@ export class BundleDataClient {
           // slow fill request must have been included in a previous bundle AND the slow fill request should not
           // be included in this bundle. This is because a slow fill request is only valid once its deposit
           // has been mined, so if the deposit is not in a prior bundle to the fill, then no slow fill leaf could
-          // have been created. Secondly, the slow fill request itself must have occurred in an older bundle than the 
+          // have been created. Secondly, the slow fill request itself must have occurred in an older bundle than the
           // fill otherwise the slow fill leaf be unexecutable for an already-filled deposit..
           if (
             matchedDeposit.blockNumber < originBlockRange[0] &&
             // If there is a slow fill request in this bundle that matches the relay hash, then there was no slow fill
             // created that would be considered excess.
-            (!slowFillRequest ||
-            slowFillRequest.blockNumber < destinationBlockRange[0])
+            (!slowFillRequest || slowFillRequest.blockNumber < destinationBlockRange[0])
           ) {
             validatedBundleUnexecutableSlowFills.push(deposits[0]);
           }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1381,8 +1381,9 @@ export class BundleDataClient {
 
         // If there is a slow fill request in this bundle, then the expired deposit refund will supercede
         // the slow fill request. If there is no slow fill request seen or its older than this bundle, then we can
-        // assume a slow fill leaf was created for it because of the previous _canCreateSlowFillLeaf check.
-        // The slow fill request was also sent before the fill deadline expired since we checked that above.
+        // assume a slow fill leaf was created for it when the deposit was mined. Therefore, because the deposit
+        // was in an older bundle, we can assume that a slow fill leaf was created at that time and therefore
+        // is now unexecutable.
         if (!slowFillRequest || slowFillRequest.blockNumber < destinationBlockRange[0]) {
           validatedBundleUnexecutableSlowFills.push(deposit);
         }


### PR DESCRIPTION
If a slow fill request matched with a deposit in a future bundle, then no slow fill leaf is created in that bundle. Instead, the slow fill leaf is created when the deposit is included in the next bundle.

Therefore, if a fast-fill replaces that slow fill request in the same bundle as the deposit triggering the slow fill request, then there is no unexecutable slow fill to be created!

I found this bug while examining prior bundle data trying to figure out why Arbitrum has a persistent small deficit. I narrowed it down to this [slow fill request](https://arbiscan.io/tx/0xa87d13f5cf4aab3e69c35aa335781bf0980374eadf37e2d507b8116362a687e1) for [this deposit](https://explorer.zksync.io/tx/0x7ce35f8d82959a9469c058a1b4f7596d518547d9643fc8b6bac3aa844fa39a5f) that was replaced by this [fast fill](https://arbiscan.io/tx/0xfcd68880c58a64286a27918208c6c685dc49063d93bc96fabc6c954a90013973).

The bundle containing the fill and the deposit is [this one](https://etherscan.io/tx/0xe156543249ff9758be37ea2126b02a92493d94c6708fb188c5ec9b45f29b88be) while the [prior bundle](0x872940220d09ee7848149739a9fe81c8d2d41bb46b343723dee0c2d5e64daadc) contained the slow fill request.

Leaving this PR in draft mode as I sanity check a few more things but I feel pretty confident this is a bug.
