### PR TITLE
feat(SvmSpokePoolClient): relayFillStatus and fillStatusArray implementation

### DIFF
--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -160,7 +160,7 @@ export async function findDepositBlock(
 export async function relayFillStatus(
   spokePool: Contract,
   relayData: RelayData,
-  blockTag?: number | "latest",
+  blockTag: BlockTag = "latest",
   destinationChainId?: number
 ): Promise<FillStatus> {
   destinationChainId ??= await spokePool.chainId();

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -87,11 +87,7 @@ export function findDepositBlock(
 /**
  * Resolves the fill status of a deposit at a specific slot or at the current confirmed one.
  *
- * If no slot is provided, the function first tries to fetch the status from the fill status PDA.
- * - If the PDA exists, it reads the status directly.
- * - If the PDA is missing and the deposit's fill deadline has not passed, the deposit is considered unfilled.
- *
- * If a specific slot is requested, or if the PDA is unavailable, the status is reconstructed from PDA events.
+ * If no slot is provided, attempts to solve the fill status using the PDA. Otherwise, it is reconstructed from PDA events.
  *
  * @param programId - The spoke pool program ID.
  * @param relayData - Deposit information used to locate the fill status.
@@ -137,9 +133,8 @@ export async function relayFillStatus(
 }
 
 /**
- * Resolves the fill status of an array of deposits at the requested slot or at the current confirmed one.
- * For current slot queries, first tries to fetch statuses using the PDAs.
- * When PDAs are unavailable, or for specific slot queries, it reconstructs status using PDA events.
+ * Resolves fill statuses for multiple deposits at a specific slot or current confirmed slot.
+ * Uses PDAs for current slot queries, falls back to event reconstruction when needed.
  *
  * @param programId The spoke pool program ID.
  * @param relayData An array of relay data to resolve fill statuses for.

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { Logger } from "winston";
 import { Rpc, SolanaRpcApi, Address, fetchEncodedAccounts, fetchEncodedAccount } from "@solana/kit";
 import { fetchState, decodeFillStatusAccount } from "@across-protocol/contracts/dist/src/svm/clients/SvmSpoke";
 
@@ -153,7 +154,8 @@ export async function fillStatusArray(
   destinationChainId: number,
   provider: Provider,
   svmEventsClient: SvmCpiEventsClient,
-  atHeight?: number
+  atHeight?: number,
+  logger?: Logger
 ): Promise<(FillStatus | undefined)[]> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
 
@@ -169,11 +171,12 @@ export async function fillStatusArray(
     )
   ).flat();
 
-  if (atHeight !== undefined) {
-    console.warn(
-      "fillStatusArray: Querying specific slots for large arrays is slow. " +
-        "For current status, omit 'atHeight' param to use latest confirmed slot instead."
-    );
+  if (atHeight !== undefined && logger) {
+    logger.warn({
+      at: "SvmSpokeUtils#fillStatusArray",
+      message:
+        "Querying specific slots for large arrays is slow. For current status, omit 'atHeight' param to use latest confirmed slot instead.",
+    });
   }
 
   // If no specific slot is requested, try fetching current statuses from PDAs

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -95,10 +95,10 @@ export function findDepositBlock(
 export async function relayFillStatus(
   programId: Address,
   relayData: RelayData,
-  blockTag: number | "confirmed" = "confirmed",
   destinationChainId: number,
   provider: Provider,
-  svmEventsClient: SvmCpiEventsClient
+  svmEventsClient: SvmCpiEventsClient,
+  blockTag?: number
 ): Promise<FillStatus> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
 
@@ -107,7 +107,7 @@ export async function relayFillStatus(
 
   // Set search range
   let toSlot: bigint;
-  if (blockTag === "confirmed") {
+  if (!blockTag) {
     toSlot = await provider.getSlot({ commitment: "confirmed" }).send();
   } else {
     toSlot = BigInt(blockTag);
@@ -148,10 +148,10 @@ export async function relayFillStatus(
 export async function fillStatusArray(
   programId: Address,
   relayData: RelayData[],
-  blockTag: number | "confirmed" = "confirmed",
   destinationChainId: number,
   provider: Provider,
-  svmEventsClient: SvmCpiEventsClient
+  svmEventsClient: SvmCpiEventsClient,
+  blockTag?: number
 ): Promise<(FillStatus | undefined)[]> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
   const chunkSize = 2;
@@ -160,7 +160,7 @@ export async function fillStatusArray(
   for (const chunk of chunkedRelayData) {
     const chunkResults = await Promise.all(
       chunk.map((relayData) =>
-        relayFillStatus(programId, relayData, blockTag, destinationChainId, provider, svmEventsClient)
+        relayFillStatus(programId, relayData, destinationChainId, provider, svmEventsClient, blockTag)
       )
     );
     results.push(...chunkResults);

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -4,7 +4,7 @@ import { fetchState, decodeFillStatusAccount } from "@across-protocol/contracts/
 
 import { SvmCpiEventsClient } from "./eventsClient";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../../interfaces";
-import { BigNumber, chainIsSvm, chunk, getCurrentTime, isUnsafeDepositId } from "../../utils";
+import { BigNumber, chainIsSvm, chunk, isUnsafeDepositId } from "../../utils";
 import { getFillStatusPda } from "./utils";
 import { SVMEventNames } from "./types";
 
@@ -109,11 +109,14 @@ export async function relayFillStatus(
 
   // Get fill status PDA using relayData
   const fillStatusPda = await getFillStatusPda(programId, relayData, destinationChainId);
+  const currentSlot = await provider.getSlot({ commitment: "confirmed" }).send();
 
   // If no specific slot is requested, try fetching the current status from the PDA
   if (atHeight === undefined) {
-    const fillStatusAccount = await fetchEncodedAccount(provider, fillStatusPda, { commitment: "confirmed" });
-
+    const [fillStatusAccount, currentSlotTimestamp] = await Promise.all([
+      fetchEncodedAccount(provider, fillStatusPda, { commitment: "confirmed" }),
+      provider.getBlockTime(currentSlot).send(),
+    ]);
     // If the PDA exists, return the stored fill status
     if (fillStatusAccount.exists) {
       const decodedAccountData = decodeFillStatusAccount(fillStatusAccount);
@@ -121,13 +124,13 @@ export async function relayFillStatus(
     }
     // If the PDA doesn't exist and the deadline hasn't passed yet, the deposit must be unfilled,
     // since PDAs can't be closed before the fill deadline.
-    else if (getCurrentTime() < relayData.fillDeadline) {
+    else if (Number(currentSlotTimestamp) < relayData.fillDeadline) {
       return FillStatus.Unfilled;
     }
   }
 
   // If status couldn't be determined from the PDA, or if a specific slot was requested, reconstruct the status from events
-  const toSlot = atHeight ? BigInt(atHeight) : await provider.getSlot({ commitment: "confirmed" }).send();
+  const toSlot = atHeight ? BigInt(atHeight) : currentSlot;
 
   return resolveFillStatusFromPdaEvents(fillStatusPda, toSlot, svmEventsClient);
 }
@@ -301,15 +304,18 @@ async function fetchBatchFillStatusFromPdaAccounts(
   relayDataArray: RelayData[]
 ): Promise<(FillStatus | undefined)[]> {
   const chunkSize = 100; // SVM method getMultipleAccounts allows a max of 100 addresses per request
-  const pdaAccounts = (
-    await Promise.all(
+  const currentSlot = await provider.getSlot({ commitment: "confirmed" }).send();
+
+  const [pdaAccounts, currentSlotTimestamp] = await Promise.all([
+    Promise.all(
       chunk(fillStatusPdas, chunkSize).map((chunk) =>
         fetchEncodedAccounts(provider, chunk, { commitment: "confirmed" })
       )
-    )
-  ).flat();
+    ),
+    provider.getBlockTime(currentSlot).send(),
+  ]);
 
-  const fillStatuses = pdaAccounts.map((account, index) => {
+  const fillStatuses = pdaAccounts.flat().map((account, index) => {
     // If the PDA exists, we can fetch the status directly.
     if (account.exists) {
       const decodedAccount = decodeFillStatusAccount(account);
@@ -317,7 +323,7 @@ async function fetchBatchFillStatusFromPdaAccounts(
     }
     // If the PDA doesn't exist and the deadline hasn't passed yet, the deposit must be unfilled,
     // since PDAs can't be closed before the fill deadline.
-    else if (getCurrentTime() < relayDataArray[index].fillDeadline) {
+    else if (Number(currentSlotTimestamp) < relayDataArray[index].fillDeadline) {
       return FillStatus.Unfilled;
     }
     // If the PDA doesn't exist and the fill deadline has passed, then the status can't be determined and is set to undefined.

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -133,8 +133,8 @@ export async function relayFillStatus(
 }
 
 /**
- * Resolves fill statuses for multiple deposits at a specific slot or current confirmed slot.
- * Uses PDAs for current slot queries, falls back to event reconstruction when needed.
+ * Resolves fill statuses for multiple deposits at a specific or latest confirmed slot,
+ * using PDAs when possible and falling back to events if needed.
  *
  * @param programId The spoke pool program ID.
  * @param relayData An array of relay data to resolve fill statuses for.
@@ -165,6 +165,13 @@ export async function fillStatusArray(
       )
     )
   ).flat();
+
+  if (atHeight !== undefined) {
+    console.warn(
+      "fillStatusArray: Querying specific slots for large arrays is slow. " +
+        "For current status, omit 'atHeight' param to use latest confirmed slot instead."
+    );
+  }
 
   // If no specific slot is requested, try fetching current statuses from PDAs
   // Otherwise, initialize all statuses as undefined

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -196,7 +196,6 @@ export async function fillStatusArray(
   // @note: This path is mostly used for deposits past their fill deadline.
   // If it becomes a bottleneck, consider returning an "Unknown" status that can be handled downstream.
   for (const chunk of missingChunked) {
-    const start = performance.now();
     const chunkResults = await Promise.all(
       chunk.map(async (missingIndex) => {
         return {
@@ -206,8 +205,6 @@ export async function fillStatusArray(
       })
     );
     missingResults.push(...chunkResults);
-    const end = performance.now();
-    console.log(`Processing ${chunk.length} deposits took ${end - start}ms`);
   }
 
   // Fill in missing statuses back to the result array

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
-import { Rpc, SolanaRpcApi, Address } from "@solana/kit";
-import { fetchState } from "@across-protocol/contracts/dist/src/svm/clients/SvmSpoke";
+import { Rpc, SolanaRpcApi, Address, fetchEncodedAccounts, fetchEncodedAccount } from "@solana/kit";
+import { fetchState, decodeFillStatusAccount } from "@across-protocol/contracts/dist/src/svm/clients/SvmSpoke";
 
 import { SvmCpiEventsClient } from "./eventsClient";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../../interfaces";
-import { BigNumber, chainIsSvm, chunk, isUnsafeDepositId } from "../../utils";
+import { BigNumber, chainIsSvm, chunk, getCurrentTime, isUnsafeDepositId } from "../../utils";
 import { getFillStatusPda } from "./utils";
 import { SVMEventNames } from "./types";
 
@@ -85,12 +85,21 @@ export function findDepositBlock(
 }
 
 /**
- * Find the fill status for a deposit at a particular block.
- * @param spokePool SpokePool contract instance.
- * @param relayData Deposit information that is used to complete a fill.
- * @param fromSlot Slot to start the search at.
- * @param blockTag Slot (numeric or "confirmed") to query at.
- * @returns The fill status for the specified deposit at the requested slot (or at the current confirmed slot).
+ * Resolves the fill status of a deposit at a specific slot or at the current confirmed one.
+ *
+ * If no slot is provided, the function first tries to fetch the status from the fill status PDA.
+ * - If the PDA exists, it reads the status directly.
+ * - If the PDA is missing and the deposit's fill deadline has not passed, the deposit is considered unfilled.
+ *
+ * If a specific slot is requested, or if the PDA is unavailable, the status is reconstructed from PDA events.
+ *
+ * @param programId - The spoke pool program ID.
+ * @param relayData - Deposit information used to locate the fill status.
+ * @param destinationChainId - Destination chain ID (must be an SVM chain).
+ * @param provider - SVM provider instance.
+ * @param svmEventsClient - SVM events client for querying events.
+ * @param atHeight - (Optional) Specific slot number to query. Defaults to the latest confirmed slot.
+ * @returns The fill status for the deposit at the specified or current slot.
  */
 export async function relayFillStatus(
   programId: Address,
@@ -98,74 +107,115 @@ export async function relayFillStatus(
   destinationChainId: number,
   provider: Provider,
   svmEventsClient: SvmCpiEventsClient,
-  blockTag?: number
+  atHeight?: number
 ): Promise<FillStatus> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
 
   // Get fill status PDA using relayData
   const fillStatusPda = await getFillStatusPda(programId, relayData, destinationChainId);
 
-  // Set search range
-  let toSlot: bigint;
-  if (!blockTag) {
-    toSlot = await provider.getSlot({ commitment: "confirmed" }).send();
-  } else {
-    toSlot = BigInt(blockTag);
+  // If no specific slot is requested, try fetching the current status from the PDA
+  if (atHeight === undefined) {
+    const fillStatusAccount = await fetchEncodedAccount(provider, fillStatusPda, { commitment: "confirmed" });
+
+    // If the PDA exists, return the stored fill status
+    if (fillStatusAccount.exists) {
+      const decodedAccountData = decodeFillStatusAccount(fillStatusAccount);
+      return decodedAccountData.data.status;
+    }
+    // If the PDA doesn't exist and the deadline hasn't passed yet, the deposit must be unfilled,
+    // since PDAs can't be closed before the fill deadline.
+    else if (getCurrentTime() < relayData.fillDeadline) {
+      return FillStatus.Unfilled;
+    }
   }
 
-  // Get fill and requested slow fill events from fillStatusPda
-  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill];
-  const relevantEvents = (
-    await Promise.all(
-      eventsToQuery.map((eventName) =>
-        svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, undefined, toSlot, { limit: 50 })
-      )
-    )
-  ).flat();
+  // If status couldn't be determined from the PDA, or if a specific slot was requested, reconstruct the status from events
+  const toSlot = atHeight ? BigInt(atHeight) : await provider.getSlot({ commitment: "confirmed" }).send();
 
-  if (relevantEvents.length === 0) {
-    // No fill or requested slow fill events found for this fill status PDA
-    return FillStatus.Unfilled;
-  }
-
-  // Sort events in ascending order of slot number
-  relevantEvents.sort((a, b) => Number(a.slot - b.slot));
-
-  // At this point we have an ordered array of fill and requested slow fill events and since it's not possible to
-  // submit a slow fill request once a fill has been submitted, we can use the last event in the sorted list to
-  // determine the fill status at the requested block.
-  const fillStatusEvent = relevantEvents.pop();
-  switch (fillStatusEvent!.name) {
-    case SVMEventNames.FilledRelay:
-      return FillStatus.Filled;
-    case SVMEventNames.RequestedSlowFill:
-      return FillStatus.RequestedSlowFill;
-    default:
-      throw new Error(`Unexpected event name: ${fillStatusEvent!.name}`);
-  }
+  return resolveFillStatusFromPdaEvents(fillStatusPda, toSlot, svmEventsClient);
 }
 
+/**
+ * Resolves the fill status of an array of deposits at the requested slot or at the current confirmed one.
+ * For current slot queries, first tries to fetch statuses using the PDAs.
+ * When PDAs are unavailable, or for specific slot queries, it reconstructs status using PDA events.
+ *
+ * @param programId The spoke pool program ID.
+ * @param relayData An array of relay data to resolve fill statuses for.
+ * @param destinationChainId The destination chain ID (must be an SVM chain).
+ * @param provider SVM Provider instance.
+ * @param svmEventsClient SVM events client instance for querying events.
+ * @param atHeight (Optional) The slot number to query at. If omitted, queries the latest confirmed slot.
+ * @returns An array of fill statuses for the specified deposits at the requested slot (or at the current confirmed slot).
+ */
 export async function fillStatusArray(
   programId: Address,
   relayData: RelayData[],
   destinationChainId: number,
   provider: Provider,
   svmEventsClient: SvmCpiEventsClient,
-  blockTag?: number
+  atHeight?: number
 ): Promise<(FillStatus | undefined)[]> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
-  const chunkSize = 2;
+
+  const chunkSize = 100;
   const chunkedRelayData = chunk(relayData, chunkSize);
-  const results = [];
-  for (const chunk of chunkedRelayData) {
-    const chunkResults = await Promise.all(
-      chunk.map((relayData) =>
-        relayFillStatus(programId, relayData, destinationChainId, provider, svmEventsClient, blockTag)
+
+  // Get all PDAs
+  const fillStatusPdas = (
+    await Promise.all(
+      chunkedRelayData.map((relayDataChunk) =>
+        Promise.all(relayDataChunk.map((relayData) => getFillStatusPda(programId, relayData, destinationChainId)))
       )
+    )
+  ).flat();
+
+  // If no specific slot is requested, try fetching current statuses from PDAs
+  // Otherwise, initialize all statuses as undefined
+  const fillStatuses: (FillStatus | undefined)[] =
+    atHeight === undefined
+      ? await fetchBatchFillStatusFromPdaAccounts(provider, fillStatusPdas, relayData)
+      : new Array(relayData.length).fill(undefined);
+
+  // Collect indices of deposits that still need their status resolved
+  const missingStatuses = fillStatuses.reduce<number[]>((acc, status, index) => {
+    if (status === undefined) {
+      acc.push(index);
+    }
+    return acc;
+  }, []);
+
+  // Chunk the missing deposits for batch processing
+  const missingChunked = chunk(missingStatuses, chunkSize);
+  const missingResults: { index: number; fillStatus: FillStatus }[] = [];
+
+  // Determine the toSlot to use for event reconstruction
+  const toSlot = atHeight ? BigInt(atHeight) : await provider.getSlot({ commitment: "confirmed" }).send();
+
+  // @note: This path is mostly used for deposits past their fill deadline.
+  // If it becomes a bottleneck, consider returning an "Unknown" status that can be handled downstream.
+  for (const chunk of missingChunked) {
+    const start = performance.now();
+    const chunkResults = await Promise.all(
+      chunk.map(async (missingIndex) => {
+        return {
+          index: missingIndex,
+          fillStatus: await resolveFillStatusFromPdaEvents(fillStatusPdas[missingIndex], toSlot, svmEventsClient),
+        };
+      })
     );
-    results.push(...chunkResults);
+    missingResults.push(...chunkResults);
+    const end = performance.now();
+    console.log(`Processing ${chunk.length} deposits took ${end - start}ms`);
   }
-  return results.flat();
+
+  // Fill in missing statuses back to the result array
+  missingResults.forEach(({ index, fillStatus }) => {
+    fillStatuses[index] = fillStatus;
+  });
+
+  return fillStatuses;
 }
 
 /**
@@ -193,4 +243,87 @@ export function findFillEvent(
   _highBlockNumber?: number
 ): Promise<FillWithBlock | undefined> {
   throw new Error("fillStatusArray: not implemented");
+}
+
+async function resolveFillStatusFromPdaEvents(
+  fillStatusPda: Address,
+  toSlot: bigint,
+  svmEventsClient: SvmCpiEventsClient
+): Promise<FillStatus> {
+  // Get fill and requested slow fill events from fillStatus PDA
+  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill];
+  const relevantEvents = (
+    await Promise.all(
+      eventsToQuery.map((eventName) =>
+        // PDAs should have only a few events, requesting up to 10 should be enough.
+        svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, undefined, toSlot, { limit: 10 })
+      )
+    )
+  ).flat();
+
+  if (relevantEvents.length === 0) {
+    // No fill or requested slow fill events found for this PDA
+    return FillStatus.Unfilled;
+  }
+
+  // Sort events in ascending order of slot number
+  relevantEvents.sort((a, b) => Number(a.slot - b.slot));
+
+  // At this point we have an ordered array of only fill and requested slow fill events and
+  // since it's not possible to submit a slow fill request once a fill has been submitted,
+  // we can use the last event in the list to determine the fill status at the requested slot.
+  const fillStatusEvent = relevantEvents.pop();
+  switch (fillStatusEvent!.name) {
+    case SVMEventNames.FilledRelay:
+      return FillStatus.Filled;
+    case SVMEventNames.RequestedSlowFill:
+      return FillStatus.RequestedSlowFill;
+    default:
+      throw new Error(`Unexpected event name: ${fillStatusEvent!.name}`);
+  }
+}
+
+/**
+ * Attempts to resolve the fill status for an array of deposits by reading their fillStatus PDAs.
+ *
+ * - If a PDA exists, the status is read directly from it.
+ * - If the PDA does not exist but the deposit's fill deadline has not passed, the deposit is considered unfilled.
+ * - If the PDA does not exist and the fill deadline has passed, the status cannot be determined and is set to undefined.
+ *
+ * Assumes PDAs can only be closed after the fill deadline expires.
+ *
+ * @param provider SVM provider instance
+ * @param fillStatusPdas An array of fill status PDAs to retrieve the fill status for.
+ * @param relayData An array of relay data from which the fill status PDAs were derived.
+ */
+async function fetchBatchFillStatusFromPdaAccounts(
+  provider: Provider,
+  fillStatusPdas: Address[],
+  relayDataArray: RelayData[]
+): Promise<(FillStatus | undefined)[]> {
+  const chunkSize = 100; // SVM method getMultipleAccounts allows a max of 100 addresses per request
+  const pdaAccounts = (
+    await Promise.all(
+      chunk(fillStatusPdas, chunkSize).map((chunk) =>
+        fetchEncodedAccounts(provider, chunk, { commitment: "confirmed" })
+      )
+    )
+  ).flat();
+
+  const fillStatuses = pdaAccounts.map((account, index) => {
+    // If the PDA exists, we can fetch the status directly.
+    if (account.exists) {
+      const decodedAccount = decodeFillStatusAccount(account);
+      return decodedAccount.data.status;
+    }
+    // If the PDA doesn't exist and the deadline hasn't passed yet, the deposit must be unfilled,
+    // since PDAs can't be closed before the fill deadline.
+    else if (getCurrentTime() < relayDataArray[index].fillDeadline) {
+      return FillStatus.Unfilled;
+    }
+    // If the PDA doesn't exist and the fill deadline has passed, then the status can't be determined and is set to undefined.
+    return undefined;
+  });
+
+  return fillStatuses;
 }

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -95,7 +95,6 @@ export function findDepositBlock(
 export async function relayFillStatus(
   programId: Address,
   relayData: RelayData,
-  fromSlot: number,
   blockTag: number | "confirmed" = "confirmed",
   destinationChainId: number,
   provider: Provider,
@@ -119,7 +118,7 @@ export async function relayFillStatus(
   const relevantEvents = (
     await Promise.all(
       eventsToQuery.map((eventName) =>
-        svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, BigInt(fromSlot), toSlot, { limit: 50 })
+        svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, undefined, toSlot, { limit: 50 })
       )
     )
   ).flat();
@@ -149,20 +148,19 @@ export async function relayFillStatus(
 export async function fillStatusArray(
   programId: Address,
   relayData: RelayData[],
-  fromSlot: number,
   blockTag: number | "confirmed" = "confirmed",
   destinationChainId: number,
   provider: Provider,
   svmEventsClient: SvmCpiEventsClient
 ): Promise<(FillStatus | undefined)[]> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
-  const chunkSize = 100;
+  const chunkSize = 2;
   const chunkedRelayData = chunk(relayData, chunkSize);
   const results = [];
   for (const chunk of chunkedRelayData) {
     const chunkResults = await Promise.all(
       chunk.map((relayData) =>
-        relayFillStatus(programId, relayData, fromSlot, blockTag, destinationChainId, provider, svmEventsClient)
+        relayFillStatus(programId, relayData, blockTag, destinationChainId, provider, svmEventsClient)
       )
     );
     results.push(...chunkResults);

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -31,7 +31,6 @@ export class SvmCpiEventsClient {
   private programAddress: Address;
   private programEventAuthority: Address;
   private idl: Idl;
-  private derivedAddress?: Address;
 
   /**
    * Private constructor. Use the async create() method to instantiate.
@@ -40,14 +39,12 @@ export class SvmCpiEventsClient {
     rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>,
     address: Address,
     eventAuthority: Address,
-    idl: Idl,
-    derivedAddress?: Address
+    idl: Idl
   ) {
     this.rpc = rpc;
     this.programAddress = address;
     this.programEventAuthority = eventAuthority;
     this.idl = idl;
-    this.derivedAddress = derivedAddress;
   }
 
   /**
@@ -63,16 +60,14 @@ export class SvmCpiEventsClient {
   public static async createFor(
     rpc: web3.Rpc<web3.SolanaRpcApiFromTransport<RpcTransport>>,
     programId: string,
-    idl: Idl,
-    pda?: string
+    idl: Idl
   ): Promise<SvmCpiEventsClient> {
     const address = web3.address(programId);
-    const derivedAddress = pda ? web3.address(pda) : undefined;
     const [eventAuthority] = await web3.getProgramDerivedAddress({
       programAddress: address,
       seeds: ["__event_authority"],
     });
-    return new SvmCpiEventsClient(rpc, address, eventAuthority, idl, derivedAddress);
+    return new SvmCpiEventsClient(rpc, address, eventAuthority, idl);
   }
 
   /**
@@ -105,11 +100,12 @@ export class SvmCpiEventsClient {
    */
   public async queryDerivedAddressEvents(
     eventName: string,
+    derivedAddress: Address,
     fromSlot?: bigint,
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
-    const events = await this.queryAllEvents(fromSlot, toSlot, options, true);
+    const events = await this.queryAllEvents(fromSlot, toSlot, options, derivedAddress);
     return events.filter((event) => event.name === eventName) as EventWithData[];
   }
 
@@ -126,16 +122,12 @@ export class SvmCpiEventsClient {
     fromSlot?: bigint,
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" },
-    forDerivedAddress: boolean = false
+    derivedAddress?: Address
   ): Promise<EventWithData[]> {
+    const addressToQuery = derivedAddress || this.programAddress;
     const allSignatures: GetSignaturesForAddressTransaction[] = [];
     let hasMoreSignatures = true;
     let currentOptions = options;
-
-    if (forDerivedAddress && !this.derivedAddress) {
-      throw new Error("Unable to query PDA events. Derived address not set.");
-    }
-    const addressToQuery = forDerivedAddress ? this.derivedAddress : this.programAddress;
 
     while (hasMoreSignatures) {
       const signatures: GetSignaturesForAddressApiResponse = await this.rpc

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -43,12 +43,12 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     super(logger, hubPoolClient, chainId, deploymentBlock, eventSearchConfig);
   }
 
-  public override relayFillStatus(relayData: RelayData, blockTag?: number): Promise<FillStatus> {
-    return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
+  public override relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus> {
+    return relayFillStatus(this.spokePool, relayData, atHeight, this.chainId);
   }
 
-  public override fillStatusArray(relayData: RelayData[], blockTag?: number): Promise<(FillStatus | undefined)[]> {
-    return fillStatusArray(this.spokePool, relayData, blockTag);
+  public override fillStatusArray(relayData: RelayData[], atHeight?: number): Promise<(FillStatus | undefined)[]> {
+    return fillStatusArray(this.spokePool, relayData, atHeight);
   }
 
   public override getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -43,14 +43,11 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     super(logger, hubPoolClient, chainId, deploymentBlock, eventSearchConfig);
   }
 
-  public override relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus> {
+  public override relayFillStatus(relayData: RelayData, blockTag?: number): Promise<FillStatus> {
     return relayFillStatus(this.spokePool, relayData, blockTag, this.chainId);
   }
 
-  public override fillStatusArray(
-    relayData: RelayData[],
-    blockTag?: number | "latest"
-  ): Promise<(FillStatus | undefined)[]> {
+  public override fillStatusArray(relayData: RelayData[], blockTag?: number): Promise<(FillStatus | undefined)[]> {
     return fillStatusArray(this.spokePool, relayData, blockTag);
   }
 

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -214,6 +214,14 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, atHeight);
+    return fillStatusArray(
+      this.programId,
+      relayData,
+      destinationChainId,
+      this.rpc,
+      this.svmEventsClient,
+      atHeight,
+      this.logger
+    );
   }
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -195,12 +195,12 @@ export class SvmSpokePoolClient extends SpokePoolClient {
    */
   public override relayFillStatus(
     relayData: RelayData,
-    blockTag: number | "confirmed",
+    blockTag?: number,
     destinationChainId?: number
   ): Promise<FillStatus> {
     destinationChainId ??= this.chainId;
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
-    return relayFillStatus(this.programId, relayData, blockTag, destinationChainId, this.rpc, this.svmEventsClient);
+    return relayFillStatus(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, blockTag);
   }
 
   /**
@@ -211,11 +211,11 @@ export class SvmSpokePoolClient extends SpokePoolClient {
    */
   public fillStatusArray(
     relayData: RelayData[],
-    blockTag?: number | "confirmed",
+    blockTag?: number,
     destinationChainId?: number
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(this.programId, relayData, blockTag, destinationChainId, this.rpc, this.svmEventsClient);
+    return fillStatusArray(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, blockTag);
   }
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -191,31 +191,29 @@ export class SvmSpokePoolClient extends SpokePoolClient {
 
   /**
    * Retrieves the fill status for a given relay data from the SVM chain.
-   * TODO: Implement SVM state query for fill status.
    */
   public override relayFillStatus(
     relayData: RelayData,
-    blockTag?: number,
+    atHeight?: number,
     destinationChainId?: number
   ): Promise<FillStatus> {
     destinationChainId ??= this.chainId;
-    // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
-    return relayFillStatus(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, blockTag);
+    return relayFillStatus(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, atHeight);
   }
 
   /**
    * Retrieves the fill status for an array of given relay data.
    * @param relayData The array relay data to retrieve the fill status for.
-   * @param blockTag The block at which to query the fill status.
+   * @param atHeight The slot at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
   public fillStatusArray(
     relayData: RelayData[],
-    blockTag?: number,
+    atHeight?: number,
     destinationChainId?: number
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, blockTag);
+    return fillStatusArray(this.programId, relayData, destinationChainId, this.rpc, this.svmEventsClient, atHeight);
   }
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -200,7 +200,15 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ): Promise<FillStatus> {
     destinationChainId ??= this.chainId;
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
-    return relayFillStatus(this.programId, relayData, this.deploymentBlock, blockTag, destinationChainId, this.rpc);
+    return relayFillStatus(
+      this.programId,
+      relayData,
+      this.deploymentBlock,
+      blockTag,
+      destinationChainId,
+      this.rpc,
+      this.svmEventsClient
+    );
   }
 
   /**
@@ -216,6 +224,14 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(this.programId, relayData, this.deploymentBlock, blockTag, destinationChainId, this.rpc);
+    return fillStatusArray(
+      this.programId,
+      relayData,
+      this.deploymentBlock,
+      blockTag,
+      destinationChainId,
+      this.rpc,
+      this.svmEventsClient
+    );
   }
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -7,6 +7,8 @@ import {
   getTimestampForSlot,
   getStatePda,
   SvmCpiEventsClient,
+  relayFillStatus,
+  fillStatusArray,
 } from "../../arch/svm";
 import { FillStatus, RelayData, SortableEvent } from "../../interfaces";
 import {
@@ -191,12 +193,14 @@ export class SvmSpokePoolClient extends SpokePoolClient {
    * Retrieves the fill status for a given relay data from the SVM chain.
    * TODO: Implement SVM state query for fill status.
    */
-  public relayFillStatus(
-    _relayData: RelayData,
-    _slot?: number | "latest", // Use slot instead of blockTag
-    _destinationChainId?: number
+  public override relayFillStatus(
+    relayData: RelayData,
+    blockTag: number | "confirmed",
+    destinationChainId?: number
   ): Promise<FillStatus> {
-    throw new Error("relayFillStatus not implemented for SVM");
+    destinationChainId ??= this.chainId;
+    // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
+    return relayFillStatus(this.programId, relayData, this.deploymentBlock, blockTag, destinationChainId, this.rpc);
   }
 
   /**
@@ -205,7 +209,13 @@ export class SvmSpokePoolClient extends SpokePoolClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
-  public fillStatusArray(_relayData: RelayData[], _blockTag?: number | "latest"): Promise<(FillStatus | undefined)[]> {
-    throw new Error("fillStatusArray not implemented for SVM");
+  public fillStatusArray(
+    relayData: RelayData[],
+    blockTag?: number | "confirmed",
+    destinationChainId?: number
+  ): Promise<(FillStatus | undefined)[]> {
+    // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
+    destinationChainId ??= this.chainId;
+    return fillStatusArray(this.programId, relayData, this.deploymentBlock, blockTag, destinationChainId, this.rpc);
   }
 }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -200,15 +200,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ): Promise<FillStatus> {
     destinationChainId ??= this.chainId;
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
-    return relayFillStatus(
-      this.programId,
-      relayData,
-      this.deploymentBlock,
-      blockTag,
-      destinationChainId,
-      this.rpc,
-      this.svmEventsClient
-    );
+    return relayFillStatus(this.programId, relayData, blockTag, destinationChainId, this.rpc, this.svmEventsClient);
   }
 
   /**
@@ -224,14 +216,6 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(
-      this.programId,
-      relayData,
-      this.deploymentBlock,
-      blockTag,
-      destinationChainId,
-      this.rpc,
-      this.svmEventsClient
-    );
+    return fillStatusArray(this.programId, relayData, blockTag, destinationChainId, this.rpc, this.svmEventsClient);
   }
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -804,10 +804,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for the given relay data.
    */
-  public abstract relayFillStatus(
-    relayData: RelayData,
-    blockTag?: number | "latest" | "confirmed"
-  ): Promise<FillStatus>;
+  public abstract relayFillStatus(relayData: RelayData, blockTag?: number): Promise<FillStatus>;
 
   /**
    * Retrieves the fill status for an array of given relay data.
@@ -815,8 +812,5 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
-  public abstract fillStatusArray(
-    relayData: RelayData[],
-    blockTag?: number | "latest" | "confirmed"
-  ): Promise<(FillStatus | undefined)[]>;
+  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number): Promise<(FillStatus | undefined)[]>;
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -801,16 +801,16 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   /**
    * Retrieves the fill status for a given relay data.
    * @param relayData The relay data to retrieve the fill status for.
-   * @param blockTag The block at which to query the fill status.
+   * @param atHeight The height at which to query the fill status.
    * @returns The fill status for the given relay data.
    */
-  public abstract relayFillStatus(relayData: RelayData, blockTag?: number): Promise<FillStatus>;
+  public abstract relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus>;
 
   /**
    * Retrieves the fill status for an array of given relay data.
    * @param relayData The array relay data to retrieve the fill status for.
-   * @param blockTag The block at which to query the fill status.
+   * @param atHeight The height at which to query the fill status.
    * @returns The fill status for each of the given relay data.
    */
-  public abstract fillStatusArray(relayData: RelayData[], blockTag?: number): Promise<(FillStatus | undefined)[]>;
+  public abstract fillStatusArray(relayData: RelayData[], atHeight?: number): Promise<(FillStatus | undefined)[]>;
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -804,7 +804,10 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block at which to query the fill status.
    * @returns The fill status for the given relay data.
    */
-  public abstract relayFillStatus(relayData: RelayData, blockTag?: number | "latest"): Promise<FillStatus>;
+  public abstract relayFillStatus(
+    relayData: RelayData,
+    blockTag?: number | "latest" | "confirmed"
+  ): Promise<FillStatus>;
 
   /**
    * Retrieves the fill status for an array of given relay data.
@@ -814,6 +817,6 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    */
   public abstract fillStatusArray(
     relayData: RelayData[],
-    blockTag?: number | "latest"
+    blockTag?: number | "latest" | "confirmed"
   ): Promise<(FillStatus | undefined)[]>;
 }

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -3,8 +3,9 @@ import { MAX_SAFE_DEPOSIT_ID, ZERO_ADDRESS, ZERO_BYTES } from "../constants";
 import { Deposit, RelayData } from "../interfaces";
 import { toBytes32 } from "./AddressUtils";
 import { keccak256 } from "./common";
-import { BigNumber } from "./BigNumberUtils";
+import { BigNumber, toBN } from "./BigNumberUtils";
 import { isMessageEmpty } from "./DepositUtils";
+import { chainIsSvm } from "./NetworkUtils";
 
 /**
  * Produce the RelayData for a Deposit.
@@ -43,6 +44,9 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
     outputToken: toBytes32(relayData.outputToken),
     exclusiveRelayer: toBytes32(relayData.exclusiveRelayer),
   };
+  if (chainIsSvm(destinationChainId)) {
+    return _getRelayDataHashSvm(_relayData, destinationChainId);
+  }
   return keccak256(
     ethersUtils.defaultAbiCoder.encode(
       [
@@ -69,6 +73,46 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
 
 export function getRelayHashFromEvent(e: RelayData & { destinationChainId: number }): string {
   return getRelayDataHash(e, e.destinationChainId);
+}
+
+function _getRelayDataHashSvm(relayData: RelayData, destinationChainId: number): string {
+  const uint8ArrayFromHexString = (hex: string, littleEndian: boolean = false): Uint8Array => {
+    const buffer = Buffer.from(hex.slice(2), "hex");
+    if (buffer.length < 32) {
+      const zeroPad = new Uint8Array(32);
+      buffer.copy(zeroPad, 32 - buffer.length);
+      return littleEndian ? zeroPad.reverse() : zeroPad;
+    }
+    const result = new Uint8Array(buffer.slice(0, 32));
+    return littleEndian ? result.reverse() : result;
+  };
+  const uint8ArrayFromInt = (num: BigNumber, byteLength: number, littleEndian: boolean = true): Uint8Array => {
+    const buffer = Buffer.from(num.toHexString().slice(2), "hex");
+    if (buffer.length < byteLength) {
+      const zeroPad = new Uint8Array(byteLength);
+      buffer.copy(zeroPad, byteLength - buffer.length);
+      return littleEndian ? zeroPad.reverse() : zeroPad;
+    }
+    const result = new Uint8Array(buffer.slice(0, byteLength));
+    return littleEndian ? result.reverse() : result;
+  };
+  const contentToHash = Buffer.concat([
+    uint8ArrayFromHexString(relayData.depositor),
+    uint8ArrayFromHexString(relayData.recipient),
+    uint8ArrayFromHexString(relayData.exclusiveRelayer),
+    uint8ArrayFromHexString(relayData.inputToken),
+    uint8ArrayFromHexString(relayData.outputToken),
+    uint8ArrayFromInt(relayData.inputAmount, 8),
+    uint8ArrayFromInt(relayData.outputAmount, 8),
+    uint8ArrayFromInt(toBN(relayData.originChainId), 8),
+    uint8ArrayFromInt(relayData.depositId, 32, false),
+    uint8ArrayFromInt(toBN(relayData.fillDeadline), 4),
+    uint8ArrayFromInt(toBN(relayData.exclusivityDeadline), 4),
+    uint8ArrayFromHexString(getMessageHash(relayData.message)),
+    uint8ArrayFromInt(toBN(destinationChainId), 8),
+  ]);
+  const returnHash = keccak256(contentToHash);
+  return returnHash;
 }
 
 export function isUnsafeDepositId(depositId: BigNumber): boolean {


### PR DESCRIPTION
This PR introduces the SVM implementation of `relayFillStatus`, which resolves a relay's fill status using PDA data or, if necessary, PDA events.

The resolution process is:

1. Retrieve the fill status PDA for the relay.
2. If querying the current slot:
   - If the PDA exists, fetch the status directly.
   - If the PDA doesn't exist but the fill deadline hasn’t passed, solve the status as Unfilled. This relies on the fact that PDAs can't be closed before the fill deadline.
3. If the status can't be determined using the PDA, or if a specific slot is requested, fetch and sort relevant PDA events (fills and slow fill requests) to resolve it.

This PR also introduces `fillStatusArray`, a batched version of the same logic for resolving multiple deposits. Note that resolving status via events for large arrays is slow. If it becomes a bottleneck, we could introduce a new `Unknown` fill status to skip event reconstruction entirely. This should be acceptable, as event-based resolution is only needed for deposits whose fill deadline has already passed or for queries at a specific slot. 

Some execution times observed during local testing:
- Fetching data from 100 accounts takes ~250ms. Multiple requests can run concurrently.
- Resolving statuses via events takes ~9000ms for each batch of 100 deposits.
Note: These timings were measured without caching which could reduce them further. 
