### PR TITLE
improve: allow pool rebalance routes to be removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.36",
+  "version": "4.1.37",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Contract, EventFilter } from "ethers";
 import _ from "lodash";
 import winston from "winston";
-import { DEFAULT_CACHING_SAFE_LAG, DEFAULT_CACHING_TTL } from "../constants";
+import { DEFAULT_CACHING_SAFE_LAG, DEFAULT_CACHING_TTL, ZERO_ADDRESS } from "../constants";
 import {
   CachingMechanismInterface,
   CancelledRootBundle,
@@ -918,21 +918,29 @@ export class HubPoolClient extends BaseAbstractClient {
     if (eventsToQuery.includes("SetPoolRebalanceRoute")) {
       for (const event of events["SetPoolRebalanceRoute"]) {
         const args = spreadEventWithBlockNumber(event) as SetPoolRebalanceRoot;
-        assign(this.l1TokensToDestinationTokens, [args.l1Token, args.destinationChainId], args.destinationToken);
-        assign(
-          this.l1TokensToDestinationTokensWithBlock,
-          [args.l1Token, args.destinationChainId],
-          [
-            {
-              l1Token: args.l1Token,
-              l2Token: args.destinationToken,
-              blockNumber: args.blockNumber,
-              transactionIndex: args.transactionIndex,
-              logIndex: args.logIndex,
-              transactionHash: args.transactionHash,
-            },
-          ]
-        );
+        // If the destination token is set to the zero address in an event, then this means Across should no longer
+        // rebalance to this chain.
+        if (args.destinationToken !== ZERO_ADDRESS) {
+          assign(this.l1TokensToDestinationTokens, [args.l1Token, args.destinationChainId], args.destinationToken);
+          assign(
+            this.l1TokensToDestinationTokensWithBlock,
+            [args.l1Token, args.destinationChainId],
+            [
+              {
+                l1Token: args.l1Token,
+                l2Token: args.destinationToken,
+                blockNumber: args.blockNumber,
+                transactionIndex: args.transactionIndex,
+                logIndex: args.logIndex,
+                transactionHash: args.transactionHash,
+              },
+            ]
+          );
+        } else {
+          // Clear out the mapping for the L1 token entirely.
+          delete this.l1TokensToDestinationTokens[args.l1Token][args.destinationChainId];
+          delete this.l1TokensToDestinationTokensWithBlock[(args.l1Token, args.destinationChainId)];
+        }
       }
     }
 
@@ -953,7 +961,7 @@ export class HubPoolClient extends BaseAbstractClient {
         ),
       ]);
       for (const info of tokenInfo) {
-        if (!this.l1Tokens.find((token) => token.symbol === info.symbol)) {
+        if (!this.l1Tokens.find((token) => token.address === info.address)) {
           if (info.decimals > 0 && info.decimals <= 18) {
             this.l1Tokens.push(info);
           } else {


### PR DESCRIPTION
This PR makes two improvements:
- Every time we observe a `L1TokenEnabledForLiquidityProvision`, we distinguish the token based on its symbol. This is unhelpful for testnet since there are multiple tokens we need to support with the same symbol (e.g. multiple definitions of different `WETH` tokens). We now discriminate these tokens based on their address.
-  Pool rebalance routes could not be set back to `address(0)` since we query `SetPoolRebalanceRoute` events and set `l1TokensToDestinationTokens` the most up-to-date event arguments. Now, if we do observe a `SetPoolRebalanceRoute` where `destinationToken` is `address(0)`, we interpret this as "removing" that pool rebalance route, so we delete the mapping. Note that since these events are sorted, we can still set it to zero and then later reset it to a proper value. This was needed since the Sepolia WETH address for Tatara actually had a defined pool rebalance route for Base (set to the zero address).