### PR TITLE
feat(svm): update to latest contracts and refactor SVM functions for u256 amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.2",
+  "version": "4.3.2-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [
@@ -106,7 +106,7 @@
   "dependencies": {
     "@across-protocol/across-token": "^1.0.0",
     "@across-protocol/constants": "^3.1.68",
-    "@across-protocol/contracts": "^4.0.12",
+    "@across-protocol/contracts": "^4.0.14-alpha.1",
     "@coral-xyz/anchor": "^0.30.1",
     "@eth-optimism/sdk": "^3.3.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -18,6 +18,7 @@ import {
   getU32Encoder,
   getU64Encoder,
   pipe,
+  ReadonlyUint8Array,
   some,
   type TransactionSigner,
 } from "@solana/kit";
@@ -39,6 +40,7 @@ import {
 } from "../../utils";
 import {
   SvmCpiEventsClient,
+  bigToU8a32,
   createDefaultTransaction,
   getEventAuthority,
   getFillStatusPda,
@@ -447,7 +449,7 @@ export async function fillRelayInstruction(
       exclusiveRelayer,
       inputToken,
       outputToken,
-      inputAmount: relayData.inputAmount.toBigInt(),
+      inputAmount: bigToU8a32(relayData.inputAmount.toBigInt()),
       outputAmount: relayData.outputAmount.toBigInt(),
       originChainId: BigInt(relayData.originChainId),
       fillDeadline: relayData.fillDeadline,
@@ -643,7 +645,7 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId: numbe
     encodeAddress(relayData.exclusiveRelayer),
     encodeAddress(relayData.inputToken),
     encodeAddress(relayData.outputToken),
-    Uint8Array.from(uint64Encoder.encode(BigInt(relayData.inputAmount.toString()))),
+    arrayify(hexZeroPad(hexlify(relayData.inputAmount), 32)),
     Uint8Array.from(uint64Encoder.encode(BigInt(relayData.outputAmount.toString()))),
     Uint8Array.from(uint64Encoder.encode(BigInt(relayData.originChainId.toString()))),
     arrayify(hexZeroPad(hexlify(relayData.depositId), 32)),
@@ -751,7 +753,7 @@ export async function getDepositDelegatePda(
     inputToken: Address<string>;
     outputToken: Address<string>;
     inputAmount: bigint;
-    outputAmount: bigint;
+    outputAmount: ReadonlyUint8Array;
     destinationChainId: bigint;
     exclusiveRelayer: Address<string>;
     quoteTimestamp: bigint;
@@ -771,7 +773,7 @@ export async function getDepositDelegatePda(
     Uint8Array.from(addrEnc.encode(depositData.inputToken)),
     Uint8Array.from(addrEnc.encode(depositData.outputToken)),
     Uint8Array.from(u64.encode(depositData.inputAmount)),
-    Uint8Array.from(u64.encode(depositData.outputAmount)),
+    Uint8Array.from(depositData.outputAmount),
     Uint8Array.from(u64.encode(depositData.destinationChainId)),
     Uint8Array.from(addrEnc.encode(depositData.exclusiveRelayer)),
     Uint8Array.from(u32.encode(depositData.quoteTimestamp)),
@@ -801,7 +803,7 @@ export async function getDepositNowDelegatePda(
     inputToken: Address<string>;
     outputToken: Address<string>;
     inputAmount: bigint;
-    outputAmount: bigint;
+    outputAmount: ReadonlyUint8Array;
     destinationChainId: bigint;
     exclusiveRelayer: Address<string>;
     fillDeadlineOffset: bigint;
@@ -820,7 +822,7 @@ export async function getDepositNowDelegatePda(
     Uint8Array.from(addrEnc.encode(depositData.inputToken)),
     Uint8Array.from(addrEnc.encode(depositData.outputToken)),
     Uint8Array.from(u64.encode(depositData.inputAmount)),
-    Uint8Array.from(u64.encode(depositData.outputAmount)),
+    Uint8Array.from(depositData.outputAmount),
     Uint8Array.from(u64.encode(depositData.destinationChainId)),
     Uint8Array.from(addrEnc.encode(depositData.exclusiveRelayer)),
     Uint8Array.from(u32.encode(depositData.fillDeadlineOffset)),

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -19,6 +19,7 @@ import { SvmSpokeClient } from "@across-protocol/contracts";
 import { FillType, RelayData } from "../../interfaces";
 import { BigNumber, getRelayDataHash, isUint8Array, Address as SdkAddress } from "../../utils";
 import { EventName, SVMEventNames, SVMProvider } from "./types";
+import { intToU8Array32 } from "@across-protocol/contracts/dist/src/svm/web3-v1";
 
 /**
  * Basic void TransactionSigner type
@@ -310,4 +311,22 @@ export const createDefaultTransaction = async (rpcClient: SVMProvider, signer: T
     (tx) => setTransactionMessageFeePayerSigner(signer, tx),
     (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx)
   );
+};
+
+/**
+ * Converts a BigNumber or bigint to a Uint8Array of 32 bytes.
+ * @param bn - The BigNumber or bigint to convert.
+ * @returns The Uint8Array of 32 bytes.
+ */
+export const bigToU8a32 = (bn: BigNumber | bigint) => {
+  return new Uint8Array(intToU8Array32(Number(bn)));
+};
+
+/**
+ * Converts a number to a Uint8Array of 32 bytes.
+ * @param n - The number to convert.
+ * @returns The Uint8Array of 32 bytes.
+ */
+export const numberToU8a32 = (n: number) => {
+  return new Uint8Array(intToU8Array32(n));
 };

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -17,6 +17,7 @@ import {
   SVMEventNames,
   SVMProvider,
   getRandomSvmAddress,
+  bigToU8a32,
 } from "../../arch/svm";
 import { bnZero, bnOne, bs58, getCurrentTime, randomAddress, EvmAddress, SvmAddress } from "../../utils";
 import { FillType } from "../../interfaces";
@@ -82,7 +83,7 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     const inputToken = deposit.inputToken ?? getRandomSvmAddress();
     const outputToken = deposit.outputToken ?? SvmAddress.from(randomBytes(32), "base16").toBase58();
     inputAmount ??= BigInt(random(1, 1000, false));
-    outputAmount ??= (inputAmount * BigInt(95)) / BigInt(100);
+    outputAmount ??= bigToU8a32((inputAmount * BigInt(95)) / BigInt(100));
     const message = deposit.message ?? new Uint8Array(32);
     const quoteTimestamp = deposit.quoteTimestamp ?? getCurrentTime();
 
@@ -114,8 +115,9 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     const { slot } = fill;
     let { depositId, inputAmount, outputAmount, fillDeadline } = fill;
     depositId ??= arrayify(hexZeroPad(hexlify(random(1, 100_000, false)), 32));
-    inputAmount ??= BigInt(random(1, 1000, false));
-    outputAmount ??= (inputAmount * BigInt(95)) / BigInt(100);
+    const inputAmountBigInt = BigInt(random(1, 1000, false));
+    inputAmount ??= bigToU8a32(inputAmountBigInt);
+    outputAmount ??= (inputAmountBigInt * BigInt(95)) / BigInt(100);
     fillDeadline ??= getCurrentTime() + 60;
 
     const depositor = fill.depositor ?? EvmAddress.from(randomAddress()).toBase58();

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -7,6 +7,7 @@ import { getComputeUnitEstimateForTransactionMessageFactory } from "@solana/kit"
 import {
   SVMProvider,
   SolanaVoidSigner,
+  bigToU8a32,
   createFillInstruction,
   getAssociatedTokenAddress,
   getEventAuthority,
@@ -196,7 +197,7 @@ export class SvmQuery implements QueryInterface {
       exclusiveRelayer: toAddress(exclusiveRelayer),
       inputToken: toAddress(inputToken),
       outputToken: mint,
-      inputAmount: relayData.inputAmount.toBigInt(),
+      inputAmount: bigToU8a32(relayData.inputAmount.toBigInt()),
       outputAmount: relayData.outputAmount.toBigInt(),
       originChainId: relayData.originChainId,
       depositId: new Uint8Array(intToU8Array32(relayData.depositId.toNumber())),

--- a/test/SVMSpokePoolClient.fills.ts
+++ b/test/SVMSpokePoolClient.fills.ts
@@ -8,6 +8,7 @@ import {
   createCloseFillPdaInstruction,
   findFillEvent,
   getRandomSvmAddress,
+  numberToU8a32,
 } from "../src/arch/svm";
 import { SVMSpokePoolClient } from "../src/clients";
 import { Deposit, FillStatus } from "../src/interfaces";
@@ -64,7 +65,7 @@ describe("SVMSpokePoolClient: Fills", function () {
       exclusiveRelayer: toAddressType(SVM_DEFAULT_ADDRESS, CHAIN_IDs.SOLANA),
       inputToken,
       outputToken: toAddressType(mint.address, CHAIN_IDs.SOLANA),
-      inputAmount: 10,
+      inputAmount: numberToU8a32(10),
       outputAmount: 9,
       originChainId: CHAIN_IDs.MAINNET,
       depositId: new Uint8Array(intToU8Array32(depositId)),

--- a/test/Solana.SvmCpiEventsClient.Integration.test.ts
+++ b/test/Solana.SvmCpiEventsClient.Integration.test.ts
@@ -3,7 +3,7 @@ import { SvmSpokeClient } from "@across-protocol/contracts";
 import { u8Array32ToInt } from "@across-protocol/contracts/dist/src/svm/web3-v1";
 import { KeyPairSigner, address } from "@solana/kit";
 import { expect } from "chai";
-import { SvmCpiEventsClient } from "../src/arch/svm";
+import { SvmCpiEventsClient, bigToU8a32 } from "../src/arch/svm";
 import { signer } from "./Solana.setup";
 import {
   createDefaultSolanaClient,
@@ -41,11 +41,11 @@ describe("SvmCpiEventsClient (integration)", () => {
     const payerAta = await mintTokens(signer, solanaClient, mint.address, tokenAmount * 2n + 1n);
     await sendCreateDeposit(solanaClient, signer, mint, decimals, payerAta, {
       inputAmount: tokenAmount,
-      outputAmount: tokenAmount,
+      outputAmount: bigToU8a32(tokenAmount),
     });
     await sendCreateDeposit(solanaClient, signer, mint, decimals, payerAta, {
       inputAmount: tokenAmount + 1n,
-      outputAmount: tokenAmount + 1n,
+      outputAmount: bigToU8a32(tokenAmount + 1n),
     });
     // Store final slot
     const toSlot = await solanaClient.rpc.getSlot().send();
@@ -60,7 +60,7 @@ describe("SvmCpiEventsClient (integration)", () => {
     const payerAta = await mintTokens(signer, solanaClient, mint.address, tokenAmount);
     const { depositInput } = await sendCreateDeposit(solanaClient, signer, mint, decimals, payerAta, {
       inputAmount: tokenAmount,
-      outputAmount: tokenAmount,
+      outputAmount: bigToU8a32(tokenAmount),
       message: Buffer.from([48, 120]),
     });
 
@@ -73,7 +73,9 @@ describe("SvmCpiEventsClient (integration)", () => {
     expect(data.inputToken).to.equal(depositInput.inputToken.toString());
     expect(data.outputToken).to.equal(depositInput.outputToken.toString());
     expect(data.inputAmount).to.equal(depositInput.inputAmount);
-    expect(data.outputAmount).to.equal(depositInput.outputAmount);
+    expect(u8Array32ToInt(Array.from(data.outputAmount))).to.equal(
+      u8Array32ToInt(Array.from(depositInput.outputAmount))
+    );
     expect(data.destinationChainId).to.equal(BigInt(depositInput.destinationChainId));
     expect(data.exclusiveRelayer).to.equal(depositInput.exclusiveRelayer.toString());
     expect(data.quoteTimestamp).to.equal(depositInput.quoteTimestamp);
@@ -86,7 +88,7 @@ describe("SvmCpiEventsClient (integration)", () => {
     const payerAta = await mintTokens(signer, solanaClient, mint.address, tokenAmount * 2n + 1n);
     const { signature: firstSig } = await sendCreateDeposit(solanaClient, signer, mint, decimals, payerAta, {
       inputAmount: tokenAmount,
-      outputAmount: tokenAmount,
+      outputAmount: bigToU8a32(tokenAmount),
     });
     const tx1 = await solanaClient.rpc
       .getTransaction(firstSig, {
@@ -103,7 +105,7 @@ describe("SvmCpiEventsClient (integration)", () => {
       mint,
       decimals,
       payerAta,
-      { inputAmount: tokenAmount + 1n, outputAmount: tokenAmount + 1n }
+      { inputAmount: tokenAmount + 1n, outputAmount: bigToU8a32(tokenAmount + 1n) }
     );
     const tx2 = await solanaClient.rpc
       .getTransaction(secondSig, {
@@ -134,7 +136,7 @@ describe("SvmCpiEventsClient (integration)", () => {
     expect(data.recipient).to.equal(relayData.recipient.toBase58());
     expect(data.inputToken).to.equal(relayData.inputToken.toBase58());
     expect(data.outputToken).to.equal(relayData.outputToken.toBase58());
-    expect(data.inputAmount).to.equal(BigInt(relayData.inputAmount));
+    expect(u8Array32ToInt(Array.from(data.inputAmount))).to.equal(u8Array32ToInt(Array.from(relayData.inputAmount)));
     expect(data.outputAmount).to.equal(BigInt(relayData.outputAmount));
     expect(data.originChainId).to.equal(BigInt(relayData.originChainId));
     expect(data.depositId.toString()).to.equal(Array.from(relayData.depositId).toString());
@@ -153,7 +155,7 @@ describe("SvmCpiEventsClient (integration)", () => {
     expect(data.recipient).to.equal(relayData.recipient.toBase58());
     expect(data.inputToken).to.equal(relayData.inputToken.toBase58());
     expect(data.outputToken).to.equal(relayData.outputToken.toBase58());
-    expect(data.inputAmount).to.equal(BigInt(relayData.inputAmount));
+    expect(u8Array32ToInt(Array.from(data.inputAmount))).to.equal(u8Array32ToInt(Array.from(relayData.inputAmount)));
     expect(data.outputAmount).to.equal(BigInt(relayData.outputAmount));
     expect(data.originChainId).to.equal(BigInt(relayData.originChainId));
     expect(data.depositId.toString()).to.equal(Array.from(relayData.depositId).toString());
@@ -167,7 +169,7 @@ describe("SvmCpiEventsClient (integration)", () => {
     const payerAta = await mintTokens(signer, solanaClient, address(mint.address), tokenAmount);
     const { depositInput, signature } = await sendCreateDeposit(solanaClient, signer, mint, decimals, payerAta, {
       inputAmount: tokenAmount,
-      outputAmount: tokenAmount,
+      outputAmount: bigToU8a32(tokenAmount),
     });
 
     const depositEvents = await client.getDepositEventsFromSignature(solanaClient.chainId, signature);
@@ -179,7 +181,9 @@ describe("SvmCpiEventsClient (integration)", () => {
     expect(depositEvent.inputToken.toBase58()).to.equal(depositInput.inputToken.toString());
     expect(depositEvent.outputToken.toBase58()).to.equal(depositInput.outputToken.toString());
     expect(depositEvent.inputAmount.toString()).to.equal(depositInput.inputAmount.toString());
-    expect(depositEvent.outputAmount.toString()).to.equal(depositInput.outputAmount.toString());
+    expect(BigInt(depositEvent.outputAmount.toString())).to.equal(
+      BigInt(u8Array32ToInt(Array.from(depositInput.outputAmount)))
+    );
     expect(depositEvent.destinationChainId).to.equal(depositInput.destinationChainId);
   });
 
@@ -199,7 +203,9 @@ describe("SvmCpiEventsClient (integration)", () => {
     expect(fillEvent.recipient.toBase58()).to.equal(relayData.recipient.toBase58());
     expect(fillEvent.inputToken.toBase58()).to.equal(relayData.inputToken.toBase58());
     expect(fillEvent.outputToken.toBase58()).to.equal(relayData.outputToken.toBase58());
-    expect(fillEvent.inputAmount.toString()).to.equal(BigInt(relayData.inputAmount).toString());
+    expect(BigInt(fillEvent.inputAmount.toString())).to.equal(
+      BigInt(u8Array32ToInt(Array.from(relayData.inputAmount)))
+    );
     expect(fillEvent.outputAmount.toString()).to.equal(BigInt(relayData.outputAmount).toString());
     expect(fillEvent.originChainId).to.equal(Number(relayData.originChainId));
     expect(fillEvent.depositId).to.equal(u8Array32ToInt(Array.from(relayData.depositId)));

--- a/test/utils/svm/utils.ts
+++ b/test/utils/svm/utils.ts
@@ -34,6 +34,7 @@ import {
   RpcClient,
   SVM_DEFAULT_ADDRESS,
   SVM_SPOKE_SEED,
+  bigToU8a32,
   createDefaultTransaction,
   createDepositInstruction,
   createFillInstruction,
@@ -46,6 +47,7 @@ import {
   getRandomSvmAddress,
   getStatePda,
   toAddress,
+  numberToU8a32,
 } from "../../../src/arch/svm";
 import { RelayData } from "../../../src/interfaces";
 import {
@@ -244,7 +246,7 @@ export const sendCreateFill = async (
     inputToken:
       overrides.inputToken ?? toAddressType(address(EvmAddress.from(randomAddress()).toBase58()), CHAIN_IDs.MAINNET),
     outputToken: toAddressType(mint.address),
-    inputAmount: overrides.inputAmount ?? getRandomInt(),
+    inputAmount: overrides.inputAmount ?? bigToU8a32(BigNumber.from(getRandomInt())),
     outputAmount: overrides.outputAmount ?? getRandomInt(),
     originChainId: overrides.originChainId ?? CHAIN_IDs.MAINNET,
     depositId: overrides.depositId ?? new Uint8Array(intToU8Array32(getRandomInt())),
@@ -329,7 +331,7 @@ export const sendRequestSlowFill = async (
     exclusiveRelayer: overrides.exclusiveRelayer ?? toAddressType(SVM_DEFAULT_ADDRESS, CHAIN_IDs.SOLANA),
     inputToken: overrides.inputToken ?? EvmAddress.from(randomAddress()),
     outputToken: overrides.outputToken ?? toAddressType(getRandomSvmAddress(), CHAIN_IDs.SOLANA),
-    inputAmount: overrides.inputAmount ?? getRandomInt(),
+    inputAmount: overrides.inputAmount ?? numberToU8a32(getRandomInt()),
     outputAmount: overrides.outputAmount ?? getRandomInt(),
     originChainId: overrides.originChainId ?? CHAIN_IDs.MAINNET,
     depositId: overrides.depositId ?? new Uint8Array(intToU8Array32(getRandomInt())),
@@ -392,7 +394,7 @@ export const sendCreateDeposit = async (
     inputToken: mint.address,
     outputToken: overrides.outputToken ?? address(EvmAddress.from(randomAddress()).toBase58()),
     inputAmount: overrides.inputAmount ?? getRandomInt(),
-    outputAmount: overrides.outputAmount ?? getRandomInt(),
+    outputAmount: overrides.outputAmount ?? numberToU8a32(getRandomInt()),
     destinationChainId: destinationChainId,
     exclusiveRelayer: overrides.exclusiveRelayer ?? address(EvmAddress.from(randomAddress()).toBase58()),
     quoteTimestamp: overrides.quoteTimestamp ?? Number(currentTime),
@@ -417,7 +419,7 @@ export const sendCreateDeposit = async (
     inputToken: depositInput.inputToken,
     outputToken: depositInput.outputToken,
     inputAmount: BigInt(depositInput.inputAmount),
-    outputAmount: BigInt(depositInput.outputAmount),
+    outputAmount: depositInput.outputAmount,
     destinationChainId: BigInt(destinationChainId),
     exclusiveRelayer: depositInput.exclusiveRelayer,
     quoteTimestamp: BigInt(depositInput.quoteTimestamp),

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,7 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants@^3.1.63":
-  version "3.1.67"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.67.tgz#10e37b48792e839a94e4841cd6f31b8980969147"
-  integrity sha512-5XJcHU0I8UksYHCHO394uiAAAKkmlNs49dWBSgD5UZwslo/U7HTiQY6MfO24f/Q8rgSabBsSt9jdquyeba7VxA==
-
-"@across-protocol/constants@^3.1.68":
+"@across-protocol/constants@^3.1.66", "@across-protocol/constants@^3.1.68":
   version "3.1.68"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.68.tgz#2a58b091b3f717394ee8025b20ee89022da849d8"
   integrity sha512-f/o4i323HxwT/4h32xZdxKLwN3xXoAaxcd/xwP0tfAc/+X4/a+1qJ5Mfx+U2IwDkSheiSyqRYF3z5oYPnax3mg==
@@ -35,12 +30,12 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/contracts@^4.0.12":
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-4.0.12.tgz#45e8d6cc1fe137ae5349c1aa4b17e9ebc8e982cd"
-  integrity sha512-OreKSdJS1uOo9/bPkYQrym1Gcwz9ccINviQ+72Nbfw11NwJmlkdWEMAMQ7Y8MaiXPvneOkXH1enZJI2M9YIrgA==
+"@across-protocol/contracts@^4.0.14-alpha.1":
+  version "4.0.14-alpha.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-4.0.14-alpha.1.tgz#0f6a04df5a999c56e787304b7a68e76c3f456cbc"
+  integrity sha512-HgUy3Di7qxdwbOV6BrmqPgN6RmiijBL/m/LrAJ2AMIF7rqSe3urEE1skpMyGBzVOL3d2ocOa0rT3YqAxqlz2yA==
   dependencies:
-    "@across-protocol/constants" "^3.1.63"
+    "@across-protocol/constants" "^3.1.66"
     "@coral-xyz/anchor" "^0.31.1"
     "@defi-wonderland/smock" "^2.3.4"
     "@eth-optimism/contracts" "^0.5.40"


### PR DESCRIPTION
Summary

This PR updates the SDK to use the latest SVM contract version and migrates relevant SVM logic to support u256 (as Uint8Array) for inputAmount and outputAmount.

Changes
- Bumped @across-protocol/contracts version
- Replaced u64 amount handling with u256 (Uint8Array)
- Updated utils, mock clients, and tests accordingly