### PR TITLE
chore: bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.23",
+  "version": "4.1.24",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [


### PR DESCRIPTION
The bump in the last PR was removed during a merge with master, so it needs to be bumped again so `Address` can be exposed downstream.