### PR TITLE
improve: Cleanup chain-specific address type handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.2.16-alpha.5",
+  "version": "4.2.16-alpha.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -40,7 +40,7 @@ type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> &
 
 /**
  * @param spokePool SpokePool Contract instance.
- * @param deposit V3Deopsit instance.
+ * @param deposit A prototype Fill instance that will be used to create a fillRelay transaction.
  * @param repaymentChainId Optional repaymentChainId (defaults to destinationChainId).
  * @returns An Ethers UnsignedTransaction instance.
  */

--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -1,10 +1,18 @@
 import assert from "assert";
 import { BytesLike, Contract, PopulatedTransaction, providers } from "ethers";
 import { CHAIN_IDs } from "../../constants";
-import { Deposit, FillStatus, FillWithBlock, RelayData, RelayExecutionEventInfo } from "../../interfaces";
+import {
+  Deposit,
+  FillStatus,
+  FillWithBlock,
+  RelayData,
+  RelayExecutionEventInfo,
+  SpeedUpCommon,
+} from "../../interfaces";
 import {
   bnUint32Max,
   BigNumber,
+  EvmAddress,
   toBN,
   bnZero,
   chunk,
@@ -22,6 +30,14 @@ import {
 
 type BlockTag = providers.BlockTag;
 
+type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> &
+  Pick<Deposit, "speedUpSignature"> &
+  Partial<SpeedUpCommon> & {
+    destinationChainId: number;
+    recipient: EvmAddress;
+    outputToken: EvmAddress;
+  };
+
 /**
  * @param spokePool SpokePool Contract instance.
  * @param deposit V3Deopsit instance.
@@ -30,7 +46,7 @@ type BlockTag = providers.BlockTag;
  */
 export function populateV3Relay(
   spokePool: Contract,
-  deposit: Omit<Deposit, "messageHash" | "fromLiteChain" | "toLiteChain">,
+  deposit: ProtoFill,
   repaymentAddress: Address,
   repaymentChainId = deposit.destinationChainId
 ): Promise<PopulatedTransaction> {

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -377,7 +377,7 @@ export async function findFillEvent(
 
 /**
  * @param spokePool Address (program ID) of the SvmSpoke.
- * @param deposit V3Deopsit instance.
+ * @param deposit A prototype Fill instance that will be used to create a fillRelay transaction.
  * @param relayer Address of the relayer filling the deposit.
  * @param repaymentChainId Optional repaymentChainId (defaults to destinationChainId).
  * @returns An Ethers UnsignedTransaction instance.

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -25,14 +25,7 @@ import assert from "assert";
 import { arrayify, hexZeroPad, hexlify } from "ethers/lib/utils";
 import { Logger } from "winston";
 import { SYSTEM_PROGRAM_ADDRESS } from "@solana-program/system";
-import {
-  Deposit,
-  DepositWithBlock,
-  FillStatus,
-  FillWithBlock,
-  RelayData,
-  RelayExecutionEventInfo,
-} from "../../interfaces";
+import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayExecutionEventInfo } from "../../interfaces";
 import {
   BigNumber,
   EvmAddress,
@@ -61,6 +54,12 @@ import { SVMEventNames, SVMProvider } from "./types";
  *        and choose 400 to ensure that the most slots get included in our ranges
  */
 export const SLOT_DURATION_MS = 400;
+
+type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> & {
+  destinationChainId: number;
+  recipient: SvmAddress;
+  outputToken: SvmAddress;
+};
 
 /**
  * Retrieves the chain time at a particular slot.
@@ -385,14 +384,7 @@ export async function findFillEvent(
  */
 export async function fillRelayInstruction(
   spokePool: SvmAddress,
-  deposit: Omit<
-    Deposit,
-    "recipient" | "outputToken" | "exclusiveRelayer" | "messageHash" | "fromLiteChain" | "toLiteChain"
-  > & {
-    recipient: SvmAddress;
-    outputToken: SvmAddress;
-    exclusiveRelayer: SvmAddress;
-  },
+  deposit: ProtoFill,
   signer: TransactionSigner<string>,
   recipientTokenAccount: Address<string>,
   repaymentAddress: EvmAddress | SvmAddress = SvmAddress.from(signer.address),

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -377,18 +377,18 @@ export async function findFillEvent(
 
 /**
  * @param spokePool Address (program ID) of the SvmSpoke.
- * @param deposit A prototype Fill instance that will be used to create a fillRelay transaction.
+ * @param relayData RelayData instance, supplemented with destinationChainId
  * @param relayer Address of the relayer filling the deposit.
  * @param repaymentChainId Optional repaymentChainId (defaults to destinationChainId).
  * @returns An Ethers UnsignedTransaction instance.
  */
 export async function fillRelayInstruction(
   spokePool: SvmAddress,
-  deposit: ProtoFill,
+  relayData: ProtoFill,
   signer: TransactionSigner<string>,
   recipientTokenAccount: Address<string>,
   repaymentAddress: EvmAddress | SvmAddress = SvmAddress.from(signer.address),
-  repaymentChainId = deposit.destinationChainId
+  repaymentChainId = relayData.destinationChainId
 ) {
   const program = toAddress(spokePool);
 
@@ -397,22 +397,22 @@ export async function fillRelayInstruction(
     `Invalid repayment address for chain ${repaymentChainId}: ${repaymentAddress.toNative()}.`
   );
 
-  const _relayDataHash = getRelayDataHash(deposit, deposit.destinationChainId);
+  const _relayDataHash = getRelayDataHash(relayData, relayData.destinationChainId);
   const relayDataHash = new Uint8Array(Buffer.from(_relayDataHash.slice(2), "hex"));
 
   const relayer = SvmAddress.from(signer.address);
 
   // Create ATA for the relayer and recipient token accounts
-  const relayerTokenAccount = await getAssociatedTokenAddress(relayer, deposit.outputToken);
+  const relayerTokenAccount = await getAssociatedTokenAddress(relayer, relayData.outputToken);
 
   const [statePda, fillStatusPda, eventAuthority] = await Promise.all([
     getStatePda(program),
-    getFillStatusPda(program, deposit, deposit.destinationChainId),
+    getFillStatusPda(program, relayData, relayData.destinationChainId),
     getEventAuthority(program),
   ]);
 
   const depositIdBuffer = new Uint8Array(32);
-  const shortenedBuffer = new Uint8Array(Buffer.from(deposit.depositId.toHexString().slice(2), "hex"));
+  const shortenedBuffer = new Uint8Array(Buffer.from(relayData.depositId.toHexString().slice(2), "hex"));
   depositIdBuffer.set(shortenedBuffer, 32 - shortenedBuffer.length);
 
   const delegatePda = await getFillRelayDelegatePda(
@@ -423,11 +423,11 @@ export async function fillRelayInstruction(
   );
 
   const [recipient, outputToken, exclusiveRelayer, depositor, inputToken] = [
-    deposit.recipient,
-    deposit.outputToken,
-    deposit.exclusiveRelayer,
-    deposit.depositor,
-    deposit.inputToken,
+    relayData.recipient,
+    relayData.outputToken,
+    relayData.exclusiveRelayer,
+    relayData.depositor,
+    relayData.inputToken,
   ].map(toAddress);
 
   return SvmSpokeClient.getFillRelayInstruction({
@@ -447,13 +447,13 @@ export async function fillRelayInstruction(
       exclusiveRelayer,
       inputToken,
       outputToken,
-      inputAmount: deposit.inputAmount.toBigInt(),
-      outputAmount: deposit.outputAmount.toBigInt(),
-      originChainId: BigInt(deposit.originChainId),
-      fillDeadline: deposit.fillDeadline,
-      exclusivityDeadline: deposit.exclusivityDeadline,
+      inputAmount: relayData.inputAmount.toBigInt(),
+      outputAmount: relayData.outputAmount.toBigInt(),
+      originChainId: BigInt(relayData.originChainId),
+      fillDeadline: relayData.fillDeadline,
+      exclusivityDeadline: relayData.exclusivityDeadline,
       depositId: depositIdBuffer,
-      message: new Uint8Array(Buffer.from(deposit.message.slice(2), "hex")),
+      message: new Uint8Array(Buffer.from(relayData.message.slice(2), "hex")),
     }),
     repaymentChainId: some(BigInt(repaymentChainId)),
     repaymentAddress: toAddress(repaymentAddress),

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -18,14 +18,17 @@ export interface RelayData {
   exclusivityDeadline: number;
 }
 
-export interface Deposit extends RelayData {
+export interface SpeedUpCommon {
+  updatedRecipient: Address;
+  updatedOutputAmount: BigNumber;
+  updatedMessage: string;
+}
+
+export interface Deposit extends RelayData, Partial<SpeedUpCommon> {
   messageHash: string;
   destinationChainId: number;
   quoteTimestamp: number;
   speedUpSignature?: string;
-  updatedRecipient?: Address;
-  updatedOutputAmount?: BigNumber;
-  updatedMessage?: string;
   fromLiteChain: boolean;
   toLiteChain: boolean;
 }
@@ -78,14 +81,11 @@ export interface EnabledDepositRoute {
 }
 
 export interface EnabledDepositRouteWithBlock extends EnabledDepositRoute, SortableEvent {}
-export interface SpeedUp {
+export interface SpeedUp extends SpeedUpCommon {
   depositor: EvmAddress;
   depositorSignature: string;
   depositId: BigNumber;
   originChainId: number;
-  updatedRecipient: Address;
-  updatedOutputAmount: BigNumber;
-  updatedMessage: string;
 }
 
 export interface SpeedUpWithBlock extends SpeedUp, SortableEvent {}

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -132,7 +132,6 @@ export class QueryBase implements QueryInterface {
     deposit: Omit<Deposit, "messageHash"> & {
       recipient: EvmAddress;
       outputToken: EvmAddress;
-      exclusiveRelayer: EvmAddress;
     },
     relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId)
   ): Promise<PopulatedTransaction> {

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -19,7 +19,7 @@ import {
   Address,
 } from "../../utils";
 import assert from "assert";
-import { Logger, QueryInterface, getDefaultSimulatedRelayerAddress } from "../relayFeeCalculator";
+import { Logger, QueryInterface, getDefaultRelayer } from "../relayFeeCalculator";
 import { Transport } from "viem";
 import { getGasPriceEstimate } from "../../gasPriceOracle";
 import { EvmProvider } from "../../arch/evm/types";
@@ -74,7 +74,7 @@ export class QueryBase implements QueryInterface {
    */
   async getGasCosts(
     relayData: RelayData & { destinationChainId: number },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId),
+    relayer = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId),
     options: Partial<{
       gasPrice: BigNumberish;
       gasUnits: BigNumberish;
@@ -133,7 +133,7 @@ export class QueryBase implements QueryInterface {
       recipient: EvmAddress;
       outputToken: EvmAddress;
     },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId)
+    relayer = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId)
   ): Promise<PopulatedTransaction> {
     return populateV3Relay(this.spokePool, relayData, relayer);
   }
@@ -146,7 +146,7 @@ export class QueryBase implements QueryInterface {
    */
   async getNativeGasCost(
     relayData: RelayData & { destinationChainId: number },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId)
+    relayer = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId)
   ): Promise<BigNumber> {
     const { recipient, outputToken, exclusiveRelayer } = relayData;
     assert(recipient.isEVM(), `getNativeGasCost: recipient not an EVM address (${recipient})`);
@@ -171,7 +171,7 @@ export class QueryBase implements QueryInterface {
    */
   async getOpStackL1DataFee(
     unsignedTx: PopulatedTransaction,
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(unsignedTx.chainId), CHAIN_IDs.MAINNET),
+    relayer = toAddressType(getDefaultRelayer(unsignedTx.chainId), CHAIN_IDs.MAINNET),
     options: Partial<{
       opStackL2GasUnits: BigNumberish;
       opStackL1DataFeeMultiplier: BigNumber;

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -4,7 +4,7 @@ import { isL2Provider as isOptimismL2Provider } from "@eth-optimism/sdk/dist/l2-
 import { PopulatedTransaction, providers, VoidSigner } from "ethers";
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";
-import { Deposit } from "../../interfaces";
+import { RelayData } from "../../interfaces";
 import { SpokePool, SpokePool__factory } from "../../typechain";
 import { populateV3Relay } from "../../arch/evm";
 import {
@@ -74,7 +74,7 @@ export class QueryBase implements QueryInterface {
    * @returns The gas estimate for this function call (multiplied with the optional buffer).
    */
   async getGasCosts(
-    deposit: Omit<Deposit, "messageHash">,
+    deposit: RelayData & { destinationChainId: number },
     relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId),
     options: Partial<{
       gasPrice: BigNumberish;
@@ -129,7 +129,8 @@ export class QueryBase implements QueryInterface {
    * @returns PopulatedTransaction
    */
   getUnsignedTxFromDeposit(
-    deposit: Omit<Deposit, "messageHash"> & {
+    deposit: Omit<RelayData, "recipient" | "outputToken"> & {
+      destinationChainId: number;
       recipient: EvmAddress;
       outputToken: EvmAddress;
     },
@@ -145,7 +146,7 @@ export class QueryBase implements QueryInterface {
    * @returns Estimated gas cost based on ethers.VoidSigner's gas estimation
    */
   async getNativeGasCost(
-    deposit: Omit<Deposit, "messageHash">,
+    deposit: RelayData & { destinationChainId: number },
     relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId)
   ): Promise<BigNumber> {
     const { recipient, outputToken, exclusiveRelayer } = deposit;

--- a/src/relayFeeCalculator/chain-queries/factory.ts
+++ b/src/relayFeeCalculator/chain-queries/factory.ts
@@ -7,7 +7,7 @@ import { CUSTOM_GAS_TOKENS } from "../../constants";
 import { chainIsOPStack, isDefined, chainIsSvm, SvmAddress } from "../../utils";
 import { QueryBase } from "./baseQuery";
 import { SVMProvider as svmProvider } from "../../arch/svm";
-import { DEFAULT_LOGGER, getDefaultSimulatedRelayerAddress, Logger } from "../relayFeeCalculator";
+import { DEFAULT_LOGGER, getDefaultRelayer, Logger } from "../relayFeeCalculator";
 import { CustomGasTokenQueries } from "./customGasToken";
 import { SvmQuery } from "./svmQuery";
 
@@ -25,7 +25,7 @@ export class QueryBase__factory {
     provider: providers.Provider | svmProvider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
     spokePoolAddress = getDeployedAddress("SpokePool", chainId),
-    simulatedRelayerAddress = getDefaultSimulatedRelayerAddress(chainId),
+    simulatedRelayerAddress = getDefaultRelayer(chainId),
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,
     coingeckoBaseCurrency = "eth"

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -66,7 +66,7 @@ export class SvmQuery implements QueryInterface {
 
   /**
    * Retrieves the current gas costs of performing a fillRelay contract at the referenced SpokePool.
-   * @param deposit V3 deposit instance.
+   * @param relayData RelayData instance, supplemented with destinationChainId
    * @param _relayer Relayer address to simulate with.
    * @param options
    * @param options.gasPrice Optional gas price to use for the simulation.
@@ -75,8 +75,8 @@ export class SvmQuery implements QueryInterface {
    * @returns The gas estimate for this function call (multiplied with the optional buffer).
    */
   async getGasCosts(
-    deposit: RelayData & { destinationChainId: number },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId),
+    relayData: RelayData & { destinationChainId: number },
+    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId),
     options: Partial<{
       gasPrice: BigNumberish;
       gasUnits: BigNumberish;
@@ -84,12 +84,12 @@ export class SvmQuery implements QueryInterface {
       priorityFeeMultiplier: BigNumber;
     }> = {}
   ): Promise<TransactionCostEstimate> {
-    const { recipient, outputToken, exclusiveRelayer } = deposit;
+    const { recipient, outputToken, exclusiveRelayer } = relayData;
     assert(recipient.isSVM(), `getGasCosts: recipient not an SVM address (${recipient})`);
     assert(outputToken.isSVM(), `getGasCosts: outputToken not an SVM address (${outputToken})`);
     assert(exclusiveRelayer.isSVM(), `getGasCosts: exclusiveRelayer not an SVM address (${exclusiveRelayer})`);
 
-    const fillRelayTx = await this.getFillRelayTx({ ...deposit, recipient, outputToken, exclusiveRelayer }, relayer);
+    const fillRelayTx = await this.getFillRelayTx({ ...relayData, recipient, outputToken, exclusiveRelayer }, relayer);
 
     const [computeUnitsConsumed, gasPriceEstimate] = await Promise.all([
       toBN(await this.computeUnitEstimator(fillRelayTx)),
@@ -134,24 +134,24 @@ export class SvmQuery implements QueryInterface {
 
   /**
    * @notice Return the fillRelay transaction for a given deposit
-   * @param deposit
+   * @param relayData RelayData instance, supplemented with destinationChainId
    * @param relayer SVM address of the relayer
    * @returns FillRelay transaction
    */
   async getFillRelayTx(
-    deposit: Omit<RelayData, "recipent" | "outputToken"> & {
+    relayData: Omit<RelayData, "recipent" | "outputToken"> & {
       destinationChainId: number;
       recipient: SvmAddress;
       outputToken: SvmAddress;
     },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId),
-    repaymentChainId = deposit.destinationChainId,
+    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId),
+    repaymentChainId = relayData.destinationChainId,
     repaymentAddress = toAddressType(
-      getDefaultSimulatedRelayerAddress(deposit.destinationChainId),
-      deposit.destinationChainId
+      getDefaultSimulatedRelayerAddress(relayData.destinationChainId),
+      relayData.destinationChainId
     )
   ) {
-    const { depositor, recipient, inputToken, outputToken, exclusiveRelayer, destinationChainId } = deposit;
+    const { depositor, recipient, inputToken, outputToken, exclusiveRelayer, destinationChainId } = relayData;
 
     // tsc appeasement...should be unnecessary, but isn't. @todo Identify why.
     assert(recipient.isSVM(), `getFillRelayTx: recipient not an SVM address (${recipient})`);
@@ -161,7 +161,7 @@ export class SvmQuery implements QueryInterface {
     );
 
     const program = toAddress(this.spokePool);
-    const _relayDataHash = getRelayDataHash(deposit, destinationChainId);
+    const _relayDataHash = getRelayDataHash(relayData, destinationChainId);
     const relayDataHash = new Uint8Array(Buffer.from(_relayDataHash.slice(2), "hex"));
 
     const [state, delegate] = await Promise.all([
@@ -175,23 +175,23 @@ export class SvmQuery implements QueryInterface {
     const [recipientAta, relayerAta, fillStatus, eventAuthority] = await Promise.all([
       getAssociatedTokenAddress(recipient, outputToken, mintInfo.programAddress),
       getAssociatedTokenAddress(SvmAddress.from(relayer.toBase58()), outputToken, mintInfo.programAddress),
-      getFillStatusPda(program, deposit, destinationChainId),
+      getFillStatusPda(program, relayData, destinationChainId),
       getEventAuthority(program),
     ]);
 
-    const relayData: SvmSpokeClient.FillRelayInput["relayData"] = {
+    const svmRelayData: SvmSpokeClient.FillRelayInput["relayData"] = {
       depositor: toAddress(depositor),
       recipient: toAddress(recipient),
       exclusiveRelayer: toAddress(exclusiveRelayer),
       inputToken: toAddress(inputToken),
       outputToken: mint,
-      inputAmount: deposit.inputAmount.toBigInt(),
-      outputAmount: deposit.outputAmount.toBigInt(),
-      originChainId: deposit.originChainId,
-      depositId: new Uint8Array(intToU8Array32(deposit.depositId.toNumber())),
-      fillDeadline: deposit.fillDeadline,
-      exclusivityDeadline: deposit.exclusivityDeadline,
-      message: new Uint8Array(Buffer.from(deposit.message, "hex")),
+      inputAmount: relayData.inputAmount.toBigInt(),
+      outputAmount: relayData.outputAmount.toBigInt(),
+      originChainId: relayData.originChainId,
+      depositId: new Uint8Array(intToU8Array32(relayData.depositId.toNumber())),
+      fillDeadline: relayData.fillDeadline,
+      exclusivityDeadline: relayData.exclusivityDeadline,
+      message: new Uint8Array(Buffer.from(relayData.message, "hex")),
     };
 
     const simulatedSigner = SolanaVoidSigner(relayer.toBase58());
@@ -209,7 +209,7 @@ export class SvmQuery implements QueryInterface {
       eventAuthority,
       program,
       relayHash: relayDataHash,
-      relayData,
+      relayData: svmRelayData,
       repaymentChainId: BigInt(repaymentChainId),
       repaymentAddress: toAddress(repaymentAddress),
     };

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -28,7 +28,7 @@ import {
   toAddressType,
   toBN,
 } from "../../utils";
-import { Logger, QueryInterface, getDefaultSimulatedRelayerAddress } from "../relayFeeCalculator";
+import { Logger, QueryInterface, getDefaultRelayer } from "../relayFeeCalculator";
 import { SymbolMappingType } from "./";
 
 /**
@@ -76,7 +76,7 @@ export class SvmQuery implements QueryInterface {
    */
   async getGasCosts(
     relayData: RelayData & { destinationChainId: number },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId),
+    relayer = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId),
     options: Partial<{
       gasPrice: BigNumberish;
       gasUnits: BigNumberish;
@@ -121,7 +121,7 @@ export class SvmQuery implements QueryInterface {
    */
   async getNativeGasCost(
     deposit: RelayData & { destinationChainId: number },
-    _relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId)
+    _relayer = toAddressType(getDefaultRelayer(deposit.destinationChainId), deposit.destinationChainId)
   ): Promise<BigNumber> {
     const { recipient, outputToken, exclusiveRelayer } = deposit;
     assert(recipient.isSVM(), `getNativeGasCost: recipient not an SVM address (${recipient})`);
@@ -144,12 +144,9 @@ export class SvmQuery implements QueryInterface {
       recipient: SvmAddress;
       outputToken: SvmAddress;
     },
-    relayer = toAddressType(getDefaultSimulatedRelayerAddress(relayData.destinationChainId), relayData.destinationChainId),
+    relayer = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId),
     repaymentChainId = relayData.destinationChainId,
-    repaymentAddress = toAddressType(
-      getDefaultSimulatedRelayerAddress(relayData.destinationChainId),
-      relayData.destinationChainId
-    )
+    repaymentAddress = toAddressType(getDefaultRelayer(relayData.destinationChainId), relayData.destinationChainId)
   ) {
     const { depositor, recipient, inputToken, outputToken, exclusiveRelayer, destinationChainId } = relayData;
 

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -18,7 +18,7 @@ import {
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";
 import { getGasPriceEstimate } from "../../gasPriceOracle";
-import { Deposit } from "../../interfaces";
+import { RelayData } from "../../interfaces";
 import {
   BigNumber,
   BigNumberish,
@@ -75,7 +75,7 @@ export class SvmQuery implements QueryInterface {
    * @returns The gas estimate for this function call (multiplied with the optional buffer).
    */
   async getGasCosts(
-    deposit: Omit<Deposit, "messageHash">,
+    deposit: RelayData & { destinationChainId: number },
     relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId),
     options: Partial<{
       gasPrice: BigNumberish;
@@ -120,7 +120,7 @@ export class SvmQuery implements QueryInterface {
    * @returns Estimated gas cost in compute units
    */
   async getNativeGasCost(
-    deposit: Omit<Deposit, "messageHash">, // @todo Update interface to permit EvmAddress | SvmAddress
+    deposit: RelayData & { destinationChainId: number },
     _relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId)
   ): Promise<BigNumber> {
     const { recipient, outputToken, exclusiveRelayer } = deposit;
@@ -139,10 +139,10 @@ export class SvmQuery implements QueryInterface {
    * @returns FillRelay transaction
    */
   async getFillRelayTx(
-    deposit: Omit<Deposit, "recipent" | "outputToken" | "exclusiveRelayer" | "messageHash"> & {
+    deposit: Omit<RelayData, "recipent" | "outputToken"> & {
+      destinationChainId: number;
       recipient: SvmAddress;
       outputToken: SvmAddress;
-      exclusiveRelayer: SvmAddress;
     },
     relayer = toAddressType(getDefaultSimulatedRelayerAddress(deposit.destinationChainId), deposit.destinationChainId),
     repaymentChainId = deposit.destinationChainId,

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -114,7 +114,7 @@ export const DEFAULT_LOGGER: Logger = {
   error: (...args) => console.error(args),
 };
 
-export function getDefaultSimulatedRelayerAddress(chainId?: number) {
+export function getDefaultRelayer(chainId?: number) {
   return isDefined(chainId) && chainIsSvm(chainId)
     ? DEFAULT_SIMULATED_RELAYER_ADDRESS_SVM
     : DEFAULT_SIMULATED_RELAYER_ADDRESS;
@@ -256,10 +256,7 @@ export class RelayFeeCalculator {
     deposit: Deposit,
     outputAmount: BigNumberish,
     simulateZeroFill = false,
-    relayerAddress = toAddressType(
-      getDefaultSimulatedRelayerAddress(deposit.destinationChainId),
-      deposit.destinationChainId
-    ),
+    relayerAddress = toAddressType(getDefaultRelayer(deposit.destinationChainId), deposit.destinationChainId),
     _tokenPrice?: number,
     tokenMapping = TOKEN_SYMBOLS_MAP,
     gasPrice?: BigNumberish,
@@ -498,10 +495,7 @@ export class RelayFeeCalculator {
     deposit: Deposit,
     outputAmount?: BigNumberish,
     simulateZeroFill = false,
-    relayerAddress = toAddressType(
-      getDefaultSimulatedRelayerAddress(deposit.destinationChainId),
-      deposit.destinationChainId
-    ),
+    relayerAddress = toAddressType(getDefaultRelayer(deposit.destinationChainId), deposit.destinationChainId),
     _tokenPrice?: number,
     gasPrice?: BigNumberish,
     gasUnits?: BigNumberish,


### PR DESCRIPTION
- Don't require exclusiveRelayer to be valid on the destination chain,
  there's no requirement for this to be true.
- Refocus on RelayData as the core type for "proto" fill types, and 
  add supplemental fields as required. This is cleaner.
- Slight re-org in the SpokePool interfaces to permit reuse of some
  SpeedUp fields. There's more work to be done to clean this up, but 
  hat's deferred for now because it's unrelated to SVM work.