### PR TITLE
improve: SVM getTimestampForSlot

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -25,29 +25,12 @@ export function populateV3Relay(
 }
 
 /**
- * Retrieves the time from the SpokePool contract at a particular block.
- * @returns The time at the specified block tag.
- */
-export function getTimeAt(_spokePool: unknown, _blockNumber: number): Promise<number> {
-  throw new Error("getTimeAt: not implemented");
-}
-
-/**
  * Retrieves the chain time at a particular slot.
- * @note This should be the same as getTimeAt() but can differ in test. These two functions should be consolidated.
- * @returns The chain time at the specified slot.
  */
 export async function getTimestampForSlot(provider: SVMProvider, slotNumber: number): Promise<number> {
-  const block = await provider.getBlock(BigInt(slotNumber)).send();
-  let timestamp: number;
-  if (!block?.blockTime) {
-    console.error(`Unable to resolve block for slot ${slotNumber}`);
-    timestamp = 0; // @todo: How to handle this?
-  } else {
-    timestamp = Number(block.blockTime); // Unix timestamps fit within number.
-  }
-
-  return timestamp;
+  // @note: getBlockTime receives a slot number, not a block number.
+  const slotTime = await provider.getBlockTime(BigInt(slotNumber)).send();
+  return Number(slotTime);
 }
 
 /**

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -198,10 +198,12 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   }
 
   /**
-   * Retrieves the time (timestamp) from the SVM chain state at a particular slot.
+   * Retrieves the timestamp for a given SVM slot number.
+   * @note This function uses the same underlying function as getTimestampForBlock.
+   *       It is kept for consistency with the EVM SpokePoolClient.
    */
-  public getTimeAt(_slot: number): Promise<number> {
-    throw new Error("getTimeAt not implemented for SVM");
+  public getTimeAt(slot: number): Promise<number> {
+    return getTimestampForSlot(this.svmEventsClient.getRpc(), slot);
   }
 
   /**


### PR DESCRIPTION
This PR changes the implementation of `getTimestampForSlot` to use [getBlockTime](https://solana.com/docs/rpc/http/getblocktime). This RPC method does exactly what we need. It takes a slot (despite its misleading name 😅) and returns its timestamp. By using it we no longer need to handle the case when there was no block mined in the requested slot.

This PR also implements `getTimeAt` which also uses `getTimestampForSlot`.
