### PR TITLE
fix(CacheProvider): Exit early if cacheType based on blockNumber of RPC response is NONE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.18",
+  "version": "4.1.19",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/providers/cachedProvider.ts
+++ b/src/providers/cachedProvider.ts
@@ -59,6 +59,9 @@ export class CacheProvider extends RateLimitedProvider {
       if (cacheType === CacheType.DECIDE_TTL_POST_SEND) {
         const blockNumber = this.getBlockNumberFromRpcResponse(method, result);
         cacheType = await this.cacheTypeForBlock(blockNumber);
+        if (cacheType === CacheType.NONE) {
+          return result;
+        }
       }
 
       // Note: use swtich to ensure all enum cases are handled.


### PR DESCRIPTION
This [line](https://github.com/across-protocol/sdk/blob/80e2ab26b9dc68265d8d1707a3ee025e03cbc4dc/src/providers/cachedProvider.ts#L77) is triggering and throwing an error when an RPC request for a method like `eth_getTransactionReceipt` has an initial cache type of `DECIDE_TTL_POST_SEND` and then the RPC response reveals a `blockNumber` that is too close to HEAD.

So the `cacheTypeForBlock` is returning `NONE` [here](https://github.com/across-protocol/sdk/blob/80e2ab26b9dc68265d8d1707a3ee025e03cbc4dc/src/providers/cachedProvider.ts#L174) which then throws an error when we try to set this RPC result in the cache