### PR TITLE
improve: Return empty array if Fills for Deposit doesn't exists

### DIFF
--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -361,7 +361,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
   }
 
   public getFillsForDeposit(deposit: Deposit): FillWithBlock[] {
-    return this.depositHashesToFills[this.getDepositHash(deposit)];
+    return this.depositHashesToFills[this.getDepositHash(deposit)] ?? [];
   }
 
   public isDepositFilled(deposit: Deposit): boolean {


### PR DESCRIPTION
Return empty array if Fills for Deposit doesn't exists instead of undefined.