### PR TITLE
refactor(sdk): transition SVM events client to use blocks instead of slots

### DIFF
--- a/src/svm/eventsClient.ts
+++ b/src/svm/eventsClient.ts
@@ -12,6 +12,7 @@ import web3, {
 import { EventData, EventName, EventWithData } from "./types";
 import { getEventName, parseEventData } from "./utils/events";
 import { isDevnet } from "./utils/helpers";
+import { getSlotForBlock } from "../arch/svm";
 
 // Utility type to extract the return type for the JSON encoding overload. We only care about the overload where the
 // configuration parameter (C) has the optional property 'encoding' set to 'json'.
@@ -65,37 +66,50 @@ export class SvmSpokeEventsClient {
    * Queries events for the SvmSpoke program filtered by event name.
    *
    * @param eventName - The name of the event to filter by.
-   * @param fromSlot - Optional starting slot.
-   * @param toSlot - Optional ending slot.
+   * @param fromBlock - Optional starting block.
+   * @param toBlock - Optional ending block.
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of events matching the eventName.
    */
   public async queryEvents<T extends EventData>(
     eventName: EventName,
-    fromSlot?: bigint,
-    toSlot?: bigint,
+    fromBlock?: bigint,
+    toBlock?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData<T>[]> {
-    const events = await this.queryAllEvents(fromSlot, toSlot, options);
+    const events = await this.queryAllEvents(fromBlock, toBlock, options);
     return events.filter((event) => event.name === eventName) as EventWithData<T>[];
   }
 
   /**
    * Queries all events for a specific program.
    *
-   * @param fromSlot - Optional starting slot.
-   * @param toSlot - Optional ending slot.
+   * @param fromBlock - Optional starting block.
+   * @param toBlock - Optional ending block.
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of all events with additional metadata.
    */
   private async queryAllEvents(
-    fromSlot?: bigint,
-    toSlot?: bigint,
+    fromBlock?: bigint,
+    toBlock?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData<EventData>[]> {
     const allSignatures: GetSignaturesForAddressTransaction[] = [];
     let hasMoreSignatures = true;
     let currentOptions = options;
+
+    let fromSlot: bigint | undefined;
+    let toSlot: bigint | undefined;
+
+    if (fromBlock) {
+      const slot = await getSlotForBlock(this.rpc, fromBlock, BigInt(0));
+      fromSlot = slot;
+    }
+
+    if (toBlock) {
+      const slot = await getSlotForBlock(this.rpc, toBlock, BigInt(0));
+      toSlot = slot;
+    }
 
     while (hasMoreSignatures) {
       const signatures: GetSignaturesForAddressApiResponse = await this.rpc


### PR DESCRIPTION
This commit changes the SVM events client implementation to primarily work with blocks rather than slots, pushing the slot-to-block translation logic upstream. This makes the interface more consistent with other chain implementations and eliminates slot-specific handling throughout the codebase.

By dealing with blocks as the primary unit of reference, we simplify cross-chain compatibility and create a more unified developer experience across all supported chains. The slot-to-block translation now happens in lower-level utils functions, keeping the main client interface clean.