### PR TITLE
improve: expose more spoke pool client objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.2.3-alpha.0",
+  "version": "4.2.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.2.2",
+  "version": "4.2.3-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -1,12 +1,6 @@
 import assert from "assert";
 import { clamp, sortedIndexBy } from "lodash";
-import {
-  BlockFinder,
-  type Block,
-  type BlockFinderOpts as Opts,
-  type BlockTimeAverage,
-  type BlockFinderHints,
-} from "../../utils/BlockFinder";
+import { BlockFinder, type Block, type BlockTimeAverage, type BlockFinderHints } from "../../utils/BlockFinder";
 import { isDefined } from "../../utils/TypeGuards";
 import { getCurrentTime } from "../../utils/TimeUtils";
 import { CHAIN_IDs } from "../../constants";
@@ -24,17 +18,18 @@ const averageBlockTimes: { [chainId: number]: BlockTimeAverage } = {
  * @dev Solana slots are all defined to be ~400ms away from each other += a small deviation, so we can hardcode this.
  * @returns Average number of seconds per slot
  */
-export function averageBlockTime(
-  _provider: SVMProvider,
-  _opts: Opts = {}
-): Pick<BlockTimeAverage, "average" | "blockRange"> {
+export function averageBlockTime(): Pick<BlockTimeAverage, "average" | "blockRange"> {
   // @todo This may need to be expanded to work without assuming that chainId = CHAIN_IDs.SOLANA.
   return averageBlockTimes[CHAIN_IDs.SOLANA];
 }
 
-async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0, provider: SVMProvider): Promise<number> {
+async function estimateBlocksElapsed(
+  seconds: number,
+  cushionPercentage = 0.0,
+  _provider: SVMProvider
+): Promise<number> {
   const cushionMultiplier = cushionPercentage + 1.0;
-  const { average } = await averageBlockTime(provider);
+  const { average } = await averageBlockTime();
   return Math.floor((seconds * cushionMultiplier) / average);
 }
 

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -38,7 +38,7 @@ export type DepositEventFromSignature = Omit<DepositWithTime, "fromLiteChain" | 
 export type FillEventFromSignature = FillWithTime;
 
 export class SvmCpiEventsClient {
-  private rpc: SVMProvider;
+  public rpc: SVMProvider;
   private programAddress: Address;
   private programEventAuthority: Address;
   private idl: Idl;

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -38,7 +38,7 @@ export type DepositEventFromSignature = Omit<DepositWithTime, "fromLiteChain" | 
 export type FillEventFromSignature = FillWithTime;
 
 export class SvmCpiEventsClient {
-  public rpc: SVMProvider;
+  private rpc: SVMProvider;
   private programAddress: Address;
   private programEventAuthority: Address;
   private idl: Idl;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -6,6 +6,13 @@ export {
 } from "./AcrossConfigStoreClient";
 export { UpdateFailureReason } from "./BaseAbstractClient";
 export { HubPoolClient, LpFeeRequest } from "./HubPoolClient";
-export { SpokePoolClient, SpokePoolUpdate, EVMSpokePoolClient, SVMSpokePoolClient } from "./SpokePoolClient";
+export {
+  SpokePoolClient,
+  SpokePoolUpdate,
+  EVMSpokePoolClient,
+  SVMSpokePoolClient,
+  isEVMSpokePoolClient,
+  isSVMSpokePoolClient,
+} from "./SpokePoolClient";
 export * as BundleDataClient from "./BundleDataClient";
 export * as mocks from "./mocks";


### PR DESCRIPTION
We will likely need to expose more spoke pool client functions/variables to support the relayer.