### PR TITLE
refactor(SpokeUtils): Relocate chain-agnostic functions

### DIFF
--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CACHING_SAFE_LAG, DEFAULT_CACHING_TTL } from "../constants";
 import { CachingMechanismInterface, Deposit, Fill, SlowFillRequest } from "../interfaces";
 import assert from "assert";
 import { composeRevivers, objectWithBigNumberReviver } from "./ReviverUtils";
-import { getRelayEventKey } from "./SpokeUtils";
+import { getRelayEventKey } from "./DepositUtils";
 import { getCurrentTime } from "./TimeUtils";
 import { isDefined } from "./TypeGuards";
 

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -167,6 +167,35 @@ export function validateFillForDeposit(
 }
 
 /**
+ * Concatenate all fields from a Deposit, Fill or SlowFillRequest into a single string.
+ * This can be used to identify a bridge event in a mapping. This is used instead of the actual keccak256 hash
+ * (getRelayDataHash()) for two reasons: performance and the fact that only Deposit includes the `message` field, which
+ * is required to compute a complete RelayData hash.
+ * note: This function should _not_ be used to query the SpokePool.fillStatuses mapping.
+ */
+export function getRelayEventKey(
+  data: Omit<RelayData, "message"> & { messageHash: string; destinationChainId: number }
+): string {
+  return [
+    data.depositor,
+    data.recipient,
+    data.exclusiveRelayer,
+    data.inputToken,
+    data.outputToken,
+    data.inputAmount,
+    data.outputAmount,
+    data.originChainId,
+    data.destinationChainId,
+    data.depositId,
+    data.fillDeadline,
+    data.exclusivityDeadline,
+    data.messageHash,
+  ]
+    .map(String)
+    .join("-");
+}
+
+/**
  * Returns true if filling this deposit (as a slow or fast fill) or refunding it would not change any state
  * on-chain. The dataworker functions can use this to conveniently filter out useless deposits.
  * @dev The reason we allow a 0-input deposit to have a non-empty message is that the message might be used

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,11 +1,11 @@
 import assert from "assert";
 import { SpokePoolClient } from "../clients";
-import { DEFAULT_CACHING_TTL, EMPTY_MESSAGE, ZERO_BYTES } from "../constants";
-import { CachingMechanismInterface, Deposit, DepositWithBlock, Fill, SlowFillRequest } from "../interfaces";
+import { DEFAULT_CACHING_TTL, EMPTY_MESSAGE, UNDEFINED_MESSAGE_HASH, ZERO_BYTES } from "../constants";
+import { CachingMechanismInterface, Deposit, DepositWithBlock, Fill, RelayData, SlowFillRequest } from "../interfaces";
 import { getNetworkName } from "./NetworkUtils";
 import { bnZero } from "./BigNumberUtils";
 import { getDepositInCache, getDepositKey, setDepositInCache } from "./CachingUtils";
-import { getMessageHash, isUnsafeDepositId, validateFillForDeposit } from "./SpokeUtils";
+import { getMessageHash, isUnsafeDepositId } from "./SpokeUtils";
 import { getCurrentTime } from "./TimeUtils";
 import { isDefined } from "./TypeGuards";
 import { isDepositFormedCorrectly } from "./ValidatorUtils";
@@ -123,6 +123,47 @@ export async function queryHistoricalDepositForFill(
     code: InvalidFill.FillMismatch,
     reason: match.reason,
   };
+}
+
+const RELAYDATA_KEYS = [
+  "depositId",
+  "originChainId",
+  "destinationChainId",
+  "depositor",
+  "recipient",
+  "inputToken",
+  "inputAmount",
+  "outputToken",
+  "outputAmount",
+  "fillDeadline",
+  "exclusivityDeadline",
+  "exclusiveRelayer",
+  "messageHash",
+] as const;
+
+// Ensure that each deposit element is included with the same value in the fill. This includes all elements defined
+// by the depositor as well as destinationToken, which are pulled from other clients.
+export function validateFillForDeposit(
+  relayData: Omit<RelayData, "message"> & { messageHash: string; destinationChainId: number },
+  deposit?: Omit<Deposit, "quoteTimestamp" | "fromLiteChain" | "toLiteChain">
+): { valid: true } | { valid: false; reason: string } {
+  if (deposit === undefined) {
+    return { valid: false, reason: "Deposit is undefined" };
+  }
+
+  // Note: this short circuits when a key is found where the comparison doesn't match.
+  // TODO: if we turn on "strict" in the tsconfig, the elements of FILL_DEPOSIT_COMPARISON_KEYS will be automatically
+  // validated against the fields in Fill and Deposit, generating an error if there is a discrepency.
+  let invalidKey = RELAYDATA_KEYS.find((key) => relayData[key].toString() !== deposit[key].toString());
+
+  // There should be no paths for `messageHash` to be unset, but mask it off anyway.
+  if (!isDefined(invalidKey) && [relayData.messageHash, deposit.messageHash].includes(UNDEFINED_MESSAGE_HASH)) {
+    invalidKey = "messageHash";
+  }
+
+  return isDefined(invalidKey)
+    ? { valid: false, reason: `${invalidKey} mismatch (${relayData[invalidKey]} != ${deposit[invalidKey]})` }
+    : { valid: true };
 }
 
 /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -60,35 +60,6 @@ export function populateV3Relay(
 }
 
 /**
- * Concatenate all fields from a Deposit, Fill or SlowFillRequest into a single string.
- * This can be used to identify a bridge event in a mapping. This is used instead of the actual keccak256 hash
- * (getRelayDataHash()) for two reasons: performance and the fact that only Deposit includes the `message` field, which
- * is required to compute a complete RelayData hash.
- * note: This function should _not_ be used to query the SpokePool.fillStatuses mapping.
- */
-export function getRelayEventKey(
-  data: Omit<RelayData, "message"> & { messageHash: string; destinationChainId: number }
-): string {
-  return [
-    data.depositor,
-    data.recipient,
-    data.exclusiveRelayer,
-    data.inputToken,
-    data.outputToken,
-    data.inputAmount,
-    data.outputAmount,
-    data.originChainId,
-    data.destinationChainId,
-    data.depositId,
-    data.fillDeadline,
-    data.exclusivityDeadline,
-    data.messageHash,
-  ]
-    .map(String)
-    .join("-");
-}
-
-/**
  * Find the block range that contains the deposit ID. This is a binary search that searches for the block range
  * that contains the deposit ID.
  * @param targetDepositId The target deposit ID to search for.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { BytesLike, Contract, PopulatedTransaction, providers, utils as ethersUtils } from "ethers";
-import { CHAIN_IDs, MAX_SAFE_DEPOSIT_ID, UNDEFINED_MESSAGE_HASH, ZERO_ADDRESS, ZERO_BYTES } from "../constants";
+import { CHAIN_IDs, MAX_SAFE_DEPOSIT_ID, ZERO_ADDRESS, ZERO_BYTES } from "../constants";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
 import { chunk } from "./ArrayUtils";
@@ -86,47 +86,6 @@ export function getRelayEventKey(
   ]
     .map(String)
     .join("-");
-}
-
-const RELAYDATA_KEYS = [
-  "depositId",
-  "originChainId",
-  "destinationChainId",
-  "depositor",
-  "recipient",
-  "inputToken",
-  "inputAmount",
-  "outputToken",
-  "outputAmount",
-  "fillDeadline",
-  "exclusivityDeadline",
-  "exclusiveRelayer",
-  "messageHash",
-] as const;
-
-// Ensure that each deposit element is included with the same value in the fill. This includes all elements defined
-// by the depositor as well as destinationToken, which are pulled from other clients.
-export function validateFillForDeposit(
-  relayData: Omit<RelayData, "message"> & { messageHash: string; destinationChainId: number },
-  deposit?: Omit<Deposit, "quoteTimestamp" | "fromLiteChain" | "toLiteChain">
-): { valid: true } | { valid: false; reason: string } {
-  if (deposit === undefined) {
-    return { valid: false, reason: "Deposit is undefined" };
-  }
-
-  // Note: this short circuits when a key is found where the comparison doesn't match.
-  // TODO: if we turn on "strict" in the tsconfig, the elements of FILL_DEPOSIT_COMPARISON_KEYS will be automatically
-  // validated against the fields in Fill and Deposit, generating an error if there is a discrepency.
-  let invalidKey = RELAYDATA_KEYS.find((key) => relayData[key].toString() !== deposit[key].toString());
-
-  // There should be no paths for `messageHash` to be unset, but mask it off anyway.
-  if (!isDefined(invalidKey) && [relayData.messageHash, deposit.messageHash].includes(UNDEFINED_MESSAGE_HASH)) {
-    invalidKey = "messageHash";
-  }
-
-  return isDefined(invalidKey)
-    ? { valid: false, reason: `${invalidKey} mismatch (${relayData[invalidKey]} != ${deposit[invalidKey]})` }
-    : { valid: true };
 }
 
 /**


### PR DESCRIPTION
These function operates solely on a high-level objects (i.e. RelayData + messageHash) and there is no chain-specific implementation. Relocate them to DepositUtils because SpokeUtils will become chain-specific.