### PR TITLE
fix: Remove fromLiteChain from Fill object published to Arweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.45",
+  "version": "4.1.46",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -70,17 +70,21 @@ export async function verifyFillRepayment(
   hubPoolClient: HubPoolClient,
   bundleEndBlockForMainnet: number
 ): Promise<FillWithBlock | undefined> {
-  const fill = {
-    ..._.cloneDeep(_fill),
-    fromLiteChain: matchedDeposit.fromLiteChain,
-  };
+  const fill = _.cloneDeep(_fill);
 
   // Slow fills don't result in repayments so they're always valid.
   if (isSlowFill(fill)) {
     return fill;
   }
 
-  let repaymentChainId = _getRepaymentChainId(fill, hubPoolClient, bundleEndBlockForMainnet);
+  let repaymentChainId = _getRepaymentChainId(
+    {
+      ...fill,
+      fromLiteChain: matchedDeposit.fromLiteChain,
+    },
+    hubPoolClient,
+    bundleEndBlockForMainnet
+  );
 
   // Repayments will always go to the fill.relayer address so check if its a valid EVM address. If its not, attempt
   // to change it to the msg.sender of the FilledRelay.


### PR DESCRIPTION
Made a mistake in 758b83ce2b2efc92e4df37a28baf754ee58f23fc that accidentally added the `fromLiteChain` property to Fills published to Arweave, which is causing Dataworker to be unable to parse the Arweave data
