### PR TITLE
chore(SpokePool): Add ClaimedRelayerRefund and BridgedToHubPool events

### DIFF
--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -24,6 +24,8 @@ import {
 import { duplicateEvent, sortEventsAscendingInPlace } from "../../utils/EventUtils";
 import { ZERO_ADDRESS } from "../../constants";
 import {
+  BridgedToHubPoolWithBlock,
+  ClaimedRelayerRefundWithBlock,
   Deposit,
   DepositWithBlock,
   EnabledDepositRouteWithBlock,
@@ -60,14 +62,11 @@ export const knownEventNames = [
   "TokensBridged",
   "RelayedRootBundle",
   "ExecutedRelayerRefundRoot",
-  "V3FundsDeposited",
   "FundsDeposited",
-  "RequestedSpeedUpV3Deposit",
   "RequestedSpeedUpDeposit",
-  "RequestedV3SlowFill",
   "RequestedSlowFill",
-  "FilledV3Relay",
   "FilledRelay",
+  "ClaimedRelayerRefund",
 ];
 
 /**
@@ -84,6 +83,8 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   protected tokensBridged: TokensBridged[] = [];
   protected rootBundleRelays: RootBundleRelayWithBlock[] = [];
   protected relayerRefundExecutions: RelayerRefundExecutionWithBlock[] = [];
+  protected claimedRelayerRefunds: ClaimedRelayerRefundWithBlock[] = [];
+  protected bridgedToHubPool: BridgedToHubPoolWithBlock[] = [];
   protected configStoreClient: AcrossConfigStoreClient | undefined;
   protected invalidFills: Set<string> = new Set();
   public readonly depositHashes: { [depositHash: string]: DepositWithBlock } = {};
@@ -240,6 +241,22 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    */
   public getRelayerRefundExecutions(): RelayerRefundExecutionWithBlock[] {
     return this.relayerRefundExecutions;
+  }
+
+  /**
+   * Retrieves a list of claimed relayer refunds from the SpokePool contract.
+   * @returns A list of claimed relayer refunds.
+   */
+  public getClaimedRelayerRefunds(): ClaimedRelayerRefundWithBlock[] {
+    return this.claimedRelayerRefunds;
+  }
+
+  /**
+   * Retrieves a list of bridged to hub pool events from the SpokePool contract.
+   * @returns A list of bridged to hub pool events.
+   */
+  public getBridgedToHubPool(): BridgedToHubPoolWithBlock[] {
+    return this.bridgedToHubPool;
   }
 
   /**
@@ -655,6 +672,25 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
         []) as RelayerRefundExecutionWithBlock[];
       for (const event of refundEvents) {
         this.relayerRefundExecutions.push(event);
+      }
+    }
+
+    if (eventsToQuery.includes("ClaimedRelayerRefund")) {
+      const claimedRelayerRefundEvents = (queryResults[eventsToQuery.indexOf("ClaimedRelayerRefund")] ??
+        []) as (ClaimedRelayerRefundWithBlock & { claimAmount?: BigNumber })[];
+      for (const event of claimedRelayerRefundEvents) {
+        this.claimedRelayerRefunds.push({
+          ...event,
+          amount: event.amount || event.claimAmount, // Note: This field is named differently in EVM and SVM
+        });
+      }
+    }
+
+    if (eventsToQuery.includes("BridgedToHubPool")) {
+      const bridgedToHubPoolEvents = (queryResults[eventsToQuery.indexOf("BridgedToHubPool")] ??
+        []) as (BridgedToHubPoolWithBlock & { amount?: BigNumber })[];
+      for (const event of bridgedToHubPoolEvents) {
+        this.bridgedToHubPool.push(event);
       }
     }
 

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -133,6 +133,18 @@ export interface TokensBridged extends SortableEvent {
   l2TokenAddress: string;
 }
 
+export interface ClaimedRelayerRefundWithBlock extends SortableEvent {
+  l2TokenAddress: string;
+  refundAddress: string;
+  amount: BigNumber;
+  caller: string;
+}
+
+export interface BridgedToHubPoolWithBlock extends SortableEvent {
+  amount: BigNumber;
+  mint: string;
+}
+
 export interface SpokePoolClientsByChain {
   [chainId: number]: SpokePoolClient;
 }


### PR DESCRIPTION
We need the SpokePoolClient to support `ClaimedRelayerRefund` and `BridgedToHubPool` events for the indexer.