### PR TITLE
fix(postinstall): include scripts folder in published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.24",
+  "version": "4.1.25-beta.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.25-beta.1",
+  "version": "4.1.25",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [
     "dist",
+    "scripts",
     "src"
   ],
   "engines": {


### PR DESCRIPTION
SDK installation was failing since the scripts folder was not included in the published version.
I've tested this change with a beta version published and it is working now.
```
Error: Cannot find module '.../Across/relayer-v3/node_modules/@across-protocol/sdk/scripts/build-bigint-buffer.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:173:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
```