### PR TITLE
improve(BundleDataClient,SpokePoolClient): Log about duplicate events and delete `getLatestProposedBundleData`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.9",
+  "version": "4.1.10-beta.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.10-beta.0",
+  "version": "4.1.10",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -456,28 +456,21 @@ export class BundleDataClient {
     if (!isDefined(bundleDataOnArweave)) {
       return undefined;
     }
-    const pendingBundleData = await this.loadData(bundleBlockRanges, this.spokePoolClients, true);
-    // This should be defined since we've checked that the data exists on Arweave, but handle the unexpected
-    // case where its not.
-    if (!isDefined(pendingBundleData)) {
-      return undefined;
-    } else {
-      const hubPoolClient = this.clients.hubPoolClient;
-      const root = _buildPoolRebalanceRoot(
-        hubPoolClient.latestBlockSearched,
-        bundleBlockRanges[0][1],
-        pendingBundleData.bundleDepositsV3,
-        pendingBundleData.bundleFillsV3,
-        pendingBundleData.bundleSlowFillsV3,
-        pendingBundleData.unexecutableSlowFills,
-        pendingBundleData.expiredDepositsToRefundV3,
-        {
-          hubPoolClient,
-          configStoreClient: hubPoolClient.configStoreClient as AcrossConfigStoreClient,
-        }
-      );
-      return root;
-    }
+    const pendingBundleData = await this.loadArweaveData(bundleBlockRanges);
+    const root = _buildPoolRebalanceRoot(
+      hubPoolClient.latestBlockSearched,
+      bundleBlockRanges[0][1],
+      pendingBundleData.bundleDepositsV3,
+      pendingBundleData.bundleFillsV3,
+      pendingBundleData.bundleSlowFillsV3,
+      pendingBundleData.unexecutableSlowFills,
+      pendingBundleData.expiredDepositsToRefundV3,
+      {
+        hubPoolClient,
+        configStoreClient: hubPoolClient.configStoreClient as AcrossConfigStoreClient,
+      }
+    );
+    return root;
   }
 
   // @dev This function should probably be moved to the InventoryClient since it bypasses loadData completely now.

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -88,7 +88,7 @@ function updateBundleDepositsV3(dict: BundleDepositsV3, deposit: V3DepositWithBl
       (d) => d.transactionHash === deposit.transactionHash && d.logIndex === deposit.logIndex
     )
   ) {
-    throw new Error("Duplicate deposit in bundleDeposits");
+    throw new Error(`Duplicate deposit in bundleDeposits: ${JSON.stringify(deposit)}`);
   }
   dict[originChainId][inputToken].push(deposit);
 }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -937,71 +937,19 @@ export class BundleDataClient {
                   ) {
                     fastFillsReplacingSlowFills.push(relayDataHash);
                   }
-                } else {
-                  this.logger.debug({
-                    at: "BundleDataClient#loadData",
-                    message: "Duplicate fill detected",
-                    fill,
-                  });
-                  throw new Error("Duplicate fill detected");
                 }
-              }
-              assert(
-                isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                "Deposit should exist in relay hash dictionary."
-              );
-              v3RelayHashes[relayDataHash].fill = fill;
-              if (fill.blockNumber >= destinationChainBlockRange[0]) {
-                const fillToRefund = await verifyFillRepayment(
-                  fill,
-                  destinationClient.spokePool.provider,
-                  v3RelayHashes[relayDataHash].deposits![0],
-                  this.clients.hubPoolClient
+                assert(
+                  isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
+                  "Deposit should exist in relay hash dictionary."
                 );
-                if (!isDefined(fillToRefund)) {
-                  bundleUnrepayableFillsV3.push(fill);
-                  // We don't return here yet because we still need to mark unexecutable slow fill leaves
-                  // or duplicate deposits. However, we won't issue a fast fill refund.
-                } else {
-                  v3RelayHashes[relayDataHash].fill = fillToRefund;
-                  validatedBundleV3Fills.push({
-                    ...fillToRefund,
-                    quoteTimestamp: v3RelayHashes[relayDataHash].deposits![0].quoteTimestamp,
-                  });
-
-                  // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
-                  // sent for this fill and refund them to the filler, because this value would not be paid out
-                  // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
-                  // and they won't trigger a pre-fill refund because the fill is in this bundle.
-                  // Pre-fill refunds only happen when deposits are sent in this bundle and the
-                  // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
-                  // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
-                  // a current bundle fill.
-                  const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
-                  duplicateDeposits.forEach((duplicateDeposit) => {
-                    if (isSlowFill(fill)) {
-                      updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
-                    } else {
-                      validatedBundleV3Fills.push({
-                        ...fillToRefund,
-                        quoteTimestamp: duplicateDeposit.quoteTimestamp,
-                      });
-                    }
-                  });
-                }
-
-                // If fill replaced a slow fill request, then mark it as one that might have created an
-                // unexecutable slow fill. We can't know for sure until we check the slow fill request
-                // events.
-                if (
-                  fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
-                  _canCreateSlowFillLeaf(v3RelayHashes[relayDataHash].deposits![0])
-                ) {
-                  fastFillsReplacingSlowFills.push(relayDataHash);
-                }
+              } else {
+                this.logger.debug({
+                  at: "BundleDataClient#loadData",
+                  message: "Duplicate fill detected",
+                  fill,
+                });
+                throw new Error("Duplicate fill detected");
               }
-
-              return;
             }
 
             // At this point, there is no relay hash dictionary entry for this fill, so we need to

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -990,62 +990,7 @@ export class BundleDataClient {
             fillCounter++;
             const relayDataHash = getRelayEventKey(fill);
             if (v3RelayHashes[relayDataHash]) {
-              if (!v3RelayHashes[relayDataHash].fill) {
-                assert(
-                  isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                  "Deposit should exist in relay hash dictionary."
-                );
-                v3RelayHashes[relayDataHash].fill = fill;
-                if (fill.blockNumber >= destinationChainBlockRange[0]) {
-                  const fillToRefund = await verifyFillRepayment(
-                    fill,
-                    destinationClient.spokePool.provider,
-                    v3RelayHashes[relayDataHash].deposits![0],
-                    this.clients.hubPoolClient
-                  );
-                  if (!isDefined(fillToRefund)) {
-                    bundleUnrepayableFillsV3.push(fill);
-                    // We don't return here yet because we still need to mark unexecutable slow fill leaves
-                    // or duplicate deposits. However, we won't issue a fast fill refund.
-                  } else {
-                    v3RelayHashes[relayDataHash].fill = fillToRefund;
-                    validatedBundleV3Fills.push({
-                      ...fillToRefund,
-                      quoteTimestamp: v3RelayHashes[relayDataHash].deposits![0].quoteTimestamp,
-                    });
-
-                    // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
-                    // sent for this fill and refund them to the filler, because this value would not be paid out
-                    // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
-                    // and they won't trigger a pre-fill refund because the fill is in this bundle.
-                    // Pre-fill refunds only happen when deposits are sent in this bundle and the
-                    // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
-                    // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
-                    // a current bundle fill.
-                    const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
-                    duplicateDeposits.forEach((duplicateDeposit) => {
-                      if (isSlowFill(fill)) {
-                        updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
-                      } else {
-                        validatedBundleV3Fills.push({
-                          ...fillToRefund,
-                          quoteTimestamp: duplicateDeposit.quoteTimestamp,
-                        });
-                      }
-                    });
-                  }
-
-                  // If fill replaced a slow fill request, then mark it as one that might have created an
-                  // unexecutable slow fill. We can't know for sure until we check the slow fill request
-                  // events.
-                  if (
-                    fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
-                    _canCreateSlowFillLeaf(v3RelayHashes[relayDataHash].deposits![0])
-                  ) {
-                    fastFillsReplacingSlowFills.push(relayDataHash);
-                  }
-                }
-              } else {
+              if (v3RelayHashes[relayDataHash].fill) {
                 this.logger.debug({
                   at: "BundleDataClient#loadData",
                   message: "Duplicate fill detected",
@@ -1053,6 +998,61 @@ export class BundleDataClient {
                 });
                 throw new Error("Duplicate fill detected");
               }
+              assert(
+                isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
+                "Deposit should exist in relay hash dictionary."
+              );
+              v3RelayHashes[relayDataHash].fill = fill;
+              if (fill.blockNumber >= destinationChainBlockRange[0]) {
+                const fillToRefund = await verifyFillRepayment(
+                  fill,
+                  destinationClient.spokePool.provider,
+                  v3RelayHashes[relayDataHash].deposits![0],
+                  this.clients.hubPoolClient
+                );
+                if (!isDefined(fillToRefund)) {
+                  bundleUnrepayableFillsV3.push(fill);
+                  // We don't return here yet because we still need to mark unexecutable slow fill leaves
+                  // or duplicate deposits. However, we won't issue a fast fill refund.
+                } else {
+                  v3RelayHashes[relayDataHash].fill = fillToRefund;
+                  validatedBundleV3Fills.push({
+                    ...fillToRefund,
+                    quoteTimestamp: v3RelayHashes[relayDataHash].deposits![0].quoteTimestamp,
+                  });
+
+                  // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
+                  // sent for this fill and refund them to the filler, because this value would not be paid out
+                  // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
+                  // and they won't trigger a pre-fill refund because the fill is in this bundle.
+                  // Pre-fill refunds only happen when deposits are sent in this bundle and the
+                  // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
+                  // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
+                  // a current bundle fill.
+                  const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
+                  duplicateDeposits.forEach((duplicateDeposit) => {
+                    if (isSlowFill(fill)) {
+                      updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
+                    } else {
+                      validatedBundleV3Fills.push({
+                        ...fillToRefund,
+                        quoteTimestamp: duplicateDeposit.quoteTimestamp,
+                      });
+                    }
+                  });
+                }
+
+                // If fill replaced a slow fill request, then mark it as one that might have created an
+                // unexecutable slow fill. We can't know for sure until we check the slow fill request
+                // events.
+                if (
+                  fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
+                  _canCreateSlowFillLeaf(v3RelayHashes[relayDataHash].deposits![0])
+                ) {
+                  fastFillsReplacingSlowFills.push(relayDataHash);
+                }
+              }
+
               return;
             }
 
@@ -1152,34 +1152,33 @@ export class BundleDataClient {
             const relayDataHash = getRelayEventKey(slowFillRequest);
 
             if (v3RelayHashes[relayDataHash]) {
-              if (!v3RelayHashes[relayDataHash].slowFillRequest) {
-                v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
-                if (v3RelayHashes[relayDataHash].fill) {
-                  // Exiting here assumes that slow fill requests must precede fills, so if there was a fill
-                  // following this slow fill request, then we would have already seen it. We don't need to check
-                  // for a fill older than this slow fill request.
-                  return;
-                }
-                assert(
-                  isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                  "Deposit should exist in relay hash dictionary."
-                );
-                const matchedDeposit = v3RelayHashes[relayDataHash].deposits![0];
-
-                if (
-                  slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
-                  _canCreateSlowFillLeaf(matchedDeposit) &&
-                  !_depositIsExpired(matchedDeposit)
-                ) {
-                  validatedBundleSlowFills.push(matchedDeposit);
-                }
-              } else {
+              if (v3RelayHashes[relayDataHash].slowFillRequest) {
                 this.logger.debug({
                   at: "BundleDataClient#loadData",
                   message: "Duplicate slow fill request detected",
                   slowFillRequest,
                 });
                 throw new Error("Duplicate slow fill request detected.");
+              }
+              v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
+              if (v3RelayHashes[relayDataHash].fill) {
+                // Exiting here assumes that slow fill requests must precede fills, so if there was a fill
+                // following this slow fill request, then we would have already seen it. We don't need to check
+                // for a fill older than this slow fill request.
+                return;
+              }
+              assert(
+                isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
+                "Deposit should exist in relay hash dictionary."
+              );
+              const matchedDeposit = v3RelayHashes[relayDataHash].deposits![0];
+
+              if (
+                slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
+                _canCreateSlowFillLeaf(matchedDeposit) &&
+                !_depositIsExpired(matchedDeposit)
+              ) {
+                validatedBundleSlowFills.push(matchedDeposit);
               }
               return;
             }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -914,7 +914,7 @@ export class BundleDataClient {
           );
           if (deposit.blockNumber >= originChainBlockRange[0]) {
             if (
-              bundleDepositsV3?.[originChainId]?.[deposit.inputToken].find(
+              bundleDepositsV3?.[originChainId]?.[deposit.inputToken]?.find(
                 (d) => d.transactionHash === deposit.transactionHash && d.logIndex === deposit.logIndex
               )
             ) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -893,57 +893,57 @@ export class BundleDataClient {
                 });
                 throw new Error("Duplicate fill detected");
               }
-              const { deposits } = v3RelayHashes[relayDataHash];
-              assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
-              v3RelayHashes[relayDataHash].fill = fill;
-              if (fill.blockNumber >= destinationChainBlockRange[0]) {
-                const fillToRefund = await verifyFillRepayment(
-                  fill,
-                  destinationClient.spokePool.provider,
-                  deposits[0],
-                  this.clients.hubPoolClient
-                );
-                if (!isDefined(fillToRefund)) {
-                  bundleUnrepayableFillsV3.push(fill);
-                  // We don't return here yet because we still need to mark unexecutable slow fill leaves
-                  // or duplicate deposits. However, we won't issue a fast fill refund.
-                } else {
-                  v3RelayHashes[relayDataHash].fill = fillToRefund;
-                  validatedBundleV3Fills.push({
-                    ...fillToRefund,
-                    quoteTimestamp: deposits[0].quoteTimestamp,
-                  });
+                const { deposits } = v3RelayHashes[relayDataHash];
+                assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
+                v3RelayHashes[relayDataHash].fill = fill;
+                if (fill.blockNumber >= destinationChainBlockRange[0]) {
+                  const fillToRefund = await verifyFillRepayment(
+                    fill,
+                    destinationClient.spokePool.provider,
+                    deposits[0],
+                    this.clients.hubPoolClient
+                  );
+                  if (!isDefined(fillToRefund)) {
+                    bundleUnrepayableFillsV3.push(fill);
+                    // We don't return here yet because we still need to mark unexecutable slow fill leaves
+                    // or duplicate deposits. However, we won't issue a fast fill refund.
+                  } else {
+                    v3RelayHashes[relayDataHash].fill = fillToRefund;
+                    validatedBundleV3Fills.push({
+                      ...fillToRefund,
+                      quoteTimestamp: deposits[0].quoteTimestamp,
+                    });
 
-                  // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
-                  // sent for this fill and refund them to the filler, because this value would not be paid out
-                  // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
-                  // and they won't trigger a pre-fill refund because the fill is in this bundle.
-                  // Pre-fill refunds only happen when deposits are sent in this bundle and the
-                  // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
-                  // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
-                  // a current bundle fill.
-                  const duplicateDeposits = deposits.slice(1);
-                  duplicateDeposits.forEach((duplicateDeposit) => {
-                    if (isSlowFill(fill)) {
-                      updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
-                    } else {
-                      validatedBundleV3Fills.push({
-                        ...fillToRefund,
-                        quoteTimestamp: duplicateDeposit.quoteTimestamp,
-                      });
-                    }
-                  });
-                }
+                    // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
+                    // sent for this fill and refund them to the filler, because this value would not be paid out
+                    // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
+                    // and they won't trigger a pre-fill refund because the fill is in this bundle.
+                    // Pre-fill refunds only happen when deposits are sent in this bundle and the
+                    // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
+                    // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
+                    // a current bundle fill.
+                    const duplicateDeposits = deposits.slice(1);
+                    duplicateDeposits.forEach((duplicateDeposit) => {
+                      if (isSlowFill(fill)) {
+                        updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
+                      } else {
+                        validatedBundleV3Fills.push({
+                          ...fillToRefund,
+                          quoteTimestamp: duplicateDeposit.quoteTimestamp,
+                        });
+                      }
+                    });
+                  }
 
-                // If fill replaced a slow fill request, then mark it as one that might have created an
-                // unexecutable slow fill. We can't know for sure until we check the slow fill request
-                // events.
-                if (
-                  fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
-                  _canCreateSlowFillLeaf(deposits[0])
-                ) {
-                  fastFillsReplacingSlowFills.push(relayDataHash);
-                }
+                  // If fill replaced a slow fill request, then mark it as one that might have created an
+                  // unexecutable slow fill. We can't know for sure until we check the slow fill request
+                  // events.
+                  if (
+                    fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
+                    _canCreateSlowFillLeaf(deposits[0])
+                  ) {
+                    fastFillsReplacingSlowFills.push(relayDataHash);
+                  }
               }
               assert(
                 isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
@@ -1099,31 +1099,32 @@ export class BundleDataClient {
             const relayDataHash = getRelayEventKey(slowFillRequest);
 
             if (v3RelayHashes[relayDataHash]) {
-              if (v3RelayHashes[relayDataHash].slowFillRequest) {
+              if (!v3RelayHashes[relayDataHash].slowFillRequest) {
+                v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
+                const { deposits, fill } = v3RelayHashes[relayDataHash];
+                if (fill) {
+                  // Exiting here assumes that slow fill requests must precede fills, so if there was a fill
+                  // following this slow fill request, then we would have already seen it. We don't need to check
+                  // for a fill older than this slow fill request.
+                  return;
+                }
+                assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
+                const matchedDeposit = deposits[0];
+
+                if (
+                  slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
+                  _canCreateSlowFillLeaf(matchedDeposit) &&
+                  !_depositIsExpired(matchedDeposit)
+                ) {
+                  validatedBundleSlowFills.push(matchedDeposit);
+                }
+              } else {
                 this.logger.debug({
                   at: "BundleDataClient#loadData",
                   message: "Duplicate slow fill request detected",
                   slowFillRequest,
                 });
-                throw new Error("Duplicate slow fill request detected");
-              }
-              v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
-              const { deposits, fill } = v3RelayHashes[relayDataHash];
-              if (fill) {
-                // Exiting here assumes that slow fill requests must precede fills, so if there was a fill
-                // following this slow fill request, then we would have already seen it. We don't need to check
-                // for a fill older than this slow fill request.
-                return;
-              }
-              assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
-              const matchedDeposit = deposits[0];
-
-              if (
-                slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
-                _canCreateSlowFillLeaf(matchedDeposit) &&
-                !_depositIsExpired(matchedDeposit)
-              ) {
-                validatedBundleSlowFills.push(matchedDeposit);
+                throw new Error("Duplicate slow fill request detected.");
               }
               v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
               if (v3RelayHashes[relayDataHash].fill) {
@@ -1136,6 +1137,7 @@ export class BundleDataClient {
                 isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
                 "Deposit should exist in relay hash dictionary."
               );
+              const matchedDeposit = v3RelayHashes[relayDataHash].deposits![0];
 
               if (
                 slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -239,19 +239,6 @@ export class BundleDataClient {
     );
   }
 
-  private async getBundleDataFromArweave(blockRangesForChains: number[][]) {
-    const persistedData = await this.clients.arweaveClient.getByTopic(
-      this.getArweaveBundleDataClientKey(blockRangesForChains),
-      BundleDataSS
-    );
-    // If there is no data or the data is empty, return undefined because we couldn't
-    // pull info from the Arweave persistence layer.
-    if (!isDefined(persistedData) || persistedData.length < 1) {
-      return undefined;
-    }
-    return persistedData;
-  }
-
   private async loadPersistedDataFromArweave(
     blockRangesForChains: number[][]
   ): Promise<LoadDataReturnValue | undefined> {
@@ -259,8 +246,13 @@ export class BundleDataClient {
       return undefined;
     }
     const start = performance.now();
-    const persistedData = await this.getBundleDataFromArweave(blockRangesForChains);
-    if (!isDefined(persistedData)) {
+    const persistedData = await this.clients.arweaveClient.getByTopic(
+      this.getArweaveBundleDataClientKey(blockRangesForChains),
+      BundleDataSS
+    );
+    // If there is no data or the data is empty, return undefined because we couldn't
+    // pull info from the Arweave persistence layer.
+    if (!isDefined(persistedData) || persistedData.length < 1) {
       return undefined;
     }
 

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1022,6 +1022,11 @@ export class BundleDataClient {
                   }
                 }
               } else {
+                this.logger.debug({
+                  at: "BundleDataClient#loadData",
+                  message: "Duplicate fill detected",
+                  fill,
+                });
                 throw new Error("Duplicate fill detected");
               }
               return;
@@ -1145,6 +1150,11 @@ export class BundleDataClient {
                   validatedBundleSlowFills.push(matchedDeposit);
                 }
               } else {
+                this.logger.debug({
+                  at: "BundleDataClient#loadData",
+                  message: "Duplicate slow fill request detected",
+                  slowFillRequest,
+                });
                 throw new Error("Duplicate slow fill request detected.");
               }
               return;

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -468,6 +468,12 @@ export class BundleDataClient {
     while (n < 4) {
       const bundleDataOnArweave = await this.getBundleDataFromArweave(bundleBlockRanges);
       if (!isDefined(bundleDataOnArweave)) {
+        this.logger.debug({
+          at: "BundleDataClient#getLatestProposedBundleData",
+          message: `No bundle data found on arweave for ${this.getArweaveBundleDataClientKey(
+            bundleBlockRanges
+          )}, trying previous bundle block range`,
+        });
         // Bundle data is not arweave, try the next most recently validated bundle.
         bundleBlockRanges = getImpliedBundleBlockRanges(
           hubPoolClient,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -486,7 +486,7 @@ export class BundleDataClient {
     };
   }
 
-  async getLatestPoolRebalanceRoot(): Promise<{ root: PoolRebalanceRoot; blockRanges: number[][] }> {
+  async getLatestPoolRebalanceRootFromArweave(): Promise<{ root: PoolRebalanceRoot; blockRanges: number[][] }> {
     const { bundleData, blockRanges } = await this.getLatestProposedBundleData();
     const hubPoolClient = this.clients.hubPoolClient;
     const root = _buildPoolRebalanceRoot(

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -911,7 +911,7 @@ export class BundleDataClient {
           );
           if (deposit.blockNumber >= originChainBlockRange[0]) {
             if (
-              bundleDepositsV3[originChainId][deposit.inputToken].find(
+              bundleDepositsV3?.[originChainId]?.[deposit.inputToken].find(
                 (d) => d.transactionHash === deposit.transactionHash && d.logIndex === deposit.logIndex
               )
             ) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -992,7 +992,11 @@ export class BundleDataClient {
                   }
                 }
               } else {
-                throw new Error("Duplicate fill detected");
+                this.logger.warn({
+                  at: "BundleDataClient#loadDataFromScratch",
+                  message: "Detected duplicate fill",
+                  fill,
+                });
               }
               return;
             }
@@ -1115,7 +1119,11 @@ export class BundleDataClient {
                   validatedBundleSlowFills.push(matchedDeposit);
                 }
               } else {
-                throw new Error("Duplicate slow fill request detected.");
+                this.logger.warn({
+                  at: "BundleDataClient#loadDataFromScratch",
+                  message: "Detected duplicate slow fill request",
+                  slowFillRequest,
+                });
               }
               return;
             }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -444,7 +444,7 @@ export class BundleDataClient {
     // Determine which bundle we should fetch from arweave, either the pending bundle or the latest
     // executed one. Both should have arweave data but if for some reason the arweave data is missing,
     // this function will load the bundle data from the most recent bundle data published to Arweave.
-    
+
     let bundleBlockRanges = getImpliedBundleBlockRanges(
       hubPoolClient,
       this.clients.configStoreClient,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -885,7 +885,14 @@ export class BundleDataClient {
             fillCounter++;
             const relayDataHash = getRelayEventKey(fill);
             if (v3RelayHashes[relayDataHash]) {
-              if (!v3RelayHashes[relayDataHash].fill) {
+              if (v3RelayHashes[relayDataHash].fill) {
+                this.logger.debug({
+                  at: "BundleDataClient#loadData",
+                  message: "Duplicate fill detected",
+                  fill,
+                });
+                throw new Error("Duplicate fill detected");
+              }
                 const { deposits } = v3RelayHashes[relayDataHash];
                 assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
                 v3RelayHashes[relayDataHash].fill = fill;
@@ -937,71 +944,63 @@ export class BundleDataClient {
                   ) {
                     fastFillsReplacingSlowFills.push(relayDataHash);
                   }
-                }
-                assert(
-                  isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                  "Deposit should exist in relay hash dictionary."
-                );
-                v3RelayHashes[relayDataHash].fill = fill;
-                if (fill.blockNumber >= destinationChainBlockRange[0]) {
-                  const fillToRefund = await verifyFillRepayment(
-                    fill,
-                    destinationClient.spokePool.provider,
-                    v3RelayHashes[relayDataHash].deposits![0],
-                    this.clients.hubPoolClient
-                  );
-                  if (!isDefined(fillToRefund)) {
-                    bundleUnrepayableFillsV3.push(fill);
-                    // We don't return here yet because we still need to mark unexecutable slow fill leaves
-                    // or duplicate deposits. However, we won't issue a fast fill refund.
-                  } else {
-                    v3RelayHashes[relayDataHash].fill = fillToRefund;
-                    validatedBundleV3Fills.push({
-                      ...fillToRefund,
-                      quoteTimestamp: v3RelayHashes[relayDataHash].deposits![0].quoteTimestamp,
-                    });
-
-                    // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
-                    // sent for this fill and refund them to the filler, because this value would not be paid out
-                    // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
-                    // and they won't trigger a pre-fill refund because the fill is in this bundle.
-                    // Pre-fill refunds only happen when deposits are sent in this bundle and the
-                    // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
-                    // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
-                    // a current bundle fill.
-                    const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
-                    duplicateDeposits.forEach((duplicateDeposit) => {
-                      if (isSlowFill(fill)) {
-                        updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
-                      } else {
-                        validatedBundleV3Fills.push({
-                          ...fillToRefund,
-                          quoteTimestamp: duplicateDeposit.quoteTimestamp,
-                        });
-                      }
-                    });
-                  }
-
-                  // If fill replaced a slow fill request, then mark it as one that might have created an
-                  // unexecutable slow fill. We can't know for sure until we check the slow fill request
-                  // events.
-                  if (
-                    fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
-                    _canCreateSlowFillLeaf(v3RelayHashes[relayDataHash].deposits![0])
-                  ) {
-                    fastFillsReplacingSlowFills.push(relayDataHash);
-                  }
-                }
-
-                return;
               }
-            } else {
-              this.logger.debug({
-                at: "BundleDataClient#loadData",
-                message: "Duplicate fill detected",
-                fill,
-              });
-              throw new Error("Duplicate fill detected");
+              assert(
+                isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
+                "Deposit should exist in relay hash dictionary."
+              );
+              v3RelayHashes[relayDataHash].fill = fill;
+              if (fill.blockNumber >= destinationChainBlockRange[0]) {
+                const fillToRefund = await verifyFillRepayment(
+                  fill,
+                  destinationClient.spokePool.provider,
+                  v3RelayHashes[relayDataHash].deposits![0],
+                  this.clients.hubPoolClient
+                );
+                if (!isDefined(fillToRefund)) {
+                  bundleUnrepayableFillsV3.push(fill);
+                  // We don't return here yet because we still need to mark unexecutable slow fill leaves
+                  // or duplicate deposits. However, we won't issue a fast fill refund.
+                } else {
+                  v3RelayHashes[relayDataHash].fill = fillToRefund;
+                  validatedBundleV3Fills.push({
+                    ...fillToRefund,
+                    quoteTimestamp: v3RelayHashes[relayDataHash].deposits![0].quoteTimestamp,
+                  });
+
+                  // Now that we know this deposit has been filled on-chain, identify any duplicate deposits
+                  // sent for this fill and refund them to the filler, because this value would not be paid out
+                  // otherwise. These deposits can no longer expire and get refunded as an expired deposit,
+                  // and they won't trigger a pre-fill refund because the fill is in this bundle.
+                  // Pre-fill refunds only happen when deposits are sent in this bundle and the
+                  // fill is from a prior bundle. Paying out the filler keeps the behavior consistent for how
+                  // we deal with duplicate deposits regardless if the deposit is matched with a pre-fill or
+                  // a current bundle fill.
+                  const duplicateDeposits = v3RelayHashes[relayDataHash].deposits!.slice(1);
+                  duplicateDeposits.forEach((duplicateDeposit) => {
+                    if (isSlowFill(fill)) {
+                      updateExpiredDepositsV3(expiredDepositsToRefundV3, duplicateDeposit);
+                    } else {
+                      validatedBundleV3Fills.push({
+                        ...fillToRefund,
+                        quoteTimestamp: duplicateDeposit.quoteTimestamp,
+                      });
+                    }
+                  });
+                }
+
+                // If fill replaced a slow fill request, then mark it as one that might have created an
+                // unexecutable slow fill. We can't know for sure until we check the slow fill request
+                // events.
+                if (
+                  fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill &&
+                  _canCreateSlowFillLeaf(v3RelayHashes[relayDataHash].deposits![0])
+                ) {
+                  fastFillsReplacingSlowFills.push(relayDataHash);
+                }
+              }
+
+              return;
             }
 
             // At this point, there is no relay hash dictionary entry for this fill, so we need to

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -885,14 +885,7 @@ export class BundleDataClient {
             fillCounter++;
             const relayDataHash = getRelayEventKey(fill);
             if (v3RelayHashes[relayDataHash]) {
-              if (v3RelayHashes[relayDataHash].fill) {
-                this.logger.debug({
-                  at: "BundleDataClient#loadData",
-                  message: "Duplicate fill detected",
-                  fill,
-                });
-                throw new Error("Duplicate fill detected");
-              }
+              if (!v3RelayHashes[relayDataHash].fill) {
                 const { deposits } = v3RelayHashes[relayDataHash];
                 assert(isDefined(deposits) && deposits.length > 0, "Deposit should exist in relay hash dictionary.");
                 v3RelayHashes[relayDataHash].fill = fill;
@@ -944,6 +937,14 @@ export class BundleDataClient {
                   ) {
                     fastFillsReplacingSlowFills.push(relayDataHash);
                   }
+                } else {
+                  this.logger.debug({
+                    at: "BundleDataClient#loadData",
+                    message: "Duplicate fill detected",
+                    fill,
+                  });
+                  throw new Error("Duplicate fill detected");
+                }
               }
               assert(
                 isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -439,7 +439,10 @@ export class BundleDataClient {
       }, toBN(0));
   }
 
-  private async getLatestProposedBundleData(): Promise<{ bundleData: LoadDataReturnValue; blockRanges: number[][] }> {
+  private async getLatestProposedBundleDataFromArweave(): Promise<{
+    bundleData: LoadDataReturnValue;
+    blockRanges: number[][];
+  }> {
     const hubPoolClient = this.clients.hubPoolClient;
     // Determine which bundle we should fetch from arweave, either the pending bundle or the latest
     // executed one. Both should have arweave data but if for some reason the arweave data is missing,
@@ -462,7 +465,7 @@ export class BundleDataClient {
       const bundleDataOnArweave = await this.getBundleDataFromArweave(bundleBlockRanges);
       if (!isDefined(bundleDataOnArweave)) {
         this.logger.debug({
-          at: "BundleDataClient#getLatestProposedBundleData",
+          at: "BundleDataClient#getLatestProposedBundleDataFromArweave",
           message: `No bundle data found on arweave for ${this.getArweaveBundleDataClientKey(
             bundleBlockRanges
           )}, trying previous bundle block range`,
@@ -487,7 +490,7 @@ export class BundleDataClient {
   }
 
   async getLatestPoolRebalanceRootFromArweave(): Promise<{ root: PoolRebalanceRoot; blockRanges: number[][] }> {
-    const { bundleData, blockRanges } = await this.getLatestProposedBundleData();
+    const { bundleData, blockRanges } = await this.getLatestProposedBundleDataFromArweave();
     const hubPoolClient = this.clients.hubPoolClient;
     const root = _buildPoolRebalanceRoot(
       hubPoolClient.latestBlockSearched,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -89,7 +89,7 @@ function updateBundleDepositsV3(dict: BundleDepositsV3, deposit: V3DepositWithBl
     )
   ) {
     throw new Error("Duplicate deposit in bundleDeposits");
-  };
+  }
   dict[originChainId][inputToken].push(deposit);
 }
 

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -938,10 +938,6 @@ export class BundleDataClient {
                     fastFillsReplacingSlowFills.push(relayDataHash);
                   }
                 }
-                assert(
-                  isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                  "Deposit should exist in relay hash dictionary."
-                );
               } else {
                 this.logger.debug({
                   at: "BundleDataClient#loadData",
@@ -950,6 +946,7 @@ export class BundleDataClient {
                 });
                 throw new Error("Duplicate fill detected");
               }
+              return;
             }
 
             // At this point, there is no relay hash dictionary entry for this fill, so we need to
@@ -1074,26 +1071,6 @@ export class BundleDataClient {
                   slowFillRequest,
                 });
                 throw new Error("Duplicate slow fill request detected.");
-              }
-              v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
-              if (v3RelayHashes[relayDataHash].fill) {
-                // Exiting here assumes that slow fill requests must precede fills, so if there was a fill
-                // following this slow fill request, then we would have already seen it. We don't need to check
-                // for a fill older than this slow fill request.
-                return;
-              }
-              assert(
-                isDefined(v3RelayHashes[relayDataHash].deposits) && v3RelayHashes[relayDataHash].deposits!.length > 0,
-                "Deposit should exist in relay hash dictionary."
-              );
-              const matchedDeposit = v3RelayHashes[relayDataHash].deposits![0];
-
-              if (
-                slowFillRequest.blockNumber >= destinationChainBlockRange[0] &&
-                _canCreateSlowFillLeaf(matchedDeposit) &&
-                !_depositIsExpired(matchedDeposit)
-              ) {
-                validatedBundleSlowFills.push(matchedDeposit);
               }
               return;
             }

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -83,6 +83,13 @@ function updateBundleDepositsV3(dict: BundleDepositsV3, deposit: V3DepositWithBl
   if (!dict?.[originChainId]?.[inputToken]) {
     assign(dict, [originChainId, inputToken], []);
   }
+  if (
+    dict[originChainId][inputToken].some(
+      (d) => d.transactionHash === deposit.transactionHash && d.logIndex === deposit.logIndex
+    )
+  ) {
+    throw new Error("Duplicate deposit in bundleDeposits");
+  };
   dict[originChainId][inputToken].push(deposit);
 }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -786,7 +786,7 @@ export class HubPoolClient extends BaseAbstractClient {
       return (
         executedLeaf.blockNumber <= block &&
         executedLeaf.chainId === chain &&
-        executedLeaf.l1Tokens.some((token) => token.toLowerCase() === l1Token.toLowerCase()
+        executedLeaf.l1Tokens.some((token) => token.toLowerCase() === l1Token.toLowerCase())
       );
     });
   }

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -782,7 +782,7 @@ export class HubPoolClient extends BaseAbstractClient {
       return (
         executedLeaf.blockNumber <= block &&
         executedLeaf.chainId === chain &&
-        executedLeaf.l1Tokens.map((l1Token) => l1Token.toLowerCase()).includes(l1Token.toLowerCase())
+        executedLeaf.l1Tokens.some((token) => token.toLowerCase() === l1Token.toLowerCase()
       );
     }) as ExecutedRootBundle;
   }

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -776,7 +776,11 @@ export class HubPoolClient extends BaseAbstractClient {
     return endBlock > 0 ? endBlock + 1 : 0;
   }
 
-  getLatestExecutedRootBundleContainingL1Token(block: number, chain: number, l1Token: string): ExecutedRootBundle {
+  getLatestExecutedRootBundleContainingL1Token(
+    block: number,
+    chain: number,
+    l1Token: string
+  ): ExecutedRootBundle | undefined {
     // Search ExecutedRootBundles in descending block order to find the most recent event before the target block.
     return sortEventsDescending(this.executedRootBundles).find((executedLeaf: ExecutedRootBundle) => {
       return (
@@ -784,7 +788,7 @@ export class HubPoolClient extends BaseAbstractClient {
         executedLeaf.chainId === chain &&
         executedLeaf.l1Tokens.some((token) => token.toLowerCase() === l1Token.toLowerCase()
       );
-    }) as ExecutedRootBundle;
+    });
   }
 
   getRunningBalanceBeforeBlockForChain(block: number, chain: number, l1Token: string): TokenRunningBalance {
@@ -793,7 +797,10 @@ export class HubPoolClient extends BaseAbstractClient {
     return this.getRunningBalanceForToken(l1Token, executedRootBundle);
   }
 
-  public getRunningBalanceForToken(l1Token: string, executedRootBundle: ExecutedRootBundle): TokenRunningBalance {
+  public getRunningBalanceForToken(
+    l1Token: string,
+    executedRootBundle: ExecutedRootBundle | undefined
+  ): TokenRunningBalance {
     let runningBalance = toBN(0);
     if (executedRootBundle) {
       const indexOfL1Token = executedRootBundle.l1Tokens

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -776,17 +776,19 @@ export class HubPoolClient extends BaseAbstractClient {
     return endBlock > 0 ? endBlock + 1 : 0;
   }
 
-  getRunningBalanceBeforeBlockForChain(block: number, chain: number, l1Token: string): TokenRunningBalance {
+  getLatestExecutedRootBundleContainingL1Token(block: number, chain: number, l1Token: string): ExecutedRootBundle {
     // Search ExecutedRootBundles in descending block order to find the most recent event before the target block.
-    const executedRootBundle = sortEventsDescending(this.executedRootBundles).find(
-      (executedLeaf: ExecutedRootBundle) => {
-        return (
-          executedLeaf.blockNumber <= block &&
-          executedLeaf.chainId === chain &&
-          executedLeaf.l1Tokens.map((l1Token) => l1Token.toLowerCase()).includes(l1Token.toLowerCase())
-        );
-      }
-    ) as ExecutedRootBundle;
+    return sortEventsDescending(this.executedRootBundles).find((executedLeaf: ExecutedRootBundle) => {
+      return (
+        executedLeaf.blockNumber <= block &&
+        executedLeaf.chainId === chain &&
+        executedLeaf.l1Tokens.map((l1Token) => l1Token.toLowerCase()).includes(l1Token.toLowerCase())
+      );
+    }) as ExecutedRootBundle;
+  }
+
+  getRunningBalanceBeforeBlockForChain(block: number, chain: number, l1Token: string): TokenRunningBalance {
+    const executedRootBundle = this.getLatestExecutedRootBundleContainingL1Token(block, chain, l1Token);
 
     return this.getRunningBalanceForToken(l1Token, executedRootBundle);
   }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -21,6 +21,7 @@ import {
   toAddress,
 } from "../utils";
 import {
+  duplicateEvent,
   paginatedEventQuery,
   sortEventsAscendingInPlace,
   spreadEvent,
@@ -661,7 +662,7 @@ export class SpokePoolClient extends BaseAbstractClient {
           const allDeposits = this._getDuplicateDeposits(deposit).concat(this.depositHashes[getRelayEventKey(deposit)]);
           if (
             allDeposits.some((e) => {
-              return e.transactionHash === deposit.transactionHash && e.logIndex === deposit.logIndex;
+              return duplicateEvent(deposit, e);
             })
           ) {
             duplicateEvents.push(event);
@@ -770,9 +771,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         }
 
         // Sanity check that this event is not a duplicate.
-        const duplicateFill = this.fills[fill.originChainId]?.find(
-          (f) => f.transactionHash === fill.transactionHash && f.logIndex === fill.logIndex
-        );
+        const duplicateFill = this.fills[fill.originChainId]?.find((f) => duplicateEvent(fill, f));
         if (duplicateFill) {
           duplicateEvents.push(event);
           continue;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -663,7 +663,7 @@ export class SpokePoolClient extends BaseAbstractClient {
               return e.transactionHash === deposit.transactionHash && e.logIndex === deposit.logIndex;
             })
           ) {
-            this.logger.warn({
+            this.logger.error({
               at: "SpokePoolClient#update",
               chainId: this.chainId,
               message: "Duplicate deposit found with same transaction hash and log index",
@@ -736,7 +736,7 @@ export class SpokePoolClient extends BaseAbstractClient {
 
         // Sanity check that this event is not a duplicate.
         if (this.slowFillRequests[depositHash] !== undefined) {
-          this.logger.warn({
+          this.logger.error({
             at: "SpokePoolClient#update",
             chainId: this.chainId,
             message: "Duplicate slow fill request found",
@@ -785,7 +785,7 @@ export class SpokePoolClient extends BaseAbstractClient {
             (f) => f.transactionHash === fill.transactionHash && f.logIndex === fill.logIndex
           )
         ) {
-          this.logger.warn({
+          this.logger.error({
             at: "SpokePoolClient#update",
             chainId: this.chainId,
             message: "Duplicate fill found",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -39,6 +39,7 @@ import {
   RelayerRefundExecutionWithBlock,
   RootBundleRelayWithBlock,
   SlowFillRequestWithBlock,
+  SortableEvent,
   SpeedUpWithBlock,
   TokensBridged,
 } from "../interfaces";
@@ -587,7 +588,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @see _update
    */
   public async update(eventsToQuery = this.queryableEventNames): Promise<void> {
-    const duplicateEvents: any[] = [];
+    const duplicateEvents: SortableEvent[] = [];
     if (this.hubPoolClient !== null && !this.hubPoolClient.isUpdated) {
       throw new Error("HubPoolClient not updated");
     }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -779,12 +779,10 @@ export class SpokePoolClient extends BaseAbstractClient {
         }
 
         // Sanity check that this event is not a duplicate.
-        if (
-          this.fills[fill.originChainId] !== undefined &&
-          this.fills[fill.originChainId].some(
-            (f) => f.transactionHash === fill.transactionHash && f.logIndex === fill.logIndex
-          )
-        ) {
+        const duplicateFill = this.fills[fill.originChainId]?.find(
+          (f) => f.transactionHash === fill.transactionHash && f.logIndex === fill.logIndex
+        );
+        if (duplicateFill) {
           this.logger.error({
             at: "SpokePoolClient#update",
             chainId: this.chainId,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -660,11 +660,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         if (this.depositHashes[getRelayEventKey(deposit)] !== undefined) {
           // Sanity check that this event is not a duplicate, even though the relay data hash is a duplicate.
           const allDeposits = this._getDuplicateDeposits(deposit).concat(this.depositHashes[getRelayEventKey(deposit)]);
-          if (
-            allDeposits.some((e) => {
-              return duplicateEvent(deposit, e);
-            })
-          ) {
+          if (allDeposits.some((e) => duplicateEvent(deposit, e))) {
             duplicateEvents.push(event);
             continue;
           }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -726,18 +726,16 @@ export class SpokePoolClient extends BaseAbstractClient {
         const slowFillRequest = {
           ...spreadEventWithBlockNumber(event),
           destinationChainId: this.chainId,
-        } as SlowFillRequestWithBlock;        
+        } as SlowFillRequestWithBlock;
 
         if (eventName === "RequestedV3SlowFill") {
           slowFillRequest.messageHash = getMessageHash(slowFillRequest.message);
         }
 
         const depositHash = getRelayEventKey({ ...slowFillRequest, destinationChainId: this.chainId });
-        
+
         // Sanity check that this event is not a duplicate.
-        if (
-          this.slowFillRequests[depositHash] !== undefined
-        ) {
+        if (this.slowFillRequests[depositHash] !== undefined) {
           this.logger.warn({
             at: "SpokePoolClient#update",
             chainId: this.chainId,
@@ -746,7 +744,7 @@ export class SpokePoolClient extends BaseAbstractClient {
           });
           continue;
         }
-        
+
         this.slowFillRequests[depositHash] ??= slowFillRequest;
       }
     };

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -266,3 +266,7 @@ export function isEventOlder<T extends SortableEvent>(ex: T, ey: T): boolean {
 export function getTransactionHashes(events: SortableEvent[]): string[] {
   return [...Array.from(new Set(events.map((e) => e.transactionHash)))];
 }
+
+export function duplicateEvent(a: SortableEvent, b: SortableEvent): boolean {
+  return a.transactionHash === b.transactionHash && a.logIndex === b.logIndex;
+}


### PR DESCRIPTION
To be paired with https://github.com/across-protocol/relayer/pull/2085 in order to speed up relayer marginally when pending bundle data is not yet available on Arweave. Also adds safety checks to BundleDataClient in case there are duplicate events