### PR TITLE
feat: running balance calculations for optimistic proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.18-alpha.0",
+  "version": "4.3.18-alpha.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.50-alpha.0",
+  "version": "4.3.50-alpha.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.48",
+  "version": "4.3.49-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.17",
+  "version": "4.3.18-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -434,7 +434,8 @@ export function _buildPoolRebalanceRoot(
     });
   });
 
-  // Add to the running balance value from the last valid root bundle proposal. A root bundle proposal which is still in liveness and has not yet been executed counts as a valid proposal.
+  // Add to the running balance value from the last valid root bundle proposal for {chainId, l1Token}
+  // combination if found.
   addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
 
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -154,7 +154,7 @@ export async function _buildPoolRebalanceRoot(
   // of a different root bundle, so running balance calculations will be slightly different.
   if (
     clients.hubPoolClient.hasPendingProposal() &&
-    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[1] < mainnetBundleEndBlock
+    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[0] < mainnetBundleEndBlock
   ) {
     return await _buildOptimisticPoolRebalanceRoot(
       latestMainnetBlock,

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -146,7 +146,7 @@ export async function _buildPoolRebalanceRoot(
   addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
   if (
     clients.hubPoolClient.hasPendingProposal() &&
-    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[1] > mainnetBundleEndBlock
+    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[1] < mainnetBundleEndBlock
   ) {
     // We need to get the pool rebalance root for the pending bundle.
     // @dev It is safe to index the hub pool client's proposed root bundles here since there is guaranteed to be a pending proposal in this code block.

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -138,7 +138,7 @@ export async function buildPoolRebalanceRoot(
   },
   maxL1TokenCountOverride?: number
 ): Promise<PoolRebalanceRoot> {
-  // Build a pool rebalance root given the input bundle data. Depending on the value of `mainnetBundleEndBlock`, we may need to re-assign running balances.
+  // Build a pool rebalance root given the input bundle data. Depending on the value of `mainnetBundleEndBlock`, we may need to reassign running balances.
   const latestPoolRebalanceRoot = _buildPoolRebalanceRoot(
     latestMainnetBlock,
     mainnetBundleEndBlock,
@@ -151,7 +151,7 @@ export async function buildPoolRebalanceRoot(
     maxL1TokenCountOverride
   );
   // In this case, the pool rebalance root we wish to construct corresponds to a root bundle which is preceded by an executed root bundle, meaning that the
-  // the running balance calculation in _buildPoolRebalanceRoot does not need to be re-assigned.
+  // the running balance calculation in _buildPoolRebalanceRoot does not need to be reassigned.
   if (
     !clients.hubPoolClient.hasPendingProposal() ||
     clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[1] <= mainnetBundleEndBlock
@@ -159,7 +159,7 @@ export async function buildPoolRebalanceRoot(
     return latestPoolRebalanceRoot;
   }
   // Otherwise, the pool rebalance root we wish to construct corresponds to a root bundle which is preceded by a pending root bundle. This means that we need
-  // to optimisitically assume the pending root bundle's proposed values are correct and re-assign our pool rebalance root's running balances.
+  // to optimisitically assume the pending root bundle's proposed values are correct and reassign our pool rebalance root's running balances.
 
   // We need to get the pool rebalance root for the pending bundle.
   // @dev It is safe to index the hub pool client's proposed root bundles here since there is guaranteed to be a pending proposal in this code block.
@@ -188,12 +188,12 @@ export async function buildPoolRebalanceRoot(
     maxL1TokenCountOverride
   );
 
-  // We now need to re-assign the running balance value for `latestPoolRebalanceRoot`. The re-assignment is as follows:
+  // We now need to reassign the running balance value for `latestPoolRebalanceRoot`. The reassignment is as follows:
   // `latestPoolRebalanceRoot` has running balances value given by RB_opt := (optFills + optDeposits + optSlowFills + optExpiredDeposits + optExpiredSlowFills) + lastExecutedRunningBalances.
   // `pendingPoolRebalanceRoot` has running balances value given by RB_pend := (pendFills + pendDeposits + pendSlowFills + pendExpiredDeposits + pendExpiredSlowFills) + lastExecutedRunningBalances.
   // Note that for both pool rebalance roots, `lastExecutedRunningBalances` is the same since they obtain this value by looking at the most recent `ExecutedRootBundle` event.
   // However, `latestPoolRebalanceRoot` should have running balance value given by (optFills + optDeposits + optSlowFills + optExpiredDeposits + optExpiredSlowFills) + RB_pend.
-  // This means we need to re-assign `latestPoolRebalanceRoot`'s running balance value to (RB_pend + RB_opt - lastExecutedRunningBalances).
+  // This means we need to reassign `latestPoolRebalanceRoot`'s running balance value to (RB_pend + RB_opt - lastExecutedRunningBalances).
   //
 
   // In order to update running balances properly, we need to iterate through the pending running balance dictionary.

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -309,11 +309,8 @@ export async function _buildPoolRebalanceRoot(
   // Add to the running balance value from the last valid root bundle proposal. A root bundle proposal which is still in liveness and has not yet been executed counts as a valid proposal.
   // If the mainnetBundleEndBlock for this pool rebalance root corresponds to the pending root bundle or some root bundle before the pending root bundle, then we can fetch running balances directly from `ExecutedRootBundle` events.
   if (
-    clients.hubPoolClient.getPendingRootBundle()?.bundleEvaluationBlockNumbers[0] === mainnetBundleEndBlock ||
     !clients.hubPoolClient.hasPendingProposal() ||
-    clients.hubPoolClient
-      .getValidatedRootBundles()
-      .some((bundle) => bundle.bundleEvaluationBlockNumbers[0].toNumber() === mainnetBundleEndBlock)
+    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[0] <= mainnetBundleEndBlock
   ) {
     addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
   } else {

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -310,7 +310,7 @@ export async function _buildPoolRebalanceRoot(
   // If the mainnetBundleEndBlock for this pool rebalance root corresponds to the pending root bundle or some root bundle before the pending root bundle, then we can fetch running balances directly from `ExecutedRootBundle` events.
   if (
     !clients.hubPoolClient.hasPendingProposal() ||
-    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[0] <= mainnetBundleEndBlock
+    clients.hubPoolClient.getPendingRootBundle()!.bundleEvaluationBlockNumbers[1] <= mainnetBundleEndBlock
   ) {
     addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
   } else {

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -20,6 +20,7 @@ import {
   count3DDictionaryValues,
   toAddressType,
   getImpliedBundleBlockRanges,
+  isDefined,
 } from "../../../utils";
 import {
   addLastRunningBalance,
@@ -171,12 +172,15 @@ export async function _buildPoolRebalanceRoot(
       pendingRootBundleData.expiredDepositsToRefundV3,
       clients
     );
-    Object.keys(pendingRunningBalances).forEach((repaymentChainId) => {
-      Object.entries(pendingRunningBalances[Number(repaymentChainId)]).forEach(
-        ([l1TokenAddress, runningBalanceAmount]) => {
+    // Only add marginal pending running balances if there is already an entry in `runningBalances`. If there is no entry in `runningBalances`, then
+    // The running balance for this entry was unchanged since the last root bundle.
+    Object.keys(runningBalances).forEach((repaymentChainId) => {
+      Object.keys(runningBalances[Number(repaymentChainId)]).forEach((l1TokenAddress) => {
+        if (isDefined(pendingRunningBalances[Number(repaymentChainId)]?.[l1TokenAddress])) {
+          const runningBalanceAmount = pendingRunningBalances[Number(repaymentChainId)][l1TokenAddress];
           updateRunningBalance(runningBalances, Number(repaymentChainId), l1TokenAddress, runningBalanceAmount);
         }
-      );
+      });
     });
   }
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -312,7 +312,7 @@ export async function _buildPoolRebalanceRoot(
     clients.hubPoolClient.getPendingRootBundle()?.bundleEvaluationBlockNumbers[0] === mainnetBundleEndBlock ||
     !clients.hubPoolClient.hasPendingProposal() ||
     clients.hubPoolClient
-      .getValidatedRootBundles(latestMainnetBlock)
+      .getValidatedRootBundles()
       .some((bundle) => bundle.bundleEvaluationBlockNumbers[0].toNumber() === mainnetBundleEndBlock)
   ) {
     addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);


### PR DESCRIPTION
We need to know the pending root bundle's running balance totals, which is only retrievable by recomputing the pending root bundle's pool rebalance root.