### PR TITLE
improve(SpokePoolClient): Remove redundant relayFillStatus argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.42",
+  "version": "4.1.43",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -728,8 +728,7 @@ export class BundleDataClient {
         // hasn't queried. This is because this function will usually be called
         // in production with block ranges that were validated by
         // DataworkerUtils.blockRangesAreInvalidForSpokeClients.
-        Math.min(queryBlock, spokePoolClients[deposit.destinationChainId].latestBlockSearched),
-        deposit.destinationChainId
+        Math.min(queryBlock, spokePoolClients[deposit.destinationChainId].latestBlockSearched)
       );
     };
 

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -47,7 +47,7 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
   }
 
-  public override fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<FillStatus> {
+  public override fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<(FillStatus | undefined)[]> {
     return fillStatusArray(this.spokePool, relayData, blockTag);
   }
 

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -47,7 +47,10 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
   }
 
-  public override fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<(FillStatus | undefined)[]> {
+  public override fillStatusArray(
+    relayData: RelayData[],
+    blockTag?: number | "latest"
+  ): Promise<(FillStatus | undefined)[]> {
     return fillStatusArray(this.spokePool, relayData, blockTag);
   }
 

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -1,5 +1,6 @@
 import { Contract, EventFilter } from "ethers";
 import {
+  fillStatusArray,
   findDepositBlock,
   getMaxFillDeadlineInRange as getMaxFillDeadline,
   getTimeAt as _getTimeAt,
@@ -44,6 +45,10 @@ export class EVMSpokePoolClient extends SpokePoolClient {
 
   public override relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus> {
     return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
+  }
+
+  public override fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<FillStatus> {
+    return fillStatusArray(this.spokePool, relayData, blockTag);
   }
 
   public override getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -42,12 +42,8 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     super(logger, hubPoolClient, chainId, deploymentBlock, eventSearchConfig);
   }
 
-  public override relayFillStatus(
-    relayData: RelayData,
-    blockTag?: number | "latest",
-    destinationChainId?: number
-  ): Promise<FillStatus> {
-    return relayFillStatus(this.spokePool, relayData, blockTag, destinationChainId);
+  public override relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus> {
+    return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
   }
 
   public override getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -821,5 +821,8 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
-  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<(FillStatus | undefined)[]>;
+  public abstract fillStatusArray(
+    relayData: RelayData[],
+    blockTag?: number | "latest"
+  ): Promise<(FillStatus | undefined)[]>;
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -814,4 +814,12 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @returns The fill status for the given relay data.
    */
   public abstract relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus>;
+
+  /**
+   * Retrieves the fill status for an array of given relay data.
+   * @param relayData The array relay data to retrieve the fill status for.
+   * @param blockTag The block at which to query the fill status.
+   * @returns The fill status for each of the given relay data.
+   */
+  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<FillStatus>;
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -810,11 +810,8 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   /**
    * Retrieves the fill status for a given relay data.
    * @param relayData The relay data to retrieve the fill status for.
+   * @param blockTag The block at which to query the fill status.
    * @returns The fill status for the given relay data.
    */
-  public abstract relayFillStatus(
-    relayData: RelayData,
-    blockTag?: number | "latest",
-    destinationChainId?: number
-  ): Promise<FillStatus>;
+  public abstract relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus>;
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -821,5 +821,5 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
-  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<FillStatus>;
+  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number | "latest"): Promise<(FillStatus | undefined)[]>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * as arch from "./arch";
 export * as addressAggregator from "./addressAggregator";
 export * as lpFeeCalculator from "./lpFeeCalculator";
 export * as pool from "./pool";


### PR DESCRIPTION
The destinationChainId is implied by the SpokePool being queried, so
remove it as an argument.

While here, add `fillStatusArray` to the set of abstract methods
required by the SpokePoolClient. This is useful down in the relayer.