### PR TITLE
improve(TokenUtils): Replace getL1TokenInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.61",
+  "version": "4.1.62",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -102,6 +102,15 @@ export function isStablecoin(tokenSymbol: string): boolean {
   );
 }
 
+/**
+ * @notice Returns the Token info for the token mapping in TOKEN_SYMBOLS_MAP matching the given l2TokenAddress
+ * and chainId. If the chain is the hub chain, then will remap the L1 token to its equivalent L1 token symbol for example
+ * it will always return a token info with symbol USDC and never USDC.e if chainId = mainnet.
+ * @param l2TokenAddress 
+ * @param chainId 
+ * @param tokenMapping 
+ * @returns 
+ */
 export function getTokenInfo(l2TokenAddress: string, chainId: number, tokenMapping = TOKEN_SYMBOLS_MAP): L1Token {
   // @dev This might give false positives if tokens on different networks have the same address. I'm not sure how
   // to get around this...
@@ -137,9 +146,12 @@ export function getUsdcSymbol(l2Token: string, chainId: number): string | undefi
   );
 }
 
-export function getL1TokenInfo(l2TokenAddress: string, chainId: number): L1Token {
+/**
+ * @notice Returns the l1 token address matching the given l2TokenAddress and chainId.
+ */
+export function getL1TokenAddress(l2TokenAddress: string, chainId: number): string {
   if (chainIsL1(chainId))
-    throw new Error("chainId should be an L2 chainId because many mappings re-use the same L1 token address");
+    return l2TokenAddress;
   const tokenObject = Object.values(TOKEN_SYMBOLS_MAP).find(({ addresses }) => addresses[chainId] === l2TokenAddress);
   const l1TokenAddress = tokenObject?.addresses[chainIsProd(chainId) ? CHAIN_IDs.MAINNET : CHAIN_IDs.SEPOLIA];
   if (!l1TokenAddress) {
@@ -147,9 +159,5 @@ export function getL1TokenInfo(l2TokenAddress: string, chainId: number): L1Token
       `TokenUtils#getL1TokenInfo: Unable to resolve l1 token address in TOKEN_SYMBOLS_MAP for L2 token ${l2TokenAddress} on chain ${chainId}`
     );
   }
-  return {
-    address: l1TokenAddress,
-    symbol: tokenObject.symbol,
-    decimals: tokenObject.decimals,
-  };
+  return l1TokenAddress;
 }


### PR DESCRIPTION
This function is kind of dangerous in that it intuitively returns the `TokenInfo` for the L1 token matching the passed in l2 token/chain but it actually returns the L2 token decimals. I could see this function being misused in the future.

This PR will force users to use `getL1TokenAddress` to get the L1 token address for an l2 token and use `getTokenInfo` to get the decimals/symbol for the same l2 token.
