### PR TITLE
fix: do not delete historical pool rebalance routes

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -45,7 +45,6 @@ import {
   getUsdcSymbol,
   getL1TokenInfo,
   compareAddressesSimple,
-  deleteFromJson,
 } from "../utils";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "./AcrossConfigStoreClient/AcrossConfigStoreClient";
 import { BaseAbstractClient, isUpdateFailureReason, UpdateFailureReason } from "./BaseAbstractClient";
@@ -938,11 +937,6 @@ export class HubPoolClient extends BaseAbstractClient {
               },
             ]
           );
-        } else {
-          // Clear out the mapping for the L1 token entirely. If there is an empty dict after removing the
-          // destination chain ID mapping, delete the dict.
-          deleteFromJson(this.l1TokensToDestinationTokens, [args.l1Token, args.destinationChainId]);
-          deleteFromJson(this.l1TokensToDestinationTokensWithBlock, [args.l1Token, args.destinationChainId]);
         }
       }
     }


### PR DESCRIPTION
This recent change https://github.com/across-protocol/sdk/pull/953 removes the pool rebalance routes for a given token when they are reset to the zero address. On its own, this is good, but it mistakenly removes the _entire_ mapping (i.e. it also removes all _historical_ pool rebalance routes for that token). This fixes that issue by only appending a pool rebalance route to `this.l1TokensToDestinationTokens*` if it was set to something other than the zero address. 