### PR TITLE
fix: return relayerFeeDetails decimals in inputToken decimals 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.64-alpha.0",
+  "version": "4.1.65-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.65-alpha.0",
+  "version": "4.1.65-alpha.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.1.63",
+  "version": "4.1.64-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -302,7 +302,7 @@ export class RelayFeeCalculator {
           throw error;
         }),
     ]);
-    const gasFeesInToken = nativeToToken(tokenGasCost, tokenPrice, inputTokenInfo.decimals, this.nativeTokenDecimals);
+    const gasFeesInToken = nativeToToken(tokenGasCost, tokenPrice, outputTokenInfo.decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay.toString());
   }
 


### PR DESCRIPTION
This relates to the open question in https://github.com/across-protocol/frontend/pull/1612.

We should quote all fees in terms of input tokens, not output tokens.