### PR TITLE
feat: Decide on Cache TTL for some RPC responses post-response

### DIFF
--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -169,4 +169,5 @@ export enum CacheType {
   NONE, // Do not cache
   WITH_TTL, // Cache with TTL
   NO_TTL, // Cache with infinite TTL
+  DECIDE_TTL_POST_SEND, // Decide which TTL to cache with after we receive the RPC response
 }


### PR DESCRIPTION
The CacheProvider decides pre-request which TTL to store an RPC response in the cache which makes sense when we were originally caching only `eth_getLogs` and `eth_call` which have `blockNumber` as part of the request parameters. The TTL decision is essentially based on how much the requested data is older than the HEAD network block. The intuitionhere is that events that are already-finalized we can cache with infinite TTL while those that have re-org risk we should not cache at all or have shorter TTL.

However, this logic prevents us from being able to cache results of RPC endpoints like `eth_getTransactionReceipt` where the `blockNumber` is not part of the request parameters.

This PR introduces a new `CacheType` = `DECIDE_TTL_POST_SEND` where we defer the TTL decision until after we receive the RPC response. This response should include a `blockNumber` which we can then use to set the TTl. This logic incurs no extra compute costs or RPC requests, as regardless when we set the TTL based on the blockNumber we need to call `getBlockNumberFromRpcResponse()`.

As a motivating example, the finalizer is one example of a bot that makes the `eth_getTransactionReceipt` request in order to associate a `TokensBridged` event with the L2-specific withdrawal event needed to create finalization calldata. This is done on every single OPStack `TokensBridged` event [here](https://github.com/across-protocol/relayer/blob/356c1bc270940109cc07a82d2d778b287f779c3c/src/finalizer/utils/opStack.ts#L240). The Finalizer will regularly process the same `TokensBridged` event repeatedly until it drifts out of the lookback window so this caching of `eth_getTransactionReceipt` should yield immediate results.
