### PR TITLE
fix(findDepositBlock): Drop blockAndAggregate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.26",
+  "version": "4.1.27",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/Multicall.ts
+++ b/src/utils/Multicall.ts
@@ -70,6 +70,10 @@ export async function aggregate(multicall3: Contract, calls: Call3[], blockTag?:
   });
 }
 
+/**
+ * Note that this function behaves unexpectedly on Arbitrum chains, where block.number
+ * corresponds to the approximate block number of the underlying chain.
+ */
 export async function blockAndAggregate(
   multicall3: Contract,
   calls: Call3[],

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -7,7 +7,6 @@ import { chunk } from "./ArrayUtils";
 import { BigNumber, toBN, bnOne, bnZero } from "./BigNumberUtils";
 import { keccak256 } from "./common";
 import { isMessageEmpty } from "./DepositUtils";
-import { blockAndAggregate, getMulticall3 } from "./Multicall";
 import { isDefined } from "./TypeGuards";
 import { getNetworkName } from "./NetworkUtils";
 import { paginatedEventQuery, spreadEventWithBlockNumber } from "./EventUtils";
@@ -345,22 +344,15 @@ export async function findDepositBlock(
     throw new Error(`Cannot binary search for depositId ${depositId}`);
   }
 
-  // @todo this call can be optimised away by using multicall3.blockAndAggregate(..., { blockTag: highBlockNumber }).
-  // This is left for future because the change is a bit complex, and multicall3 isn't supported in test.
-  const { chainId } = await spokePool.provider.getNetwork();
-  const multicall3 = getMulticall3(chainId, spokePool.provider);
-  assert(multicall3, `No multicall3 defined for chain ${chainId}`);
+  highBlock ??= await spokePool.provider.getBlockNumber();
 
   // Make sure the deposit occurred within the block range supplied by the caller.
-  const [_nDepositsLow, { blockNumber: _highBlock, returnData }] = await Promise.all([
+  const [nDepositsLow, nDepositsHigh] = (await Promise.all([
     spokePool.numberOfDeposits({ blockTag: lowBlock }),
-    blockAndAggregate(multicall3, [{ contract: spokePool, method: "numberOfDeposits" }], highBlock),
-  ]);
-  highBlock = _highBlock;
+    spokePool.numberOfDeposits({ blockTag: highBlock })
+  ])).map((n) => toBN(n));
   assert(highBlock > lowBlock, `Block numbers out of range (${lowBlock} >= ${highBlock})`);
 
-  const nDepositsLow = toBN(_nDepositsLow);
-  const nDepositsHigh = toBN(returnData.at(0)!);
   if (nDepositsLow.gt(depositId) || nDepositsHigh.lte(depositId)) {
     return undefined; // Deposit did not occur within the specified block range.
   }

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -345,13 +345,15 @@ export async function findDepositBlock(
   }
 
   highBlock ??= await spokePool.provider.getBlockNumber();
+  assert(highBlock > lowBlock, `Block numbers out of range (${lowBlock} >= ${highBlock})`);
 
   // Make sure the deposit occurred within the block range supplied by the caller.
-  const [nDepositsLow, nDepositsHigh] = (await Promise.all([
-    spokePool.numberOfDeposits({ blockTag: lowBlock }),
-    spokePool.numberOfDeposits({ blockTag: highBlock })
-  ])).map((n) => toBN(n));
-  assert(highBlock > lowBlock, `Block numbers out of range (${lowBlock} >= ${highBlock})`);
+  const [nDepositsLow, nDepositsHigh] = (
+    await Promise.all([
+      spokePool.numberOfDeposits({ blockTag: lowBlock }),
+      spokePool.numberOfDeposits({ blockTag: highBlock }),
+    ])
+  ).map((n) => toBN(n));
 
   if (nDepositsLow.gt(depositId) || nDepositsHigh.lte(depositId)) {
     return undefined; // Deposit did not occur within the specified block range.


### PR DESCRIPTION
This unfortunately doesn't work as intended on Arbitrum One & Orbit chains. These chains unfortunately return the approximate block number of the _underlying_ chain. This is totally jarring and can only be fixed with a custom Multicall3 adaptation for Arbitrum chains.

Maybe one day we'll use blockAndAggregate with a custom Multicall3 deployment on Arbitrum chains. For now, revert to something that works as expected.