### PR TITLE
fix: capital cost config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.58",
+  "version": "4.1.59",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -204,7 +204,7 @@ export class RelayFeeCalculator {
    * @param capitalCosts CapitalCostConfig
    */
   static validateCapitalCostsConfig(capitalCosts: CapitalCostConfig): void {
-    assert(toBN(capitalCosts.upperBound).lt(toBNWei("0.01")), "upper bound must be < 1%");
+    assert(toBN(capitalCosts.upperBound).lt(toBNWei("1")), "upper bound must be < 100%");
     assert(capitalCosts.decimals > 0 && capitalCosts.decimals <= 18, "invalid decimals");
   }
 


### PR DESCRIPTION
We need to set upper bounds that are higher than 1%