### PR TITLE
improve(SVM): Handle no-block-at-slot madness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -216,7 +216,7 @@ export async function relayFillStatus(
   if (atHeight === undefined) {
     const [fillStatusAccount, currentSlotTimestamp] = await Promise.all([
       fetchEncodedAccount(provider, fillStatusPda, { commitment: "confirmed" }),
-      provider.getBlockTime(currentSlot).send(),
+      provider.getBlockTime(currentSlot).send(), // @todo: handle
     ]);
     // If the PDA exists, return the stored fill status
     if (fillStatusAccount.exists) {
@@ -825,7 +825,7 @@ async function fetchBatchFillStatusFromPdaAccounts(
         fetchEncodedAccounts(provider, chunk, { commitment: "confirmed" })
       )
     ),
-    provider.getBlockTime(currentSlot).send(),
+    provider.getBlockTime(currentSlot).send(), // @todo: handle
   ]);
 
   const fillStatuses = pdaAccounts.flat().map((account, index) => {

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -71,11 +71,8 @@ type ProtoFill = Omit<RelayData, "recipient" | "outputToken"> & {
  */
 export async function getTimestampForSlot(provider: SVMProvider, slotNumber: number): Promise<number | undefined> {
   // @note: getBlockTime receives a slot number, not a block number.
-  let slot = BigInt(slotNumber);
-  let blockTime: UnixTimestamp | undefined = undefined;
-
   try {
-    blockTime = await provider.getBlockTime(slot).send();
+    const blockTime = await provider.getBlockTime(BigInt(slotNumber)).send();
     return Number(blockTime);
   } catch (err) {
     if (!isSolanaError(err)) {

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -22,7 +22,6 @@ import {
   ReadonlyUint8Array,
   some,
   type TransactionSigner,
-  type UnixTimestamp,
 } from "@solana/kit";
 import assert from "assert";
 import { arrayify, hexZeroPad, hexlify } from "ethers/lib/utils";

--- a/src/arch/svm/provider.ts
+++ b/src/arch/svm/provider.ts
@@ -1,0 +1,7 @@
+export { isSolanaError } from "@solana/kit";
+
+/**
+ * SVM RPC provider error codes
+ * See https://www.quicknode.com/docs/solana/error-references
+ */
+export const SVM_NO_BLOCK_AT_SLOT = -32007;

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -20,6 +20,8 @@ import { FillType, RelayData } from "../../interfaces";
 import { BigNumber, getRelayDataHash, isDefined, isUint8Array, Address as SdkAddress } from "../../utils";
 import { EventName, SVMEventNames, SVMProvider } from "./types";
 
+export { isSolanaError } from "@solana/kit";
+
 /**
  * Basic void TransactionSigner type
  */

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -193,7 +193,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
    * Retrieves the timestamp for a given SVM slot number.
    */
   public override async getTimestampForBlock(slot: number): Promise<number> {
-    let _slot = slot;
+    let _slot = BigInt(slot);
     do {
       const timestamp = await getTimestampForSlot(this.svmEventsClient.getRpc(), _slot);
       if (isDefined(timestamp)) {

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -142,7 +142,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
     const timerStart = Date.now();
 
     const [currentTime, ...eventsQueried] = await Promise.all([
-      this.svmEventsClient.getRpc().getBlockTime(BigInt(searchConfig.to)).send(),
+      this.getTimeAt(searchConfig.to),
       ...eventsToQuery.map(async (eventName, idx) => {
         const config = eventSearchConfigs[idx];
         const events = await this.svmEventsClient.queryEvents(

--- a/src/typeguards/error.ts
+++ b/src/typeguards/error.ts
@@ -1,6 +1,8 @@
 import { ethers } from "ethers";
-import { EthersError } from "../interfaces";
 import { BaseError } from "viem";
+import { EthersError } from "../interfaces";
+
+export { isSolanaError } from "../arch/svm";
 
 export const isError = (error: unknown): error is Error => error instanceof Error;
 


### PR DESCRIPTION
Instances of slots without blocks are showing up semi-regularly in the 
bots. There's currently no handling for this, so it can trigger an
alert.

Some considerations for this change:
- It's unclear whether Solana blockTimes will increase monotonically,
  since the Solana docs have a confusing explanation of how time is
  produced when calling `getBlockTime()`.
- The SVMSpokePoolClient decides to rotate backwards through slots to
  find the first available timestamp from a preceding slot where a
  block was actually produced. It's unclear whether the 
  SVMSpokePoolClient should do this, however this would effectively
  match the EVM-side behaviour.