### PR TITLE
fix(gasPriceOracle): use latest block instead of pending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.15",
+  "version": "4.3.16",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -31,7 +31,7 @@ export async function eip1559Raw(
   priorityFeeMultiplier: BigNumber
 ): Promise<EvmGasPriceEstimate> {
   const [{ baseFeePerGas }, _maxPriorityFeePerGas] = await Promise.all([
-    provider.getBlock("pending"),
+    provider.getBlock("latest"),
     (provider as providers.JsonRpcProvider).send("eth_maxPriorityFeePerGas", []),
   ]);
   const maxPriorityFeePerGas = BigNumber.from(_maxPriorityFeePerGas);


### PR DESCRIPTION
Using block tag `pending` doesn't return correct `baseFeePerGas` for some providers.