### PR TITLE
improve(svmEventsClient): enable pda events querying

### DIFF
--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -32,6 +32,7 @@ export class SvmCpiEventsClient {
   private programAddress: Address;
   private programEventAuthority: Address;
   private idl: Idl;
+  private derivedAddress?: Address;
 
   /**
    * Private constructor. Use the async create() method to instantiate.
@@ -40,12 +41,14 @@ export class SvmCpiEventsClient {
     rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>,
     address: Address,
     eventAuthority: Address,
-    idl: Idl
+    idl: Idl,
+    derivedAddress?: Address
   ) {
     this.rpc = rpc;
     this.programAddress = address;
     this.programEventAuthority = eventAuthority;
     this.idl = idl;
+    this.derivedAddress = derivedAddress;
   }
 
   /**
@@ -61,14 +64,16 @@ export class SvmCpiEventsClient {
   public static async createFor(
     rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>,
     programId: string,
-    idl: Idl
+    idl: Idl,
+    pda?: string
   ): Promise<SvmCpiEventsClient> {
     const address = web3.address(programId);
+    const derivedAddress = pda ? web3.address(pda) : undefined;
     const [eventAuthority] = await web3.getProgramDerivedAddress({
       programAddress: address,
       seeds: ["__event_authority"],
     });
-    return new SvmCpiEventsClient(rpc, address, eventAuthority, idl);
+    return new SvmCpiEventsClient(rpc, address, eventAuthority, idl, derivedAddress);
   }
 
   /**
@@ -91,17 +96,38 @@ export class SvmCpiEventsClient {
   }
 
   /**
+   * Queries events for the provided derived address at instantiation filtered by event name.
+   *
+   * @param eventName - The name of the event to filter by.
+   * @param fromBlock - Optional starting block.
+   * @param toBlock - Optional ending block.
+   * @param options - Options for fetching signatures.
+   * @returns A promise that resolves to an array of events matching the eventName.
+   */
+  public async queryDerivedAddressEvents(
+    eventName: string,
+    fromBlock?: bigint,
+    toBlock?: bigint,
+    options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
+  ): Promise<EventWithData[]> {
+    const events = await this.queryAllEvents(fromBlock, toBlock, options, true);
+    return events.filter((event) => event.name === eventName) as EventWithData[];
+  }
+
+  /**
    * Queries all events for a specific program.
    *
    * @param fromBlock - Optional starting block.
    * @param toBlock - Optional ending block.
    * @param options - Options for fetching signatures.
+   * @param forDerivedAddress - Whether to query events for the program or the derived address.
    * @returns A promise that resolves to an array of all events with additional metadata.
    */
   private async queryAllEvents(
     fromBlock?: bigint,
     toBlock?: bigint,
-    options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
+    options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" },
+    forDerivedAddress: boolean = false
   ): Promise<EventWithData[]> {
     const allSignatures: GetSignaturesForAddressTransaction[] = [];
     let hasMoreSignatures = true;
@@ -109,6 +135,11 @@ export class SvmCpiEventsClient {
 
     let fromSlot: bigint | undefined;
     let toSlot: bigint | undefined;
+
+    if (forDerivedAddress && !this.derivedAddress) {
+      throw new Error("Unable to query PDA events. Derived address not set.");
+    }
+    const addressToQuery = forDerivedAddress ? this.derivedAddress : this.programAddress;
 
     if (fromBlock) {
       const slot = await getSlotForBlock(this.rpc, fromBlock, BigInt(0));
@@ -122,7 +153,7 @@ export class SvmCpiEventsClient {
 
     while (hasMoreSignatures) {
       const signatures: GetSignaturesForAddressApiResponse = await this.rpc
-        .getSignaturesForAddress(this.programAddress, currentOptions)
+        .getSignaturesForAddress(addressToQuery!, currentOptions)
         .send();
       // Signatures are sorted by slot in descending order.
       allSignatures.push(...signatures);


### PR DESCRIPTION
This PR adds support for querying events associated with PDAs in the SvmCpiEventsClient. 

When querying events from a PDA, there are two considerations:
1. The event authority is still derived from the program address, not from the PDA.
2. While we query transaction history by the PDA address, we still need to filter the events that were executed by the program address.

To support this, this PR:
- Adds an optional `pda` parameter to `createFor` method
- Introduces a `queryDerivedAddressEvents` method to specifically query PDA events
- Modifies event filtering logic to handle both program and PDA-specific queries