### PR TITLE
fix(SpokePoolClient): Revert to two block-to-timestamp methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.31",
+  "version": "4.1.32",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1551,8 +1551,8 @@ export class BundleDataClient {
           // there are no gaps in block timestamps between bundles.
           const endBlockForChain = Math.min(_endBlockForChain + 1, spokePoolClient.latestBlockSearched);
           const [startTime, _endTime] = [
-            await spokePoolClient.getTimeAt(startBlockForChain),
-            await spokePoolClient.getTimeAt(endBlockForChain),
+            await spokePoolClient.getTimestampForBlock(startBlockForChain),
+            await spokePoolClient.getTimestampForBlock(endBlockForChain),
           ];
           // @dev similar to reasoning above to ensure no gaps between bundle block range timestamps and also
           // no overlap, subtract 1 from the end time.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -48,6 +48,7 @@ import {
   findDepositBlock,
   getMaxFillDeadlineInRange as getMaxFillDeadline,
   getTimeAt as _getTimeAt,
+  getTimestampForBlock as _getTimestampForBlock,
   relayFillStatus,
 } from "../utils/SpokeUtils";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
@@ -949,9 +950,8 @@ export class SpokePoolClient extends BaseAbstractClient {
     );
   }
 
-  public async getTimestampForBlock(blockTag: number): Promise<number> {
-    const block = await this.spokePool.provider.getBlock(blockTag);
-    return Number(block.timestamp);
+  public getTimestampForBlock(blockTag: number): Promise<number> {
+    return _getTimestampForBlock(blockTag);
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -951,7 +951,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   public getTimestampForBlock(blockTag: number): Promise<number> {
-    return _getTimestampForBlock(blockTag);
+    return _getTimestampForBlock(this.spokePool.provider, blockTag);
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -844,11 +844,11 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
-   * Retrieves the SpokePool chain time at a particular block.
+   * Retrieves the time from the SpokePool contract at a particular block.
    * @returns The time at the specified block tag.
    */
   public getTimeAt(blockNumber: number): Promise<number> {
-    return _getTimeAt(this.spokePool.provider, blockNumber);
+    return _getTimeAt(this.spokePool, blockNumber);
   }
 
   /**
@@ -947,6 +947,11 @@ export class SpokePoolClient extends BaseAbstractClient {
     return (
       this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false
     );
+  }
+
+  public async getTimestampForBlock(blockTag: number): Promise<number> {
+    const block = await this.spokePool.provider.getBlock(blockTag);
+    return Number(block.timestamp);
   }
 
   /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -3,7 +3,7 @@ import { BytesLike, Contract, PopulatedTransaction, providers, utils as ethersUt
 import { CHAIN_IDs, MAX_SAFE_DEPOSIT_ID, ZERO_ADDRESS, ZERO_BYTES } from "../constants";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../interfaces";
 import { chunk } from "./ArrayUtils";
-import { BigNumber, toBN, bnZero } from "./BigNumberUtils";
+import { bnUint32Max, BigNumber, toBN, bnZero } from "./BigNumberUtils";
 import { keccak256 } from "./common";
 import { isMessageEmpty } from "./DepositUtils";
 import { isDefined } from "./TypeGuards";
@@ -59,12 +59,13 @@ export function populateV3Relay(
 }
 
 /**
- * Retrieves the chain time at a particular block.
+ * Retrieves the time from the SpokePool contract at a particular block.
  * @returns The time at the specified block tag.
  */
-export async function getTimeAt(provider: providers.Provider, blockNumber: number): Promise<number> {
-  const block = await provider.getBlock(blockNumber);
-  return block.timestamp;
+export async function getTimeAt(spokePool: Contract, blockNumber: number): Promise<number> {
+  const currentTime = await spokePool.getCurrentTime({ blockTag: blockNumber });
+  assert(BigNumber.isBigNumber(currentTime) && currentTime.lt(bnUint32Max));
+  return currentTime.toNumber();
 }
 
 /**

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -69,6 +69,16 @@ export async function getTimeAt(spokePool: Contract, blockNumber: number): Promi
 }
 
 /**
+ * Retrieves the chain time at a particular block.
+ * @note This should be the same as getTimeAt() but can differ in test. These two functions should be consolidated.
+ * @returns The chain time at the specified block tag.
+ */
+export async function getTimestampForBlock(provider: providers.Provider, blockNumber: number): Promise<number> {
+  const block = await provider.getBlock(blockNumber);
+  return block.timestamp;
+}
+
+/**
  * Return maximum of fill deadline buffer at start and end of block range.
  * @param spokePool SpokePool contract instance
  * @param startBlock start block


### PR DESCRIPTION
Relayer test has some unfortunate dependencies on _both_ implementations. Back these changes out for now in order to unblock changes in the relayer; we will revisit this.

This reverts commits:
- 4447626182dc381297bab36d4efe2c77be569dcf
- 43965c7ca453787ab528633643c22fcd563ac853