### PR TITLE
fix: parse outputAmount as a BigNumber in SVMSpokePoolClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -257,10 +257,10 @@ export class SvmCpiEventsClient {
     }
 
     return events.map((event) => {
-      const unwrappedEventArgs = unwrapEventData(event as Record<string, unknown>, ["depositId"]) as Record<
-        "data",
-        Deposit
-      > &
+      const unwrappedEventArgs = unwrapEventData(event as Record<string, unknown>, [
+        "depositId",
+        "outputAmount",
+      ]) as Record<"data", Deposit> &
         Record<
           "data",
           {
@@ -324,7 +324,10 @@ export class SvmCpiEventsClient {
     }
 
     return fillEvents.map((event) => {
-      const unwrappedEventData = unwrapEventData(event as Record<string, unknown>) as Record<"data", Fill> &
+      const unwrappedEventData = unwrapEventData(event as Record<string, unknown>, [
+        "depositId",
+        "outputAmount",
+      ]) as Record<"data", Fill> &
         Record<
           "data",
           {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -143,7 +143,7 @@ export function getEventName(rawName: string): EventName {
  */
 export function unwrapEventData(
   data: unknown,
-  uint8ArrayKeysAsBigInt: string[] = ["depositId"],
+  uint8ArrayKeysAsBigInt: string[] = ["depositId", "outputAmount"],
   currentKey?: string
 ): unknown {
   // Handle null/undefined


### PR DESCRIPTION
Deposits look like:
```
...
inputAmount: BigNumber { _hex: '0x01', _isBigNumber: true },
outputAmount: '0x0000000000000000000000000000000000000000000000000000000000000001',
...
```
`outputAmount` should be a BigNumber.