### PR TITLE
chore: Permit suppression of invalid fill warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -413,12 +413,17 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     const suppressWarn = process.env.RELAYER_SUPPRESS_INVALID_FILLS === "true";
     const logLevel = chainIsProd(originChainId) && !suppressWarn ? "warn" : "debug";
     if (invalidFillsForDeposit.length > 0) {
+      const invalidFills = Object.fromEntries(
+        invalidFillsForDeposit.map(({ relayer, originChainId, destinationChainId, depositId, txnRef, }) => {
+          return [relayer, { originChainId, destinationChainId, depositId, txnRef }]
+        })
+      );
       this.logger[logLevel]({
         at: "SpokePoolClient",
         chainId: this.chainId,
         message: "Invalid fills found matching deposit ID",
         deposit,
-        invalidFills: Object.fromEntries(invalidFillsForDeposit.map((x) => [x.relayer, x])),
+        invalidFills,
         notificationPath: "across-invalid-fills",
       });
     }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -414,8 +414,8 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     const logLevel = chainIsProd(originChainId) && !suppressWarn ? "warn" : "debug";
     if (invalidFillsForDeposit.length > 0) {
       const invalidFills = Object.fromEntries(
-        invalidFillsForDeposit.map(({ relayer, originChainId, destinationChainId, depositId, txnRef, }) => {
-          return [relayer, { originChainId, destinationChainId, depositId, txnRef }]
+        invalidFillsForDeposit.map(({ relayer, originChainId, destinationChainId, depositId, txnRef }) => {
+          return [relayer, { originChainId, destinationChainId, depositId, txnRef }];
         })
       );
       this.logger[logLevel]({

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -410,7 +410,8 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
       return newInvalidFill;
     });
     // Log invalid and unrepayable fills as warns if we are on a production network.
-    const logLevel = chainIsProd(originChainId) ? "warn" : "debug";
+    const suppressWarn = process.env.RELAYER_SUPPRESS_INVALID_FILLS === "true";
+    const logLevel = chainIsProd(originChainId) && !suppressWarn ? "warn" : "debug";
     if (invalidFillsForDeposit.length > 0) {
       this.logger[logLevel]({
         at: "SpokePoolClient",


### PR DESCRIPTION
When a large number of these are emitted it blows up the Slack log transports and generally causes performance degradations.