### PR TITLE
improve: implement a common interface in sdk providers

### DIFF
--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -27,6 +27,7 @@ import {
 } from "./PoolRebalanceUtils";
 import { AcrossConfigStoreClient } from "../../AcrossConfigStoreClient";
 import { HubPoolClient } from "../../HubPoolClient";
+import { CrosschainProvider } from "../../../providers";
 import { buildPoolRebalanceLeafTree } from "./MerkleTreeUtils";
 
 // and expired deposits.
@@ -113,7 +114,7 @@ export function getEndBlockBuffers(
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number) => blockRangeEndBlockBuffer[chainId] ?? 0);
 }
 
-export function _buildPoolRebalanceRoot(
+export function _buildPoolRebalanceRoot<P extends CrosschainProvider>(
   latestMainnetBlock: number,
   mainnetBundleEndBlock: number,
   bundleV3Deposits: BundleDepositsV3,
@@ -121,7 +122,7 @@ export function _buildPoolRebalanceRoot(
   bundleSlowFillsV3: BundleSlowFills,
   unexecutableSlowFills: BundleExcessSlowFills,
   expiredDepositsToRefundV3: ExpiredDepositsToRefundV3,
-  clients: { hubPoolClient: HubPoolClient; configStoreClient: AcrossConfigStoreClient },
+  clients: { hubPoolClient: HubPoolClient<P>; configStoreClient: AcrossConfigStoreClient },
   maxL1TokenCountOverride?: number
 ): PoolRebalanceRoot {
   // Running balances are the amount of tokens that we need to send to each SpokePool to pay for all instant and

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -3,10 +3,11 @@ import { providers } from "ethers";
 import { Deposit, DepositWithBlock, Fill, FillWithBlock } from "../../../interfaces";
 import { getBlockRangeForChain, isSlowFill, isValidEvmAddress, isDefined, chainIsEvm } from "../../../utils";
 import { HubPoolClient } from "../../HubPoolClient";
+import { CrosschainProvider } from "../../../providers";
 
-export function getRefundInformationFromFill(
+export function getRefundInformationFromFill<P extends CrosschainProvider>(
   fill: Fill,
-  hubPoolClient: HubPoolClient,
+  hubPoolClient: HubPoolClient<P>,
   blockRangesForChains: number[][],
   chainIdListForBundleEvaluationBlockNumbers: number[],
   fromLiteChain: boolean
@@ -53,10 +54,10 @@ export function getRepaymentChainId(fill: Fill, matchedDeposit: Deposit): number
   return matchedDeposit.fromLiteChain ? matchedDeposit.originChainId : fill.repaymentChainId;
 }
 
-export function forceDestinationRepayment(
+export function forceDestinationRepayment<P extends CrosschainProvider>(
   repaymentChainId: number,
   matchedDeposit: Deposit & { quoteBlockNumber: number },
-  hubPoolClient: HubPoolClient
+  hubPoolClient: HubPoolClient<P>
 ): boolean {
   if (!matchedDeposit.fromLiteChain) {
     try {
@@ -79,11 +80,11 @@ export function forceDestinationRepayment(
 
 // Verify that a fill sent to an EVM chain has a 20 byte address. If the fill does not, then attempt
 // to repay the `msg.sender` of the relay transaction. Otherwise, return undefined.
-export async function verifyFillRepayment(
+export async function verifyFillRepayment<P extends CrosschainProvider>(
   _fill: FillWithBlock,
   destinationChainProvider: providers.Provider,
   matchedDeposit: DepositWithBlock,
-  hubPoolClient: HubPoolClient
+  hubPoolClient: HubPoolClient<P>
 ): Promise<FillWithBlock | undefined> {
   const fill = _.cloneDeep(_fill);
 

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -5,6 +5,7 @@ import { BigNumber, bnZero, compareAddresses } from "../../../utils";
 import { HubPoolClient } from "../../HubPoolClient";
 import { V3DepositWithBlock } from "./shims";
 import { AcrossConfigStoreClient } from "../../AcrossConfigStoreClient";
+import { CrosschainProvider } from "../../../providers";
 
 export type PoolRebalanceRoot = {
   runningBalances: RunningBalances;
@@ -17,11 +18,11 @@ export type PoolRebalanceRoot = {
 // when evaluating  pending root bundle. The block end numbers must be less than the latest blocks for each chain ID
 // (because we can't evaluate events in the future), and greater than the expected start blocks, which are the
 // greater of 0 and the latest bundle end block for an executed root bundle proposal + 1.
-export function getWidestPossibleExpectedBlockRange(
+export function getWidestPossibleExpectedBlockRange<P extends CrosschainProvider>(
   chainIdListForBundleEvaluationBlockNumbers: number[],
-  spokeClients: { [chainId: number]: SpokePoolClient },
+  spokeClients: { [chainId: number]: SpokePoolClient<P> },
   endBlockBuffers: number[],
-  clients: Clients,
+  clients: Clients<P>,
   latestMainnetBlock: number,
   enabledChains: number[]
 ): number[][] {
@@ -140,10 +141,10 @@ export function updateRunningBalance(
   }
 }
 
-export function addLastRunningBalance(
+export function addLastRunningBalance<P extends CrosschainProvider>(
   latestMainnetBlock: number,
   runningBalances: RunningBalances,
-  hubPoolClient: HubPoolClient
+  hubPoolClient: HubPoolClient<P>
 ): void {
   Object.keys(runningBalances).forEach((repaymentChainId) => {
     Object.keys(runningBalances[Number(repaymentChainId)]).forEach((l1TokenAddress) => {
@@ -159,9 +160,9 @@ export function addLastRunningBalance(
   });
 }
 
-export function updateRunningBalanceForDeposit(
+export function updateRunningBalanceForDeposit<P extends CrosschainProvider>(
   runningBalances: RunningBalances,
-  hubPoolClient: HubPoolClient,
+  hubPoolClient: HubPoolClient<P>,
   deposit: V3DepositWithBlock,
   updateAmount: BigNumber
 ): void {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -54,6 +54,7 @@ import {
 } from "../utils/SpokeUtils";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
 import { HubPoolClient } from "./HubPoolClient";
+import { CrosschainProvider } from "../providers";
 import { AcrossConfigStoreClient } from "./AcrossConfigStoreClient";
 import { getRepaymentChainId, forceDestinationRepayment } from "./BundleDataClient/utils/FillUtils";
 
@@ -73,7 +74,7 @@ export type SpokePoolUpdate = SpokePoolUpdateSuccess | SpokePoolUpdateFailure;
  * SpokePoolClient is a client for the SpokePool contract. It is responsible for querying the SpokePool contract
  * for events and storing them in memory. It also provides some convenience methods for querying the stored events.
  */
-export class SpokePoolClient extends BaseAbstractClient {
+export class SpokePoolClient<P extends CrosschainProvider> extends BaseAbstractClient {
   protected currentTime = 0;
   protected depositHashes: { [depositHash: string]: DepositWithBlock } = {};
   protected duplicateDepositHashes: { [depositHash: string]: DepositWithBlock[] } = {};
@@ -102,7 +103,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     readonly logger: winston.Logger,
     readonly spokePool: Contract,
     // Can be excluded. This disables some deposit validation.
-    readonly hubPoolClient: HubPoolClient | null,
+    readonly hubPoolClient: HubPoolClient<P> | null,
     readonly chainId: number,
     public deploymentBlock: number,
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -5,6 +5,7 @@ import { L1Token, Log, PendingRootBundle, RealizedLpFee } from "../../interfaces
 import { AcrossConfigStoreClient as ConfigStoreClient } from "../AcrossConfigStoreClient";
 import { HubPoolClient, HubPoolUpdate, LpFeeRequest } from "../HubPoolClient";
 import { EventManager, EventOverrides, getEventManager } from "./MockEvents";
+import { CrosschainProvider } from "../../providers";
 
 const emptyRootBundle: PendingRootBundle = {
   poolRebalanceRoot: "",
@@ -17,7 +18,7 @@ const emptyRootBundle: PendingRootBundle = {
   proposalBlockNumber: undefined,
 };
 
-export class MockHubPoolClient extends HubPoolClient {
+export class MockHubPoolClient<P extends CrosschainProvider> extends HubPoolClient<P> {
   public rootBundleProposal = emptyRootBundle;
   private realizedLpFeePct: BigNumber = bnZero;
   private realizedLpFeePctOverride = false;

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -32,10 +32,11 @@ import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
 import { HubPoolClient } from "../HubPoolClient";
 import { EventManager, EventOverrides, getEventManager } from "./MockEvents";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
+import { CrosschainProvider } from "../../providers";
 
 // This class replaces internal SpokePoolClient functionality, enabling
 // the user to bypass on-chain queries and inject Log objects directly.
-export class MockSpokePoolClient extends SpokePoolClient {
+export class MockSpokePoolClient<P extends CrosschainProvider> extends SpokePoolClient<P> {
   public eventManager: EventManager;
   private destinationTokenForChainOverride: Record<number, string> = {};
   // Allow tester to set the numberOfDeposits() returned by SpokePool at a block height.
@@ -47,7 +48,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     spokePool: Contract,
     chainId: number,
     deploymentBlock: number,
-    opts: { hubPoolClient: HubPoolClient | null } = { hubPoolClient: null }
+    opts: { hubPoolClient: HubPoolClient<P> | null } = { hubPoolClient: null }
   ) {
     super(logger, spokePool, opts.hubPoolClient, chainId, deploymentBlock);
     this.latestBlockSearched = deploymentBlock;

--- a/src/interfaces/BundleData.ts
+++ b/src/interfaces/BundleData.ts
@@ -4,6 +4,7 @@ import { HubPoolClient } from "../clients/HubPoolClient";
 import { AcrossConfigStoreClient } from "../clients";
 import { ArweaveClient } from "../caching";
 import { BigNumber } from "../utils";
+import { CrosschainProvider } from "../providers";
 
 export type ExpiredDepositsToRefundV3 = {
   [originChainId: number]: {
@@ -55,8 +56,8 @@ export type BundleData = LoadDataReturnValue & {
   bundleBlockRanges: number[][];
 };
 
-export interface Clients {
-  hubPoolClient: HubPoolClient;
+export interface Clients<P extends CrosschainProvider> {
+  hubPoolClient: HubPoolClient<P>;
   configStoreClient: AcrossConfigStoreClient;
   hubSigner?: Signer;
   arweaveClient: ArweaveClient;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -1,6 +1,7 @@
 import { SortableEvent } from "./Common";
 import { FilledV3RelayEvent, V3FundsDepositedEvent } from "../typechain";
 import { SpokePoolClient } from "../clients";
+import { CrosschainProvider } from "../providers";
 import { BigNumber } from "../utils";
 import { RelayerRefundLeaf } from "./HubPool";
 
@@ -122,6 +123,6 @@ export interface TokensBridged extends SortableEvent {
   l2TokenAddress: string;
 }
 
-export interface SpokePoolClientsByChain {
-  [chainId: number]: SpokePoolClient;
+export interface SpokePoolClientsByChain<P extends CrosschainProvider> {
+  [chainId: number]: SpokePoolClient<P>;
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,5 +5,6 @@ export * from "./speedProvider";
 export * from "./constants";
 export * from "./types";
 export * from "./utils";
+export * from "./interface";
 export * as mocks from "./mockProvider";
 export * from "./solana";

--- a/src/providers/interface.ts
+++ b/src/providers/interface.ts
@@ -1,5 +1,4 @@
 export interface CrosschainProvider {
-  send(method: string, params: Array<unknown>): Promise<unknown>;
   getBlock(blockTag: number | string): Promise<unknown>;
   getNetworkId(): Promise<number>;
   getBlockNumber(): Promise<number>;

--- a/src/providers/interface.ts
+++ b/src/providers/interface.ts
@@ -1,0 +1,6 @@
+export interface CrosschainProvider {
+  send(method: string, params: Array<unknown>): Promise<unknown>;
+  getBlock(blockTag: number | string): Promise<unknown>;
+  getNetworkId(): Promise<number>;
+  getBlockNumber(): Promise<number>;
+}

--- a/src/providers/mockProvider.ts
+++ b/src/providers/mockProvider.ts
@@ -1,12 +1,13 @@
 import { BigNumber, providers } from "ethers";
 import { Block, BlockTag, FeeData, TransactionResponse } from "@ethersproject/abstract-provider";
 import { bnZero } from "../utils/BigNumberUtils";
+import { CrosschainProvider } from "./";
 
 /**
  * @notice Class used to test GasPriceOracle which makes ethers provider calls to the following implemented
  * methods.
  */
-export class MockedProvider extends providers.StaticJsonRpcProvider {
+export class MockedProvider extends providers.StaticJsonRpcProvider implements CrosschainProvider {
   private transactions: { [hash: string]: TransactionResponse } = {};
 
   constructor(
@@ -69,6 +70,10 @@ export class MockedProvider extends providers.StaticJsonRpcProvider {
       name: "mocknetwork",
       chainId: this.defaultChainId,
     });
+  }
+
+  getNetworkId(): Promise<number> {
+    return Promise.resolve(this.defaultChainId);
   }
 
   _setTransaction(hash: string, transaction: TransactionResponse) {

--- a/src/providers/rateLimitedProvider.ts
+++ b/src/providers/rateLimitedProvider.ts
@@ -7,10 +7,11 @@ import { ethers } from "ethers";
 import { RateLimitTask } from "./utils";
 import { getOriginFromURL } from "../utils/NetworkUtils";
 import winston, { Logger } from "winston";
+import { CrosschainProvider } from "./interface";
 
 // This provider is a very small addition to the StaticJsonRpcProvider that ensures that no more than `maxConcurrency`
 // requests are ever in flight. It uses the async/queue library to manage this.
-export class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
+export class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider implements CrosschainProvider {
   // The queue object that manages the tasks.
   private queue: QueueObject<RateLimitTask>;
 
@@ -92,5 +93,11 @@ export class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider 
       // the same behavior with the `void` keyword.
       void this.queue.push(task);
     });
+  }
+
+  // Returns the chain ID of the provider's network.
+  async getNetworkId(): Promise<number> {
+    const { chainId } = await this.getNetwork();
+    return chainId;
   }
 }

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -8,8 +8,9 @@ import { compareRpcResults, createSendErrorWithMessage, formatProviderError } fr
 import { PROVIDER_CACHE_TTL } from "./constants";
 import { JsonRpcError, RpcError } from "./types";
 import { Logger } from "winston";
+import { CrosschainProvider } from "./interface";
 
-export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
+export class RetryProvider extends ethers.providers.StaticJsonRpcProvider implements CrosschainProvider {
   readonly providers: ethers.providers.StaticJsonRpcProvider[];
   constructor(
     params: ConstructorParameters<typeof ethers.providers.StaticJsonRpcProvider>[],
@@ -228,6 +229,12 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     }
 
     return quorumResult;
+  }
+
+  // Returns the chain ID of the provider's network.
+  async getNetworkId(): Promise<number> {
+    const { chainId } = await this.getNetwork();
+    return chainId;
   }
 
   _validateResponse(method: string, _: Array<unknown>, response: unknown): boolean {

--- a/src/providers/speedProvider.ts
+++ b/src/providers/speedProvider.ts
@@ -4,11 +4,12 @@ import { CacheProvider } from "./cachedProvider";
 import { formatProviderError } from "./utils";
 import { PROVIDER_CACHE_TTL } from "./constants";
 import { Logger } from "winston";
+import { CrosschainProvider } from "./interface";
 
 /**
  * RPC provider that sends requests to multiple providers in parallel and returns the fastest response.
  */
-export class SpeedProvider extends ethers.providers.StaticJsonRpcProvider {
+export class SpeedProvider extends ethers.providers.StaticJsonRpcProvider implements CrosschainProvider {
   readonly providers: ethers.providers.StaticJsonRpcProvider[];
 
   constructor(
@@ -59,5 +60,11 @@ export class SpeedProvider extends ethers.providers.StaticJsonRpcProvider {
       }
       throw error;
     }
+  }
+
+  // Returns the chain ID of the provider's network.
+  async getNetworkId(): Promise<number> {
+    const { chainId } = await super.getNetwork();
+    return chainId;
   }
 }

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -1,5 +1,6 @@
 import { AcrossConfigStoreClient, HubPoolClient } from "../clients";
 import { ProposedRootBundle } from "../interfaces";
+import { CrosschainProvider } from "../providers";
 
 /**
  * Return block number for `chain` in `bundleEvaluationBlockNumbers` using the mapping
@@ -57,8 +58,8 @@ export function getBlockRangeForChain(
  * @param rootBundle Root bundle to return bundle block range for
  * @returns blockRanges: number[][], [[startBlock, endBlock], [startBlock, endBlock], ...]
  */
-export function getImpliedBundleBlockRanges(
-  hubPoolClient: HubPoolClient,
+export function getImpliedBundleBlockRanges<P extends CrosschainProvider>(
+  hubPoolClient: HubPoolClient<P>,
   configStoreClient: AcrossConfigStoreClient,
   rootBundle: ProposedRootBundle
 ): number[][] {

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -9,6 +9,7 @@ import { getMessageHash, isUnsafeDepositId, validateFillForDeposit } from "./Spo
 import { getCurrentTime } from "./TimeUtils";
 import { isDefined } from "./TypeGuards";
 import { isDepositFormedCorrectly } from "./ValidatorUtils";
+import { CrosschainProvider } from "../providers";
 
 // Load a deposit for a fill if the fill's deposit ID is outside this client's search range.
 // This can be used by the Dataworker to determine whether to give a relayer a refund for a fill
@@ -37,8 +38,8 @@ export type DepositSearchResult =
  * @throws If the fill's origin chain ID does not match the spoke pool client's chain ID.
  * @throws If the spoke pool client has not been updated.
  */
-export async function queryHistoricalDepositForFill(
-  spokePoolClient: SpokePoolClient,
+export async function queryHistoricalDepositForFill<P extends CrosschainProvider>(
+  spokePoolClient: SpokePoolClient<P>,
   fill: Fill | SlowFillRequest,
   cache?: CachingMechanismInterface
 ): Promise<DepositSearchResult> {

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -11,6 +11,7 @@ import { isDefined } from "./TypeGuards";
 import { getNetworkName } from "./NetworkUtils";
 import { paginatedEventQuery, spreadEventWithBlockNumber } from "./EventUtils";
 import { toBytes32 } from "./AddressUtils";
+import { CrosschainProvider } from "../providers";
 
 type BlockTag = providers.BlockTag;
 
@@ -144,12 +145,12 @@ export function validateFillForDeposit(
  *        // contain the event emitted when deposit ID was incremented to targetDepositId + 1. This is the same transaction
  *        // where the deposit with deposit ID = targetDepositId was created.
  */
-export async function getBlockRangeForDepositId(
+export async function getBlockRangeForDepositId<P extends CrosschainProvider>(
   targetDepositId: BigNumber,
   initLow: number,
   initHigh: number,
   maxSearches: number,
-  spokePool: SpokePoolClient
+  spokePool: SpokePoolClient<P>
 ): Promise<{
   low: number;
   high: number;

--- a/src/utils/TypeUtils.ts
+++ b/src/utils/TypeUtils.ts
@@ -1,9 +1,10 @@
 import { SpokePoolClient } from "../clients";
+import { CrosschainProvider } from "../providers";
 
 export type MakeOptional<Type, Key extends keyof Type> = Omit<Type, Key> & Partial<Pick<Type, Key>>;
 
 export type AnyObject = Record<string, unknown>;
 
-export type SpokePoolClients = Record<number, SpokePoolClient>;
+export type SpokePoolClients<P extends CrosschainProvider> = Record<number, SpokePoolClient<P>>;
 
 export type Reviver = (key: string, value: unknown) => unknown;

--- a/test/SpokePoolClient.v3Events.ts
+++ b/test/SpokePoolClient.v3Events.ts
@@ -12,7 +12,7 @@ import {
   SpeedUp,
   TokensBridged,
 } from "../src/interfaces";
-import { bnOne, getCurrentTime, getMessageHash, isDefined, randomAddress, toAddress, toBN } from "../src/utils";
+import { bnOne, getCurrentTime, getMessageHash, isDefined, randomAddress, toAddress, toBN, bnZero } from "../src/utils";
 import {
   SignerWithAddress,
   createSpyLogger,
@@ -23,6 +23,7 @@ import {
   hubPoolFixture,
   toBNWei,
 } from "./utils";
+import { mocks } from "../src/providers";
 
 type EventSearchConfig = sdkUtils.EventSearchConfig;
 
@@ -266,6 +267,8 @@ describe("SpokePoolClient: Event Filtering", function () {
   it("Correctly substitutes outputToken when set to 0x0", async function () {
     const { spokePool, chainId, deploymentBlock } = originSpokePoolClient;
     const spokePoolClient = new MockSpokePoolClient(logger, spokePool, chainId, deploymentBlock, { hubPoolClient });
+    // Overwrite the provider of the spoke pool client.
+    hubPoolClient.blockFinder.provider = new mocks.MockedProvider(bnZero, bnZero);
 
     const hubPoolToken = randomAddress();
     const inputToken = randomAddress();


### PR DESCRIPTION
Ideally we can make custom implementations for our providers (e.g. `speedProvider`) and also make providers for other networks (e.g. a Solana provider) while still using a common utility type (e.g. BlockFinder). I think a good way to achieve this is to extend these providers from a common interface and start utilizing generic types more.