### PR TITLE
improve(SpokePoolClient): Suppress duplicate invalid fill logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.19",
+  "version": "4.1.20",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -42,7 +42,6 @@ import {
   RelayerRefundExecutionWithBlock,
   RootBundleRelayWithBlock,
   SlowFillRequestWithBlock,
-  SortableEvent,
   SpeedUpWithBlock,
   TokensBridged,
 } from "../interfaces";

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -430,7 +430,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     const invalidFillsForDeposit = invalidFills.filter((x) => {
       const txnUid = `${x.transactionHash}:${x.logIndex}`;
       // if txnUid doesn't exist in the invalidFills set, add it now, but log the corresponding fill.
-      return x.depositId.eq(deposit.depositId) && (!this.invalidFills.has(txnUid) || this.invalidFills.add(txnUid))
+      return x.depositId.eq(deposit.depositId) && (!this.invalidFills.has(txnUid) || this.invalidFills.add(txnUid));
     });
     if (invalidFillsForDeposit.length > 0) {
       this.logger.warn({

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -430,7 +430,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     // Log any invalid deposits with same deposit id but different params.
     const invalidFillsForDeposit = invalidFills.filter((x) => {
       const txnUid = `${x.transactionHash}:${x.logIndex}`;
-      // if txnUid doesn't exist in the invalidFills set, add it now.
+      // if txnUid doesn't exist in the invalidFills set, add it now, but log the corresponding fill.
       return x.depositId.eq(deposit.depositId) && (!this.invalidFills.has(txnUid) || this.invalidFills.add(txnUid))
     });
     if (invalidFillsForDeposit.length > 0) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -433,7 +433,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       const newInvalidFill = x.depositId.eq(deposit.depositId) && !this.invalidFills.has(txnUid);
       if (newInvalidFill) {
         this.invalidFills.add(txnUid);
-      };
+      }
       return newInvalidFill;
     });
     if (invalidFillsForDeposit.length > 0) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -427,14 +427,13 @@ export class SpokePoolClient extends BaseAbstractClient {
       { validFills: [], invalidFills: [], unrepayableFills: [] }
     );
 
-    const getTxnIdx = (x: SortableEvent) => `${x.transactionHash}:${x.logIndex}`;
-
     // Log any invalid deposits with same deposit id but different params.
-    const invalidFillsForDeposit = invalidFills.filter(
-      (x) => x.depositId.eq(deposit.depositId) && !this.invalidFills.has(getTxnIdx(x))
-    );
+    const invalidFillsForDeposit = invalidFills.filter((x) => {
+      const txnUid = `${x.transactionHash}:${x.logIndex}`;
+      // if txnUid doesn't exist in the invalidFills set, add it now.
+      return x.depositId.eq(deposit.depositId) && (!this.invalidFills.has(txnUid) || this.invalidFills.add(txnUid))
+    });
     if (invalidFillsForDeposit.length > 0) {
-      invalidFillsForDeposit.forEach((x) => this.invalidFills.add(getTxnIdx(x)));
       this.logger.warn({
         at: "SpokePoolClient",
         chainId: this.chainId,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -84,7 +84,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   protected relayerRefundExecutions: RelayerRefundExecutionWithBlock[] = [];
   protected queryableEventNames: string[] = [];
   protected configStoreClient: AcrossConfigStoreClient | undefined;
-  protected invalidFills: Set<string> = new Set([]);
+  protected invalidFills: Set<string> = new Set();
   public earliestDepositIdQueried = MAX_BIG_INT;
   public latestDepositIdQueried = bnZero;
   public firstDepositIdForSpokePool = MAX_BIG_INT;
@@ -430,7 +430,11 @@ export class SpokePoolClient extends BaseAbstractClient {
     const invalidFillsForDeposit = invalidFills.filter((x) => {
       const txnUid = `${x.transactionHash}:${x.logIndex}`;
       // if txnUid doesn't exist in the invalidFills set, add it now, but log the corresponding fill.
-      return x.depositId.eq(deposit.depositId) && (!this.invalidFills.has(txnUid) || this.invalidFills.add(txnUid));
+      const newInvalidFill = x.depositId.eq(deposit.depositId) && !this.invalidFills.has(txnUid);
+      if (newInvalidFill) {
+        this.invalidFills.add(txnUid);
+      };
+      return newInvalidFill;
     });
     if (invalidFillsForDeposit.length > 0) {
       this.logger.warn({


### PR DESCRIPTION
The fast relayer logs invalid fills on every SpokePoolCLient update. This is hugely spammy when the relayer loops quickly.