### PR TITLE
feat(NetworkUtils): add chainIsSvm helper function

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@across-protocol/across-token": "^1.0.0",
-    "@across-protocol/constants": "^3.1.38",
+    "@across-protocol/constants": "^3.1.39",
     "@across-protocol/contracts": "4.0.3",
     "@coral-xyz/anchor": "^0.30.1",
     "@eth-optimism/sdk": "^3.3.1",

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -130,9 +130,17 @@ export function chainIsL1(chainId: number): boolean {
  * @returns True if chain corresponding to chainId has an EVM-like execution layer.
  */
 export function chainIsEvm(chainId: number): boolean {
-  chainId;
-  // TODO: Fix when we support non-EVM chains.
-  return true;
+  // TODO: Update when additional execution layers beyond EVM and SVM are supported.
+  return PUBLIC_NETWORKS[chainId]?.family !== ChainFamily.SVM;
+}
+
+/**
+ * Determines whether a chain ID runs on an SVM-like execution layer.
+ * @param chainId Chain ID to evaluate.
+ * @returns True if chain corresponding to chainId has an SVM-like execution layer.
+ */
+export function chainIsSvm(chainId: number): boolean {
+  return PUBLIC_NETWORKS[chainId]?.family === ChainFamily.SVM;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,15 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants@^3.1.37", "@across-protocol/constants@^3.1.38":
+"@across-protocol/constants@^3.1.37":
   version "3.1.38"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.38.tgz#63f4d9b86576b0003655152c51293dd1c7ab6a1f"
   integrity sha512-/85ACwpu4oxAADOah8VP3esxU3FVb+RieMCINgn4oUf4Rq9cC1LSJm157hy5cc4CBUaySV312MP1iM1d8ysljA==
+
+"@across-protocol/constants@^3.1.39":
+  version "3.1.39"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.39.tgz#3adff453de215057f2b945bd53376c0f0c5ac821"
+  integrity sha512-as/7d6eIUJno68ppmFFfcWXCj0putV8HqqdcE+zihqb6xSoG5l6ZLSfxgypq1pQvkmI/t+JOnZNZu+qgqnTSRQ==
 
 "@across-protocol/contracts@4.0.3":
   version "4.0.3"


### PR DESCRIPTION
This PR:
- Updates the constants package.
- Modifies the `chainIsEvm` implementation, which used to return always true.
- Adds a new utility function `chainIsSvm`.