### PR TITLE
chore: Drop unnecessary gasPriceOracle typecast

### DIFF
--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -19,7 +19,7 @@ import {
 import assert from "assert";
 import { Logger, QueryInterface, getDefaultSimulatedRelayerAddress } from "../relayFeeCalculator";
 import { Transport } from "viem";
-import { getGasPriceEstimate, EvmGasPriceEstimate } from "../../gasPriceOracle";
+import { getGasPriceEstimate } from "../../gasPriceOracle";
 import { EvmProvider } from "../../arch/evm/types";
 
 export type SymbolMappingType = Record<
@@ -213,9 +213,9 @@ export class QueryBase implements QueryInterface {
         ? Promise.resolve({ maxFeePerGas: _gasPrice })
         : getGasPriceEstimate(provider, { chainId, baseFeeMultiplier, priorityFeeMultiplier, transport, unsignedTx }),
     ] as const;
-    const [nativeGasCost, _gasPriceEstimate] = await Promise.all(queries);
-    // It should be safe to cast to an EvmGasPriceEstimate here since QueryBase is only used for EVM chains.
-    const gasPrice = (_gasPriceEstimate as EvmGasPriceEstimate).maxFeePerGas;
+    const [nativeGasCost, gasPriceEstimate] = await Promise.all(queries);
+
+    const gasPrice = gasPriceEstimate.maxFeePerGas;
     assert(nativeGasCost.gt(bnZero), "Gas cost should not be 0");
     let tokenGasCost: BigNumber;
 

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -15,7 +15,7 @@ import {
 } from "../../arch/svm";
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";
-import { SvmGasPriceEstimate, getGasPriceEstimate } from "../../gasPriceOracle";
+import { getGasPriceEstimate } from "../../gasPriceOracle";
 import { Deposit } from "../../interfaces";
 import {
   BigNumber,
@@ -85,7 +85,7 @@ export class SvmQuery implements QueryInterface {
     const relayer = _relayer ? toAddressType(_relayer).forceSvmAddress() : this.simulatedRelayerAddress;
     const fillRelayTx = await this.getFillRelayTx(deposit, relayer.toBase58());
 
-    const [computeUnitsConsumed, _gasPriceEstimate] = await Promise.all([
+    const [computeUnitsConsumed, gasPriceEstimate] = await Promise.all([
       toBN(await this.computeUnitEstimator(fillRelayTx)),
       getGasPriceEstimate(this.provider, {
         unsignedTx: fillRelayTx,
@@ -96,7 +96,6 @@ export class SvmQuery implements QueryInterface {
 
     // We can cast the gas price estimate to an SvmGasPriceEstimate here since the oracle should always
     // query the Solana adapter.
-    const gasPriceEstimate = _gasPriceEstimate as SvmGasPriceEstimate;
     const gasPrice = gasPriceEstimate.baseFee.add(
       gasPriceEstimate.microLamportsPerComputeUnit.mul(computeUnitsConsumed).div(toBN(1_000_000)) // 1_000_000 microLamports/lamport.
     );


### PR DESCRIPTION
Not needed since G's change to overload the gasPriceOracle function prototypes.