### PR TITLE
chore: bump Across constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.29",
+  "version": "4.1.30",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@across-protocol/across-token": "^1.0.0",
-    "@across-protocol/constants": "^3.1.40",
+    "@across-protocol/constants": "^3.1.43",
     "@across-protocol/contracts": "^4.0.4",
     "@coral-xyz/anchor": "^0.30.1",
     "@eth-optimism/sdk": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.40.tgz#c24cf81ba530adf64a11de6ee4f271e1104f26c9"
   integrity sha512-zUljWDsV3iX1zNKPfQzwvtX8SmOxHKwfRkUgYULsUQjSW4QC+vpNMaMJ5gMjr0VInfSu/tOzkKdeC6pRIjZt0w==
 
+"@across-protocol/constants@^3.1.43":
+  version "3.1.43"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.43.tgz#2b02ee19b9cb9eb9856ef51c573d90c6f0266ad3"
+  integrity sha512-WgRCKKgaDCgEkD/ePbf2OT+m83z/Gk/kzGYXM3fsXNMMioBP4vJM+TMZP/l5GRMnkuP0r2zHFMvs2pLg3Pp0NA==
+
 "@across-protocol/contracts@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-0.1.4.tgz#64b3d91e639d2bb120ea94ddef3d160967047fa5"


### PR DESCRIPTION
It seems like we were missing WETH definitions for Lens in the constants version the SDK is using.