### PR TITLE
refactor(SpokePoolClient): Squash redundant block-to-timestamp function

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1551,8 +1551,8 @@ export class BundleDataClient {
           // there are no gaps in block timestamps between bundles.
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
           const [startTime, _endTime] = [
-            await spokePoolClient.getTimestampForBlock(startBlockForChain),
-            await spokePoolClient.getTimestampForBlock(endBlockForChain),
+            await spokePoolClient.getTimeAt(startBlockForChain),
+            await spokePoolClient.getTimeAt(endBlockForChain),
           ];
           // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
           // no overlap, subtract 1 from the end time.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -991,11 +991,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     );
   }
 
-  public async getTimestampForBlock(blockTag: number): Promise<number> {
-    const block = await this.spokePool.provider.getBlock(blockTag);
-    return Number(block.timestamp);
-  }
-
   /**
    * Find the amount filled for a deposit at a particular block.
    * @param relayData Deposit information that is used to complete a fill.


### PR DESCRIPTION
SpokePoolClient.getTimeAt() does the same.