### PR TITLE
fix(DataworkerUtils): Don't create empty PoolRebalanceLeaf for bundle deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.59",
+  "version": "4.1.60",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.58",
+  "version": "4.1.59",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -236,7 +236,6 @@ export function _buildPoolRebalanceRoot(
             mainnetBundleEndBlock
           )
         ) {
-          chainWithRefundsOnly.add(deposit.originChainId);
           return;
         }
         updateRunningBalanceForDeposit(


### PR DESCRIPTION
Bundle deposits (not expired ones) should not create empty pool rebalance leaves because they do not create any RelayerRefundLeaves
