### PR TITLE
feat(spokePoolClient): add getter for slow fill requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -315,9 +315,17 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
+   * Retrieves a list of slow fill requests from the SpokePool contract.
+   * @returns A list of slow fill requests.
+   */
+  public getSlowFillRequests(): SlowFillRequestWithBlock[] {
+    return sortEventsAscendingInPlace(Object.values(this.slowFillRequests));
+  }
+
+  /**
    * Find a SlowFillRequested event based on its deposit RelayData.
    * @param relayData RelayData field for the SlowFill request.
-   * @returns The corresponding SlowFIllRequest event if found, otherwise undefined.
+   * @returns The corresponding SlowFillRequest event if found, otherwise undefined.
    */
   public getSlowFillRequest(relayData: RelayData): SlowFillRequestWithBlock | undefined {
     const messageHash = getMessageHash(relayData.message);

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -315,7 +315,10 @@ describe("SpokePoolClient: Event Filtering", function () {
     }
     await destinationSpokePoolClient.update(slowFillRequestedEvents);
 
-    // Should receive _all_ fills submitted on the destination chain.
+    // Should receive _all_ slow fills submitted on the destination chain.
+    const slowFillRequests = destinationSpokePoolClient.getSlowFillRequests();
+    expect(slowFillRequests.length).to.equal(requests.length);
+
     requests.forEach((event) => {
       let { args } = event;
       expect(args).to.not.be.undefined;
@@ -363,7 +366,7 @@ describe("SpokePoolClient: Event Filtering", function () {
       expect(deposit.depositId).to.equal(depositEvent.args!.depositId);
 
       const v3Fill = fillFromDeposit(deposit, relayer);
-      fillEvents.push(destinationSpokePoolClient.fillV3Relay(v3Fill as FillWithBlock));
+      fillEvents.push(destinationSpokePoolClient.fillV3Relay(v3Fill as FillWithBlock & { message: string }));
     }
     await destinationSpokePoolClient.update(filledRelayEvents);
 
@@ -447,7 +450,7 @@ describe("SpokePoolClient: Event Filtering", function () {
         exclusiveRelayer,
         relayer,
         depositId: toBN(i),
-      } as FillWithBlock);
+      } as FillWithBlock & { message: string });
       await originSpokePoolClient.update(["FilledV3Relay"]);
       let relay = originSpokePoolClient.getFills().at(-1);
       expect(relay).to.exist;


### PR DESCRIPTION
To store slow fill requests, the indexer needs to retrieve the relevant events from the SDK within the specified block range.