### PR TITLE
improve(gasPriceOracle): Add basic gas price type discriminators (#1031)

### DIFF
--- a/src/gasPriceOracle/adapters/solana.ts
+++ b/src/gasPriceOracle/adapters/solana.ts
@@ -1,6 +1,6 @@
 import { SVMProvider } from "../../arch/svm";
 import { toBN, dedupArray, parseUnits } from "../../utils";
-import { GasPriceEstimate } from "../types";
+import { SvmGasPriceEstimate } from "../types";
 import { GasPriceEstimateOptions } from "../oracle";
 import { CompilableTransactionMessage, TransactionMessageBytesBase64, compileTransaction } from "@solana/kit";
 
@@ -8,7 +8,7 @@ import { CompilableTransactionMessage, TransactionMessageBytesBase64, compileTra
  * @notice Returns result of getFeeForMessage and getRecentPrioritizationFees RPC calls.
  * @returns GasPriceEstimate
  */
-export async function messageFee(provider: SVMProvider, opts: GasPriceEstimateOptions): Promise<GasPriceEstimate> {
+export async function messageFee(provider: SVMProvider, opts: GasPriceEstimateOptions): Promise<SvmGasPriceEstimate> {
   const { unsignedTx: _unsignedTx } = opts;
 
   // Cast the opaque unsignedTx type to a solana-kit CompilableTransactionMessage.

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -49,7 +49,7 @@ export async function getGasPriceEstimate(
 /**
  * Provide an estimate for the current gas price for a particular chain.
  * @param provider A valid ethers provider.
- * @param {opts} GasPriceEstimateOptions optional parameters.
+ * @param {GasPriceEstimateOptions} opts optional parameters.
  * @returns An  object of type GasPriceEstimate.
  */
 export async function getGasPriceEstimate(

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Transport } from "viem";
 import { providers } from "ethers";
 import { CHAIN_IDs } from "../constants";
-import { BigNumber, chainIsOPStack, fixedPointAdjustment, toBNWei } from "../utils";
+import { BigNumber, chainIsOPStack, fixedPointAdjustment, isEvmProvider, toBNWei } from "../utils";
 import { SVMProvider as SolanaProvider } from "../arch/svm";
 import { EvmGasPriceEstimate, GasPriceEstimate, SvmGasPriceEstimate } from "./types";
 import { getPublicClient } from "./util";
@@ -11,7 +11,6 @@ import * as ethereum from "./adapters/ethereum";
 import * as polygon from "./adapters/polygon";
 import * as lineaViem from "./adapters/linea-viem";
 import * as solana from "./adapters/solana";
-import { isEvmProvider } from "../providers";
 
 export interface GasPriceEstimateOptions {
   // baseFeeMultiplier Multiplier applied to base fee for EIP1559 gas prices (or total fee for legacy).

--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -1,5 +1,5 @@
 import { type Chain, type Transport, PublicClient, FeeValuesEIP1559 } from "viem";
-import { BigNumber } from "../utils";
+import { BigNumber, isDefined } from "../utils";
 
 export type InternalGasPriceEstimate = FeeValuesEIP1559;
 export type GasPriceEstimate = EvmGasPriceEstimate | SvmGasPriceEstimate;
@@ -16,4 +16,14 @@ export type SvmGasPriceEstimate = {
 
 export interface GasPriceFeed {
   (provider: PublicClient<Transport, Chain>, chainId: number): Promise<InternalGasPriceEstimate>;
+}
+
+export function isEVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is EvmGasPriceEstimate {
+  const { maxFeePerGas, maxPriorityFeePerGas } = gasPrice as EvmGasPriceEstimate;
+  return isDefined(maxFeePerGas) && isDefined(maxPriorityFeePerGas);
+}
+
+export function isSVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is SvmGasPriceEstimate {
+  const { baseFee, microLamportsPerComputeUnit } = gasPrice as SvmGasPriceEstimate;
+  return isDefined(baseFee) && isDefined(microLamportsPerComputeUnit);
 }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,6 +7,7 @@ import { RPCProvider, RPCTransport } from "./types";
 import * as alchemy from "./alchemy";
 import * as infura from "./infura";
 import * as drpc from "./drpc";
+import { SVMProvider } from "../arch/svm";
 
 /**
  * Infura DIN is identified separately to allow it to be configured explicitly.
@@ -170,4 +171,8 @@ export enum CacheType {
   WITH_TTL, // Cache with TTL
   NO_TTL, // Cache with infinite TTL
   DECIDE_TTL_POST_SEND, // Decide which TTL to cache with after we receive the RPC response
+}
+
+export function isEvmProvider(provider: providers.Provider | SVMProvider): provider is providers.Provider {
+  return provider instanceof providers.Provider;
 }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,7 +7,6 @@ import { RPCProvider, RPCTransport } from "./types";
 import * as alchemy from "./alchemy";
 import * as infura from "./infura";
 import * as drpc from "./drpc";
-import { SVMProvider } from "../arch/svm";
 
 /**
  * Infura DIN is identified separately to allow it to be configured explicitly.
@@ -171,8 +170,4 @@ export enum CacheType {
   WITH_TTL, // Cache with TTL
   NO_TTL, // Cache with infinite TTL
   DECIDE_TTL_POST_SEND, // Decide which TTL to cache with after we receive the RPC response
-}
-
-export function isEvmProvider(provider: providers.Provider | SVMProvider): provider is providers.Provider {
-  return provider instanceof providers.Provider;
 }

--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -1,3 +1,6 @@
+import { providers } from "ethers";
+import { SVMProvider } from "../arch/svm/types";
+
 export function isPromiseFulfilled<T>(
   promiseSettledResult: PromiseSettledResult<T>
 ): promiseSettledResult is PromiseFulfilledResult<T> {
@@ -12,4 +15,8 @@ export function isPromiseRejected<T>(
 
 export function isDefined<T>(input: T | null | undefined): input is T {
   return input !== null && input !== undefined;
+}
+
+export function isEvmProvider(provider: providers.Provider | SVMProvider): provider is providers.Provider {
+  return provider instanceof providers.Provider;
 }


### PR DESCRIPTION
Prompted by linking against the relayer and seeing a few type incompatibility errors.