### PR TITLE
chore: Require EvmAddress types on EVM-destination fills

### DIFF
--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -3,6 +3,7 @@ import { BytesLike, Contract, PopulatedTransaction, providers } from "ethers";
 import { CHAIN_IDs } from "../../constants";
 import { Deposit, FillStatus, FillWithBlock, RelayData } from "../../interfaces";
 import {
+  EvmAddress,
   bnUint32Max,
   BigNumber,
   toBN,
@@ -29,7 +30,10 @@ type BlockTag = providers.BlockTag;
  */
 export function populateV3Relay(
   spokePool: Contract,
-  deposit: Omit<Deposit, "messageHash">,
+  deposit: Omit<Deposit, "messageHash" | "fromLiteChain" | "toLiteChain"> & {
+    recipient: EvmAddress;
+    exclusiveRelayer: EvmAddress;
+  },
   relayer: Address,
   repaymentChainId = deposit.destinationChainId
 ): Promise<PopulatedTransaction> {

--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -37,6 +37,10 @@ export function populateV3Relay(
   relayer: Address,
   repaymentChainId = deposit.destinationChainId
 ): Promise<PopulatedTransaction> {
+  assert(
+    relayer.isValidOn(repaymentChainId),
+    `Invalid repayment address for chain ${repaymentChainId}: ${relayer.toAddress()}.`
+  );
   const relayData = {
     depositor: deposit.depositor.toBytes32(),
     recipient: deposit.recipient.toBytes32(),


### PR DESCRIPTION
This requires the caller to verify that they are supplying an EVM-instantiated address to the fill function.