### PR TITLE
fix(svm): handle errors in cached solana provider

### DIFF
--- a/test/mocks/MockSolanaRpcFactory.ts
+++ b/test/mocks/MockSolanaRpcFactory.ts
@@ -1,10 +1,12 @@
 import { RpcResponse, RpcTransport } from "@solana/kit";
 import { SolanaClusterRpcFactory } from "../../src/providers";
 
+type CachedResponse = { result: unknown } | { error: unknown } | { throwError: string };
+
 // Exposes mocked RPC transport for Solana in the SolanaClusterRpcFactory class.
 export class MockSolanaRpcFactory extends SolanaClusterRpcFactory {
   private responseTime: number; // in milliseconds
-  private responses: Map<string, unknown> = new Map();
+  private responses: Map<string, CachedResponse> = new Map();
 
   constructor(...clusterConstructorParams: ConstructorParameters<typeof SolanaClusterRpcFactory>) {
     super(...clusterConstructorParams);
@@ -18,7 +20,17 @@ export class MockSolanaRpcFactory extends SolanaClusterRpcFactory {
 
   public setResult(method: string, params: unknown[], result: unknown) {
     const requestKey = JSON.stringify({ method, params });
-    this.responses.set(requestKey, result);
+    this.responses.set(requestKey, { result });
+  }
+
+  public setError(method: string, params: unknown[], error: unknown) {
+    const requestKey = JSON.stringify({ method, params });
+    this.responses.set(requestKey, { error });
+  }
+
+  public setThrow(method: string, params: unknown[], throwError: string) {
+    const requestKey = JSON.stringify({ method, params });
+    this.responses.set(requestKey, { throwError });
   }
 
   public setResponseTime(responseTime: number) {
@@ -29,14 +41,15 @@ export class MockSolanaRpcFactory extends SolanaClusterRpcFactory {
     return async <TResponse>({ payload }: Parameters<RpcTransport>[0]): Promise<RpcResponse<TResponse>> => {
       const { method, params } = payload as { method: string; params?: unknown[] };
       const requestKey = JSON.stringify({ method, params });
-      let result = this.responses.get(requestKey);
-      if (result === undefined) {
+      let jsonRpcResponse = this.responses.get(requestKey);
+      if (jsonRpcResponse === undefined) {
         const requestKeyWithoutParams = JSON.stringify({ method, params: [] });
-        result = this.responses.get(requestKeyWithoutParams);
-        if (result === undefined) result = null;
+        jsonRpcResponse = this.responses.get(requestKeyWithoutParams);
+        if (jsonRpcResponse === undefined) jsonRpcResponse = { result: null };
       }
       await new Promise((resolve) => setTimeout(resolve, this.responseTime));
-      return { result } as TResponse;
+      if ("throwError" in jsonRpcResponse) throw new Error(jsonRpcResponse.throwError);
+      return jsonRpcResponse as TResponse;
     };
   }
 }


### PR DESCRIPTION
This adds error handling in the cached Solana RPC transport. Specifically, now it does not cache and pass through json-rpc response to rpc client if:
- `getTransaction` underlying transport returns JSON-RPC error response
- `getSignatureStatuses` RPC client request errors