### PR TITLE
improve(Address): Tighten & simplify EVM/SVM address validation

### DIFF
--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -224,12 +224,15 @@ export class Address {
 
 // Subclass of address which strictly deals with 20-byte addresses. These addresses are guaranteed to be valid EVM addresses, so `toAddress` will always succeed.
 export class EvmAddress extends Address {
+  static validate(rawAddress: Uint8Array): boolean {
+    return rawAddress.length == 20 || rawAddress.length === 32 && rawAddress.slice(0,12).some((field) => field !== 0);
+  }
+
   // On construction, validate that the address can indeed be coerced into an EVM address. Throw immediately if it cannot.
   constructor(rawAddress: Uint8Array) {
     super(rawAddress);
-    const hexString = utils.hexlify(rawAddress);
-    if (!this.isValidEvmAddress()) {
-      throw new Error(`${hexString} is not a valid EVM address`);
+    if (!EvmAddress.validate(rawAddress)) {
+      throw new Error(`${utils.hexlify(rawAddress)} is not a valid EVM address`);
     }
   }
 

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -235,7 +235,7 @@ export class EvmAddress extends Address {
 
   static validate(rawAddress: Uint8Array): boolean {
     return (
-      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).some((field) => field !== 0))
+      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).every((field) => field === 0))
     );
   }
 

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -224,16 +224,19 @@ export class Address {
 
 // Subclass of address which strictly deals with 20-byte addresses. These addresses are guaranteed to be valid EVM addresses, so `toAddress` will always succeed.
 export class EvmAddress extends Address {
-  static validate(rawAddress: Uint8Array): boolean {
-    return rawAddress.length == 20 || rawAddress.length === 32 && rawAddress.slice(0,12).some((field) => field !== 0);
-  }
-
   // On construction, validate that the address can indeed be coerced into an EVM address. Throw immediately if it cannot.
   constructor(rawAddress: Uint8Array) {
-    super(rawAddress);
     if (!EvmAddress.validate(rawAddress)) {
       throw new Error(`${utils.hexlify(rawAddress)} is not a valid EVM address`);
     }
+
+    super(rawAddress);
+  }
+
+  static validate(rawAddress: Uint8Array): boolean {
+    return (
+      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).some((field) => field !== 0))
+    );
   }
 
   // Override `toAddress` to return the 20-byte representation address.
@@ -263,7 +266,15 @@ export class EvmAddress extends Address {
 export class SvmAddress extends Address {
   // On construction, validate that the address is a point on Curve25519. Throw immediately if it is not.
   constructor(rawAddress: Uint8Array) {
+    if (!SvmAddress.validate(rawAddress)) {
+      throw new Error(`${utils.hexlify(rawAddress)} is not a valid SVM address`); // @todo: Display as Base58?
+    }
+
     super(rawAddress);
+  }
+
+  static validate(rawAddress: Uint8Array): boolean {
+    return rawAddress.length === 32;
   }
 
   // Override the toAddress function for SVM addresses only since while they will never have a defined 20-byte representation. The base58 encoded addresses are also the encodings

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -20,7 +20,11 @@ describe("Address Utils: Address Type", function () {
       expect(ethers.utils.isHexString(svmToken.toAddress())).to.be.false;
     });
     it("Coerces addresses to their proper type when possible", function () {
-      const evmAddress = toAddressType(randomBytes(20), CHAIN_IDs.MAINNET);
+      let evmAddress = toAddressType(randomBytes(20), CHAIN_IDs.MAINNET);
+      expect(EvmAddress.isAddress(evmAddress)).to.be.true;
+
+      // Should also accept 32-byte zero-padded addresses.
+      evmAddress = toAddressType("0x000000000000000000000000" + randomBytes(20).slice(2), CHAIN_IDs.MAINNET);
       expect(EvmAddress.isAddress(evmAddress)).to.be.true;
 
       const invalidEvmAddress = ethers.utils.arrayify(randomBytes(32));

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -30,7 +30,16 @@ describe("Address Utils: Address Type", function () {
       const invalidEvmAddress = ethers.utils.arrayify(randomBytes(32));
       invalidEvmAddress[0] = 1;
       expect(EvmAddress.validate(invalidEvmAddress)).to.be.false;
-      expect(toAddressType(invalidEvmAddress, CHAIN_IDs.MAINNET)).to.be.reverted;
+      expect(toAddressType(invalidEvmAddress, CHAIN_IDs.MAINNET)).to.throw;
+    });
+    it("Rejects invalid SVM address lengths", function () {
+      [20, 31, 33].forEach((len) => {
+        const rawAddress = ethers.utils.arrayify(randomBytes(len));
+        expect(() => new SvmAddress(rawAddress)).to.throw;
+      });
+
+      const rawAddress = ethers.utils.arrayify(randomBytes(32));
+      expect(new SvmAddress(rawAddress)).to.not.throw;
     });
     it("Handles base58-encoded EVM addresses", function () {
       const rawAddress = ethers.utils.arrayify(randomBytes(20));

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -23,9 +23,10 @@ describe("Address Utils: Address Type", function () {
       const evmAddress = toAddressType(randomBytes(20), CHAIN_IDs.MAINNET);
       expect(EvmAddress.isAddress(evmAddress)).to.be.true;
 
-      const invalidEvmAddress = toAddressType(randomBytes(32), CHAIN_IDs.MAINNET);
-      expect(EvmAddress.isAddress(invalidEvmAddress)).to.be.false;
-      expect(Address.isAddress(invalidEvmAddress)).to.be.true;
+      const invalidEvmAddress = ethers.utils.arrayify(randomBytes(32));
+      invalidEvmAddress[0] = 1;
+      expect(EvmAddress.validate(invalidEvmAddress)).to.be.false;
+      expect(toAddressType(invalidEvmAddress, CHAIN_IDs.MAINNET)).to.be.reverted;
     });
     it("Handles base58-encoded EVM addresses", function () {
       const rawAddress = ethers.utils.arrayify(randomBytes(20));


### PR DESCRIPTION
rawAddress is already typed as a Uint8Array so there's no need to revert
to its base16 representation unless it's actually invalid.

For EVM addresses, ensure length is 20 or 32 bytes and require 12 bytes
of padding when the input length is 32 bytes.
For SVM addresses, ensure length is exactly 32 bytes.