### PR TITLE
improve(gasPriceOracle): Add basic gas price type discriminators

### DIFF
--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -27,4 +27,3 @@ export function isSVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is SvmGasPri
   const { baseFee, microLamportsPerComputeUnit } = gasPrice as SvmGasPriceEstimate;
   return isDefined(baseFee) && isDefined(microLamportsPerComputeUnit);
 }
-

--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -1,5 +1,5 @@
 import { type Chain, type Transport, PublicClient, FeeValuesEIP1559 } from "viem";
-import { BigNumber } from "../utils";
+import { BigNumber, isDefined } from "../utils";
 
 export type InternalGasPriceEstimate = FeeValuesEIP1559;
 export type GasPriceEstimate = EvmGasPriceEstimate | SvmGasPriceEstimate;
@@ -17,3 +17,14 @@ export type SvmGasPriceEstimate = {
 export interface GasPriceFeed {
   (provider: PublicClient<Transport, Chain>, chainId: number): Promise<InternalGasPriceEstimate>;
 }
+
+export function isEVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is EvmGasPriceEstimate {
+  const { maxFeePerGas, maxPriorityFeePerGas } = gasPrice as EvmGasPriceEstimate;
+  return isDefined(maxFeePerGas) && isDefined(maxPriorityFeePerGas);
+}
+
+export function isSVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is SvmGasPriceEstimate {
+  const { baseFee, microLamportsPerComputeUnit } = gasPrice as SvmGasPriceEstimate;
+  return isDefined(baseFee) && isDefined(microLamportsPerComputeUnit);
+}
+


### PR DESCRIPTION
Prompted by linking against the relayer and seeing a few type incompatibility errors.