### PR TITLE
improve: allow SVM events client to take in non-spoke IDLs

### DIFF
--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -82,14 +82,14 @@ export class SvmEventsClient {
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of events matching the eventName.
    */
-  public async queryEvents<T extends EventData>(
+  public async queryEvents(
     eventName: EventName,
     fromBlock?: bigint,
     toBlock?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
-  ): Promise<EventWithData<T>[]> {
+  ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromBlock, toBlock, options);
-    return events.filter((event) => event.name === eventName) as EventWithData<T>[];
+    return events.filter((event) => event.name === eventName) as EventWithData[];
   }
 
   /**
@@ -104,7 +104,7 @@ export class SvmEventsClient {
     fromBlock?: bigint,
     toBlock?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
-  ): Promise<EventWithData<EventData>[]> {
+  ): Promise<EventWithData[]> {
     const allSignatures: GetSignaturesForAddressTransaction[] = [];
     let hasMoreSignatures = true;
     let currentOptions = options;
@@ -189,7 +189,7 @@ export class SvmEventsClient {
    */
   private processEventFromTx(
     txResult: GetTransactionReturnType
-  ): { program: Address; data: EventData; name: EventName }[] {
+  ): { program: Address; data: unknown; name: EventName }[] {
     if (!txResult) return [];
     const events: { program: Address; data: EventData; name: EventName }[] = [];
 

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -9,7 +9,7 @@ import web3, {
   Signature,
 } from "@solana/kit";
 import { bs58 } from "../../utils";
-import { EventData, EventName, EventWithData } from "./types";
+import { EventWithData } from "./types";
 import { decodeEvent, isDevnet } from "./utils";
 import { getSlotForBlock } from "./SpokeUtils";
 
@@ -33,7 +33,7 @@ export class SvmEventsClient {
   private rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>;
   private svmAddress: Address;
   private svmEventAuthority: Address;
-  private idl;
+  private idl: Idl;
 
   /**
    * Private constructor. Use the async create() method to instantiate.
@@ -83,13 +83,13 @@ export class SvmEventsClient {
    * @returns A promise that resolves to an array of events matching the eventName.
    */
   public async queryEvents(
-    eventName: EventName,
+    eventName: string,
     fromBlock?: bigint,
     toBlock?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromBlock, toBlock, options);
-    return events.filter((event) => event.name === eventName) as EventWithData[];
+    return events.filter((event) => event.name.toLowerCase() === eventName.toLowerCase()) as EventWithData[];
   }
 
   /**
@@ -187,11 +187,9 @@ export class SvmEventsClient {
    * @param txResult - The transaction result.
    * @returns A promise that resolves to an array of events with their data and name.
    */
-  private processEventFromTx(
-    txResult: GetTransactionReturnType
-  ): { program: Address; data: unknown; name: EventName }[] {
+  private processEventFromTx(txResult: GetTransactionReturnType): { program: Address; data: unknown; name: string }[] {
     if (!txResult) return [];
-    const events: { program: Address; data: EventData; name: EventName }[] = [];
+    const events: { program: Address; data: unknown; name: string }[] = [];
 
     const accountKeys = txResult.transaction.message.accountKeys;
     const messageAccountKeys = [...accountKeys];

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -1,3 +1,4 @@
+import { Idl } from "@coral-xyz/anchor";
 import { getDeployedAddress, SvmSpokeIdl } from "@across-protocol/contracts";
 import { getSolanaChainId } from "@across-protocol/contracts/dist/src/svm/web3-v1";
 import web3, {
@@ -12,9 +13,6 @@ import { bs58 } from "../../utils";
 import { EventWithData } from "./types";
 import { decodeEvent, isDevnet } from "./utils";
 import { getSlotForBlock } from "./SpokeUtils";
-
-// Blanket type definition so that we don't need to import the `Idl` type from anchor directly.
-type Idl = typeof SvmSpokeIdl;
 
 // Utility type to extract the return type for the JSON encoding overload. We only care about the overload where the
 // configuration parameter (C) has the optional property 'encoding' set to 'json'.

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -33,7 +33,7 @@ export class SvmEventsClient {
   private rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>;
   private svmAddress: Address;
   private svmEventAuthority: Address;
-  private customIdl;
+  private idl;
 
   /**
    * Private constructor. Use the async create() method to instantiate.
@@ -42,12 +42,12 @@ export class SvmEventsClient {
     rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>,
     svmSpokeAddress: Address,
     eventAuthority: Address,
-    customIdl: Idl
+    idl: Idl
   ) {
     this.rpc = rpc;
     this.svmAddress = svmSpokeAddress;
     this.svmEventAuthority = eventAuthority;
-    this.customIdl = customIdl;
+    this.idl = idl;
   }
 
   /**
@@ -213,7 +213,7 @@ export class SvmEventsClient {
           const ixData = bs58.decode(ix.data);
           // Skip the first 8 bytes (assumed header) and encode the rest.
           const eventData = Buffer.from(ixData.slice(8)).toString("base64");
-          const { name, data } = decodeEvent(this.customIdl, eventData);
+          const { name, data } = decodeEvent(this.idl, eventData);
           events.push({ program: this.svmAddress, name, data });
         }
       }

--- a/src/arch/svm/types.ts
+++ b/src/arch/svm/types.ts
@@ -36,12 +36,12 @@ export enum SVMEventNames {
 
 export type EventName = keyof typeof SVMEventNames;
 
-export type EventWithData<T extends EventData> = {
+export type EventWithData = {
   confirmationStatus: string | null;
   blockTime: UnixTimestamp | null;
   signature: Signature;
   slot: bigint;
   name: EventName;
-  data: T;
+  data: unknown;
   program: Address;
 };

--- a/src/arch/svm/types.ts
+++ b/src/arch/svm/types.ts
@@ -1,21 +1,4 @@
 import { Signature, Address, UnixTimestamp } from "@solana/kit";
-import { SvmSpokeClient } from "@across-protocol/contracts";
-
-export type EventData =
-  | SvmSpokeClient.BridgedToHubPool
-  | SvmSpokeClient.TokensBridged
-  | SvmSpokeClient.ExecutedRelayerRefundRoot
-  | SvmSpokeClient.RelayedRootBundle
-  | SvmSpokeClient.PausedDeposits
-  | SvmSpokeClient.PausedFills
-  | SvmSpokeClient.SetXDomainAdmin
-  | SvmSpokeClient.EnabledDepositRoute
-  | SvmSpokeClient.FilledRelay
-  | SvmSpokeClient.FundsDeposited
-  | SvmSpokeClient.EmergencyDeletedRootBundle
-  | SvmSpokeClient.RequestedSlowFill
-  | SvmSpokeClient.ClaimedRelayerRefund
-  | SvmSpokeClient.TransferredOwnership;
 
 export enum SVMEventNames {
   FilledRelay = "FilledRelay",
@@ -41,7 +24,7 @@ export type EventWithData = {
   blockTime: UnixTimestamp | null;
   signature: Signature;
   slot: bigint;
-  name: EventName;
+  name: string;
   data: unknown;
   program: Address;
 };

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -40,7 +40,7 @@ export function parseEventData(eventData: any): any {
 /**
  * Decodes a raw event according to a supplied IDL.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: Record<string, unknown>; name: string } {
+export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
   const event = new BorshEventCoder(idl).decode(rawEvent);
   if (!event) throw new Error(`Malformed rawEvent for IDL ${idl.address}: ${rawEvent}`);
   return {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,6 +1,5 @@
 import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
 import web3, { address, RpcTransport } from "@solana/kit";
-import { EventName, EventData, SVMEventNames } from "./types";
 
 /**
  * Helper to determine if the current RPC network is devnet.
@@ -41,11 +40,11 @@ export function parseEventData(eventData: any): any {
 /**
  * Decodes a raw event according to a supplied IDL.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name: EventName } {
+export function decodeEvent(idl: Idl, rawEvent: string): { data: Record<string, unknown>; name: string } {
   const event = new BorshEventCoder(idl).decode(rawEvent);
   if (!event) throw new Error(`Malformed rawEvent for IDL ${idl.address}: ${rawEvent}`);
   return {
-    name: getEventName(event.name),
+    name: event.name,
     data: parseEventData(event.data),
   };
 }
@@ -55,12 +54,4 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
  */
 function snakeToCamel(s: string): string {
   return s.replace(/(_\w)/g, (match) => match[1].toUpperCase());
-}
-
-/**
- * Gets the event name from a raw name.
- */
-export function getEventName(rawName: string): EventName {
-  if (Object.values(SVMEventNames).some((name) => rawName.includes(name))) return rawName as EventName;
-  throw new Error(`Unknown event name: ${rawName}`);
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
 import { Rpc, SolanaRpcApiFromTransport, RpcTransport } from "@solana/kit";
 import { BigNumber, DepositSearchResult, EventSearchConfig, MakeOptional } from "../../utils";
-import { SvmSpokeEventsClient, SVMEventNames } from "../../arch/svm";
+import { SvmEventsClient, SVMEventNames } from "../../arch/svm";
 import { HubPoolClient } from "../HubPoolClient";
 import { knownEventNames, SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
 import { RelayData, FillStatus } from "../../interfaces";
@@ -19,7 +19,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
     chainId: number,
     deploymentSlot: bigint, // Using slot instead of block number for SVM
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock">,
-    protected svmEventsClient: SvmSpokeEventsClient,
+    protected svmEventsClient: SvmEventsClient,
     protected rpc: Rpc<SolanaRpcApiFromTransport<RpcTransport>>
   ) {
     // Convert deploymentSlot to number for base class, might need refinement
@@ -37,7 +37,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }, // Provide default
     rpc: Rpc<SolanaRpcApiFromTransport<RpcTransport>>
   ): Promise<SvmSpokePoolClient> {
-    const svmEventsClient = await SvmSpokeEventsClient.create(rpc);
+    const svmEventsClient = await SvmEventsClient.create(rpc);
     return new SvmSpokePoolClient(
       logger,
       hubPoolClient,

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
 import { Rpc, SolanaRpcApiFromTransport, RpcTransport } from "@solana/kit";
 import { BigNumber, DepositSearchResult, EventSearchConfig, MakeOptional } from "../../utils";
-import { SvmEventsClient, SVMEventNames } from "../../arch/svm";
+import { SvmCpiEventsClient, SVMEventNames } from "../../arch/svm";
 import { HubPoolClient } from "../HubPoolClient";
 import { knownEventNames, SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
 import { RelayData, FillStatus } from "../../interfaces";
@@ -19,7 +19,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
     chainId: number,
     deploymentSlot: bigint, // Using slot instead of block number for SVM
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock">,
-    protected svmEventsClient: SvmEventsClient,
+    protected svmEventsClient: SvmCpiEventsClient,
     protected rpc: Rpc<SolanaRpcApiFromTransport<RpcTransport>>
   ) {
     // Convert deploymentSlot to number for base class, might need refinement
@@ -37,7 +37,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }, // Provide default
     rpc: Rpc<SolanaRpcApiFromTransport<RpcTransport>>
   ): Promise<SvmSpokePoolClient> {
-    const svmEventsClient = await SvmEventsClient.create(rpc);
+    const svmEventsClient = await SvmCpiEventsClient.create(rpc);
     return new SvmSpokePoolClient(
       logger,
       hubPoolClient,


### PR DESCRIPTION
The events client basically serves as an SVM `paginatedEventQuery`, which is sometimes used in the bots (e.g. the rebalancer/finalizer). I would like to generalize this class a bit so that it can be used for contracts beyond just the SvmSpoke.