### PR TITLE
chore(SpokePoolClient): Tweaks for downstream implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -177,7 +177,7 @@ export class SvmCpiEventsClient {
    * @param commitment - Commitment level.
    * @returns A promise that resolves to an array of events.
    */
-  private async readEventsFromSignature(txSignature: Signature, commitment: Commitment = "confirmed") {
+  async readEventsFromSignature(txSignature: Signature, commitment: Commitment = "confirmed") {
     const txResult = await this.rpc
       .getTransaction(txSignature, { commitment, maxSupportedTransactionVersion: 0 })
       .send();

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -32,9 +32,9 @@ import { knownEventNames, SpokePoolClient, SpokePoolUpdate } from "./SpokePoolCl
  */
 export class SVMSpokePoolClient extends SpokePoolClient {
   /**
-   * Protected constructor. Use the async create() method to instantiate.
+   * Note: Strongly prefer to use the async create() method to instantiate.
    */
-  protected constructor(
+  constructor(
     logger: winston.Logger,
     hubPoolClient: HubPoolClient | null,
     chainId: number,

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -76,7 +76,6 @@ export const knownEventNames = [
  */
 export abstract class SpokePoolClient extends BaseAbstractClient {
   protected currentTime = 0;
-  protected depositHashes: { [depositHash: string]: DepositWithBlock } = {};
   protected duplicateDepositHashes: { [depositHash: string]: DepositWithBlock[] } = {};
   protected depositHashesToFills: { [depositHash: string]: FillWithBlock[] } = {};
   protected speedUps: { [depositorAddress: string]: { [depositId: string]: SpeedUpWithBlock[] } } = {};
@@ -87,6 +86,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   protected relayerRefundExecutions: RelayerRefundExecutionWithBlock[] = [];
   protected configStoreClient: AcrossConfigStoreClient | undefined;
   protected invalidFills: Set<string> = new Set();
+  public readonly depositHashes: { [depositHash: string]: DepositWithBlock } = {};
   public spokePoolAddress: Address | undefined;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
 


### PR DESCRIPTION
The "enhanced" listener classes down in the relayer need to deal with extending both the EVM and SVM SpokePoolClient variants. This is working well with Typescript mixins, which enable a single class to extend some generic description of a class, but there are a couple of hurdles.

Primarily, the SpokePoolClient depositHashes member is protected, but protected members cannot be declared in the mixin type specification because they are inherently internal. Make depositHashes globally readable for the time being.

Additionally, the SVMSpokePoolClient create static method cannot be used with mixins because it narrows the returned type to an SVMSPokePoolClient. Therefore, remove the protected constraint on the constructor and instead just recommend users to use the create() method.

Ultimately, the SpokePoolClient listener functionality will need to migrate upstream to the SDK, where it can be more directly integrated. This will permit these workarounds to be dropped.