### PR TITLE
feat: Establish platform-specific code structure

### DIFF
--- a/src/arch/evm/index.ts
+++ b/src/arch/evm/index.ts
@@ -1,0 +1,1 @@
+export const platform = "evm"; // Placeholder for actual exports.

--- a/src/arch/index.ts
+++ b/src/arch/index.ts
@@ -1,0 +1,2 @@
+export * as evm from "./evm";
+export * as svm from "./svm";

--- a/src/arch/svm/index.ts
+++ b/src/arch/svm/index.ts
@@ -1,0 +1,1 @@
+export const platform = "svm"; // Placeholder for actual exports.


### PR DESCRIPTION
The ambition here is for any chain-specific implementations to reside under src/arch/<arch>. This would include basic functionalities like utilities to retrieve blocks, scrape events, perform historical queries, as well as low-level chain-specific SpokePool functions.

This commit only establishes the structure; follow-on work will start populating it.