### PR TITLE
improve: factor out addresses in spoke pool client

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -57,7 +57,7 @@ import {
   V3FillWithBlock,
   verifyFillRepayment,
 } from "./utils";
-import { isEVMSpokePoolClient, isSvmSpokePoolClient } from "../SpokePoolClient";
+import { isEVMSpokePoolClient, isSVMSpokePoolClient } from "../SpokePoolClient";
 
 // max(uint256) - 1
 export const INFINITE_FILL_DEADLINE = bnUint32Max;
@@ -1617,7 +1617,7 @@ export class BundleDataClient {
     deposit: DepositWithBlock,
     spokePoolClient: SpokePoolClient
   ): Promise<FillWithBlock | undefined> {
-    if (isSvmSpokePoolClient(spokePoolClient)) {
+    if (isSVMSpokePoolClient(spokePoolClient)) {
       return await findSvmFillEvent(
         deposit,
         spokePoolClient.chainId,

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -16,6 +16,7 @@ import {
   isZeroAddress,
   MakeOptional,
   toBN,
+  EvmAddress,
 } from "../../utils";
 import {
   EventSearchConfig,
@@ -42,6 +43,7 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     eventSearchConfig: MakeOptional<EventSearchConfig, "to"> = { from: 0, maxLookBack: 0 }
   ) {
     super(logger, hubPoolClient, chainId, deploymentBlock, eventSearchConfig);
+    this.spokePoolAddress = EvmAddress.from(spokePool.address);
   }
 
   public override relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus> {

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -20,6 +20,7 @@ import {
   isZeroAddress,
   MakeOptional,
   sortEventsAscendingInPlace,
+  SvmAddress,
 } from "../../utils";
 import { isUpdateFailureReason } from "../BaseAbstractClient";
 import { HubPoolClient } from "../HubPoolClient";
@@ -29,7 +30,7 @@ import { knownEventNames, SpokePoolClient, SpokePoolUpdate } from "./SpokePoolCl
  * SvmSpokePoolClient is a client for the SVM SpokePool program. It extends the base SpokePoolClient
  * and implements the abstract methods required for interacting with an SVM Spoke Pool.
  */
-export class SvmSpokePoolClient extends SpokePoolClient {
+export class SVMSpokePoolClient extends SpokePoolClient {
   /**
    * Protected constructor. Use the async create() method to instantiate.
    */
@@ -45,6 +46,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ) {
     // Convert deploymentSlot to number for base class, might need refinement
     super(logger, hubPoolClient, chainId, Number(deploymentSlot), eventSearchConfig);
+    this.spokePoolAddress = SvmAddress.from(programId.toString());
   }
 
   /**
@@ -57,11 +59,11 @@ export class SvmSpokePoolClient extends SpokePoolClient {
     deploymentSlot: bigint,
     eventSearchConfig: MakeOptional<EventSearchConfig, "to"> = { from: 0, maxLookBack: 0 }, // Provide default
     rpc: Rpc<SolanaRpcApiFromTransport<RpcTransport>>
-  ): Promise<SvmSpokePoolClient> {
+  ): Promise<SVMSpokePoolClient> {
     const svmEventsClient = await SvmCpiEventsClient.create(rpc);
     const programId = svmEventsClient.getProgramAddress();
     const statePda = await getStatePda(programId);
-    return new SvmSpokePoolClient(
+    return new SVMSpokePoolClient(
       logger,
       hubPoolClient,
       chainId,
@@ -86,7 +88,7 @@ export class SvmSpokePoolClient extends SpokePoolClient {
   ) {
     const programId = eventClient.getProgramAddress();
     const statePda = await getStatePda(programId);
-    return new SvmSpokePoolClient(
+    return new SVMSpokePoolClient(
       logger,
       hubPoolClient,
       chainId,

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -87,7 +87,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   protected relayerRefundExecutions: RelayerRefundExecutionWithBlock[] = [];
   protected configStoreClient: AcrossConfigStoreClient | undefined;
   protected invalidFills: Set<string> = new Set();
-  protected spokePoolAddress: Address | undefined;
+  public spokePoolAddress: Address | undefined;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
 
   /**

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -19,6 +19,7 @@ import {
   validateFillForDeposit,
   chainIsEvm,
   chainIsProd,
+  Address,
 } from "../../utils";
 import { duplicateEvent, sortEventsAscendingInPlace } from "../../utils/EventUtils";
 import { ZERO_ADDRESS } from "../../constants";
@@ -86,6 +87,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   protected relayerRefundExecutions: RelayerRefundExecutionWithBlock[] = [];
   protected configStoreClient: AcrossConfigStoreClient | undefined;
   protected invalidFills: Set<string> = new Set();
+  protected spokePoolAddress: Address | undefined;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
 
   /**

--- a/src/clients/SpokePoolClient/index.ts
+++ b/src/clients/SpokePoolClient/index.ts
@@ -1,10 +1,10 @@
 import { EVMSpokePoolClient } from "./EVMSpokePoolClient";
-import { SvmSpokePoolClient } from "./SVMSpokePoolClient";
+import { SVMSpokePoolClient } from "./SVMSpokePoolClient";
 import { SpokePoolClient } from "./SpokePoolClient";
 
 export { EVMSpokePoolClient } from "./EVMSpokePoolClient";
 export { SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
-export { SvmSpokePoolClient } from "./SVMSpokePoolClient";
+export { SVMSpokePoolClient } from "./SVMSpokePoolClient";
 
 /**
  * Checks if a SpokePoolClient is an EVMSpokePoolClient.
@@ -20,6 +20,6 @@ export function isEVMSpokePoolClient(spokePoolClient: SpokePoolClient): spokePoo
  * @param spokePoolClient The SpokePoolClient to check.
  * @returns True if the SpokePoolClient is an SVMSpokePoolClient, false otherwise.
  */
-export function isSvmSpokePoolClient(spokePoolClient: SpokePoolClient): spokePoolClient is SvmSpokePoolClient {
-  return spokePoolClient instanceof SvmSpokePoolClient;
+export function isSVMSpokePoolClient(spokePoolClient: SpokePoolClient): spokePoolClient is SVMSpokePoolClient {
+  return spokePoolClient instanceof SVMSpokePoolClient;
 }

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -6,6 +6,6 @@ export {
 } from "./AcrossConfigStoreClient";
 export { UpdateFailureReason } from "./BaseAbstractClient";
 export { HubPoolClient, LpFeeRequest } from "./HubPoolClient";
-export { SpokePoolClient, SpokePoolUpdate, EVMSpokePoolClient, SvmSpokePoolClient } from "./SpokePoolClient";
+export { SpokePoolClient, SpokePoolUpdate, EVMSpokePoolClient, SVMSpokePoolClient } from "./SpokePoolClient";
 export * as BundleDataClient from "./BundleDataClient";
 export * as mocks from "./mocks";

--- a/src/clients/mocks/MockSvmSpokePoolClient.ts
+++ b/src/clients/mocks/MockSvmSpokePoolClient.ts
@@ -3,7 +3,7 @@ import { SvmSpokeClient } from "@across-protocol/contracts";
 import { Address } from "@solana/kit";
 import { DepositWithBlock, RelayerRefundExecution, SortableEvent, SlowFillLeaf, Log } from "../../interfaces";
 import { getCurrentTime, bnZero, MakeOptional, EventSearchConfig } from "../../utils";
-import { SpokePoolUpdate, SvmSpokePoolClient } from "../SpokePoolClient";
+import { SpokePoolUpdate, SVMSpokePoolClient } from "../SpokePoolClient";
 import { HubPoolClient } from "../HubPoolClient";
 import { EventOverrides } from "./MockEvents";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
@@ -12,7 +12,7 @@ import { EventWithData, SvmCpiEventsClient, SVMEventNames, unwrapEventData } fro
 
 // This class replaces internal SpokePoolClient functionality, enabling
 // the user to bypass on-chain queries and inject events directly.
-export class MockSvmSpokePoolClient extends SvmSpokePoolClient {
+export class MockSvmSpokePoolClient extends SVMSpokePoolClient {
   public mockEventsClient: MockSvmCpiEventsClient;
   private destinationTokenForChainOverride: Record<number, string> = {};
 

--- a/test/SVMSpokePoolClient.fills.ts
+++ b/test/SVMSpokePoolClient.fills.ts
@@ -14,7 +14,7 @@ import {
   sendRequestSlowFill,
 } from "./utils/svm/utils";
 import { SVM_DEFAULT_ADDRESS, findFillEvent, getRandomSvmAddress } from "../src/arch/svm";
-import { SvmSpokePoolClient } from "../src/clients";
+import { SVMSpokePoolClient } from "../src/clients";
 import { signer } from "./Solana.setup";
 describe("SVMSpokePoolClient: Fills", function () {
   const solanaClient = createDefaultSolanaClient();
@@ -57,7 +57,7 @@ describe("SVMSpokePoolClient: Fills", function () {
     };
 
     // Instantiate SpokePoolClient
-    spokePoolClient = await SvmSpokePoolClient.create(
+    spokePoolClient = await SVMSpokePoolClient.create(
       createSpyLogger().spyLogger,
       null,
       CHAIN_IDs.SOLANA,


### PR DESCRIPTION
We make a lot of assumptions about the structure of the spoke pool client in the relayer. The SVMSpokePoolClient and EVMSpokePoolClient both extend SpokePoolClient but largely do not share a similar API (mainly due to the latter's extensive use of the `spokePool` contract). We can refactor some of this by simply storing the address as a state variable in the SpokePoolClient's class.