### PR TITLE
refactor(SpokePoolClient): Relocate getTimeAt() implementation

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,11 +1,9 @@
-import assert from "assert";
 import { Contract, EventFilter } from "ethers";
 import winston from "winston";
 import {
   AnyObject,
   BigNumber,
   bnZero,
-  bnUint32Max,
   DefaultLogLevels,
   DepositSearchResult,
   EventSearchConfig,
@@ -47,7 +45,7 @@ import {
 } from "../interfaces";
 import { SpokePool } from "../typechain";
 import { getNetworkName } from "../utils/NetworkUtils";
-import { findDepositBlock, getDepositIdAtBlock, relayFillStatus } from "../utils/SpokeUtils";
+import { findDepositBlock, getDepositIdAtBlock, getTimeAt as _getTimeAt, relayFillStatus } from "../utils/SpokeUtils";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
 import { HubPoolClient } from "./HubPoolClient";
 import { AcrossConfigStoreClient } from "./AcrossConfigStoreClient";
@@ -895,10 +893,8 @@ export class SpokePoolClient extends BaseAbstractClient {
    * Retrieves the time from the SpokePool contract at a particular block.
    * @returns The time at the specified block tag.
    */
-  public async getTimeAt(blockNumber: number): Promise<number> {
-    const currentTime = await this.spokePool.getCurrentTime({ blockTag: blockNumber });
-    assert(BigNumber.isBigNumber(currentTime) && currentTime.lt(bnUint32Max));
-    return currentTime.toNumber();
+  public getTimeAt(blockNumber: number): Promise<number> {
+    return _getTimeAt(this.spokePool, blockNumber);
   }
 
   /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -4,7 +4,7 @@ import { CHAIN_IDs, MAX_SAFE_DEPOSIT_ID, UNDEFINED_MESSAGE_HASH, ZERO_ADDRESS, Z
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
 import { chunk } from "./ArrayUtils";
-import { BigNumber, toBN, bnOne, bnZero } from "./BigNumberUtils";
+import { bnUint32Max, BigNumber, toBN, bnOne, bnZero } from "./BigNumberUtils";
 import { keccak256 } from "./common";
 import { isMessageEmpty } from "./DepositUtils";
 import { isDefined } from "./TypeGuards";
@@ -273,6 +273,16 @@ export async function getBlockRangeForDepositId(
   // We've either found the block range or we've exceeded the maximum number of searches.
   // In either case, the block range is [low, high] so we can return it.
   return { low, high };
+}
+
+/**
+ * Retrieves the time from the SpokePool contract at a particular block.
+ * @returns The time at the specified block tag.
+ */
+export async function getTimeAt(spokePool: Contract, blockNumber: number): Promise<number> {
+  const currentTime = await spokePool.getCurrentTime({ blockTag: blockNumber });
+  assert(BigNumber.isBigNumber(currentTime) && currentTime.lt(bnUint32Max));
+  return currentTime.toNumber();
 }
 
 /**


### PR DESCRIPTION
Make way for non-evm implementations.