### PR TITLE
improve(SpokePoolClient): Negate non-EVM SpeedUp recipients

### DIFF
--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -572,11 +572,10 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId.toString()], [speedUp]);
 
         // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
-        // if the hash+data exists.
+        // if the hash+data exists. nb. Relying on depositId alone can produce collisions on deterministic deposit IDs.
         const deposit = this.getDeposit(speedUp.depositId);
 
         // SpeedUp requests are only supported EVM -> EVM.
-        // nb. Relying on depositId alone check can collide;
         if (isDefined(deposit) && chainIsEvm(deposit.destinationChainId)) {
           // We can assume all deposits in this lookback window are loaded in-memory already so if the depositHash
           // is not mapped to a deposit, then we can throw away the speedup as it can't be applied to anything.

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -576,7 +576,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
         const deposit = this.getDeposit(speedUp.depositId);
 
         // SpeedUp requests are only supported EVM -> EVM.
-        if (isDefined(deposit) && chainIsEvm(deposit.destinationChainId)) {
+        if (isDefined(deposit) && chainIsEvm(deposit.destinationChainId) && deposit.depositor === speedUp.depositor) {
           // We can assume all deposits in this lookback window are loaded in-memory already so if the depositHash
           // is not mapped to a deposit, then we can throw away the speedup as it can't be applied to anything.
           const eventKey = getRelayEventKey(deposit);


### PR DESCRIPTION
SpeedUp events are only supported for EVM -> EVM, so any other combination can be discarded immediately.