### PR TITLE
improve: enforce type correctness when calling `assign`

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -76,7 +76,7 @@ type HubPoolEvent =
   | "CrossChainContractsSet";
 
 type L1TokensToDestinationTokens = {
-  [l1Token: string]: { [destinationChainId: number]: string };
+  [l1Token: string]: { [destinationChainId: number]: Address };
 };
 
 export type LpFeeRequest = Pick<Deposit, "originChainId" | "inputToken" | "inputAmount" | "quoteTimestamp"> & {

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -747,7 +747,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
       ] as EnabledDepositRouteWithBlock[];
 
       for (const event of enableDepositsEvents) {
-        assign(this.depositRoutes, [event.originToken, event.destinationChainId], event.enabled);
+        assign(this.depositRoutes, [event.originToken.toBytes32(), event.destinationChainId], event.enabled);
       }
     }
 

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -70,10 +70,12 @@ export class MockHubPoolClient extends HubPoolClient {
       [chainId],
       [
         {
-          spokePool: toAddressType(contract, this.chainId),
+          spokePool: toAddressType(contract, chainId),
           blockNumber: blockNumber,
-          transactionIndex: 0,
           logIndex: 0,
+          l2ChainId: chainId,
+          txnIndex: 0,
+          txnRef: "",
         },
       ]
     );

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -3,7 +3,24 @@
 // Append value along the keyPath to object. For example assign(deposits, ['1337', '31337'], [{depositId:1}]) will create
 // deposits = {1337:{31337:[{depositId:1}]}}. Note that if the path into the object exists then this will append. This
 
+// -----------------------------------------------------------------------------
+// Overload declarations (must appear before the implementation).
+// -----------------------------------------------------------------------------
+export function assign<T, K1 extends keyof T>(obj: T, keyPath: [K1], value: T[K1]): void;
+export function assign<T, K1 extends keyof T, K2 extends keyof NonNullable<T[K1]>>(
+  obj: T,
+  keyPath: [K1, K2],
+  value: NonNullable<T[K1]>[K2]
+): void;
+export function assign<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof NonNullable<T[K1]>,
+  K3 extends keyof NonNullable<NonNullable<T[K1]>[K2]>,
+>(obj: T, keyPath: [K1, K2, K3], value: NonNullable<NonNullable<T[K1]>[K2]>[K3]): void;
+
 // function respects the destination type; if it is an object then deep merge and if an array effectively will push.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function assign(obj: any, keyPath: any[], value: any): void {
   const lastKeyIndex = keyPath.length - 1;
   for (let i = 0; i < lastKeyIndex; ++i) {


### PR DESCRIPTION
`assign` lives at the core of some of the important classes. Found a couple of "`Address` object used instead as string key" situations after adding these type checks