### PR TITLE
improve(HubPoolClient): Avoid loading rate model if paymentChain == originChain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.54",
+  "version": "4.1.55",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -438,7 +438,7 @@ export class HubPoolClient extends BaseAbstractClient {
       const { originChainId, paymentChainId, inputAmount, quoteTimestamp } = deposit;
       const quoteBlock = quoteBlocks[quoteTimestamp];
 
-      if (paymentChainId === undefined) {
+      if (paymentChainId === undefined || paymentChainId === originChainId) {
         return { quoteBlock, realizedLpFeePct: bnZero };
       }
 


### PR DESCRIPTION
This is a shortcut we can make because in practice, lp fees are 0 for all routes where paymentChain == originChain
