### PR TITLE
fix(SpokePoolClient): Use chain time instead of SpokePool time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.30",
+  "version": "4.1.31",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -844,11 +844,11 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
-   * Retrieves the time from the SpokePool contract at a particular block.
+   * Retrieves the SpokePool chain time at a particular block.
    * @returns The time at the specified block tag.
    */
   public getTimeAt(blockNumber: number): Promise<number> {
-    return _getTimeAt(this.spokePool, blockNumber);
+    return _getTimeAt(this.spokePool.provider, blockNumber);
   }
 
   /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -3,7 +3,7 @@ import { BytesLike, Contract, PopulatedTransaction, providers, utils as ethersUt
 import { CHAIN_IDs, MAX_SAFE_DEPOSIT_ID, ZERO_ADDRESS, ZERO_BYTES } from "../constants";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../interfaces";
 import { chunk } from "./ArrayUtils";
-import { bnUint32Max, BigNumber, toBN, bnZero } from "./BigNumberUtils";
+import { BigNumber, toBN, bnZero } from "./BigNumberUtils";
 import { keccak256 } from "./common";
 import { isMessageEmpty } from "./DepositUtils";
 import { isDefined } from "./TypeGuards";
@@ -59,13 +59,12 @@ export function populateV3Relay(
 }
 
 /**
- * Retrieves the time from the SpokePool contract at a particular block.
+ * Retrieves the chain time at a particular block.
  * @returns The time at the specified block tag.
  */
-export async function getTimeAt(spokePool: Contract, blockNumber: number): Promise<number> {
-  const currentTime = await spokePool.getCurrentTime({ blockTag: blockNumber });
-  assert(BigNumber.isBigNumber(currentTime) && currentTime.lt(bnUint32Max));
-  return currentTime.toNumber();
+export async function getTimeAt(provider: providers.Provider, blockNumber: number): Promise<number> {
+  const block = await provider.getBlock(blockNumber);
+  return block.timestamp;
 }
 
 /**


### PR DESCRIPTION
These are 1:1 in production but some quirks in test are causing failures.