### PR TITLE
feat: Allow gasPriceOracle to skip using MIN_PRIORITY_FEE when estimating gas

### DIFF
--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -37,11 +37,7 @@ export async function eip1559Raw(
   const maxPriorityFeePerGas = BigNumber.from(_maxPriorityFeePerGas);
   assert(BigNumber.isBigNumber(baseFeePerGas), `No baseFeePerGas received on ${getNetworkName(chainId)}`);
 
-  let scaledPriorityFee = maxPriorityFeePerGas.mul(priorityFeeMultiplier).div(fixedPointAdjustment);
-  const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${chainId}`] || "0", 9);
-  if (scaledPriorityFee.lt(flooredPriorityFeePerGas)) {
-    scaledPriorityFee = BigNumber.from(flooredPriorityFeePerGas);
-  }
+  const scaledPriorityFee = maxPriorityFeePerGas.mul(priorityFeeMultiplier).div(fixedPointAdjustment);
   const scaledBaseFee = baseFeePerGas.mul(baseFeeMultiplier).div(fixedPointAdjustment);
   return {
     maxFeePerGas: scaledPriorityFee.add(scaledBaseFee),

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { providers } from "ethers";
-import { BigNumber, bnZero, fixedPointAdjustment, getNetworkName, parseUnits } from "../../utils";
+import { BigNumber, bnZero, fixedPointAdjustment, getNetworkName } from "../../utils";
 import { EvmGasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
 import { GasPriceEstimateOptions } from "../oracle";

--- a/src/gasPriceOracle/adapters/solana.ts
+++ b/src/gasPriceOracle/adapters/solana.ts
@@ -1,5 +1,5 @@
 import { SVMProvider } from "../../arch/svm";
-import { toBN, dedupArray, parseUnits } from "../../utils";
+import { toBN, dedupArray } from "../../utils";
 import { SvmGasPriceEstimate } from "../types";
 import { GasPriceEstimateOptions } from "../oracle";
 import { CompilableTransactionMessage, TransactionMessageBytesBase64, compileTransaction } from "@solana/kit";

--- a/src/gasPriceOracle/adapters/solana.ts
+++ b/src/gasPriceOracle/adapters/solana.ts
@@ -32,14 +32,9 @@ export async function messageFee(provider: SVMProvider, opts: GasPriceEstimateOp
     .filter((fee) => fee > 0);
   const totalPrioritizationFees = nonzeroPrioritizationFees.reduce((acc, fee) => acc + fee, BigInt(0));
 
-  // Optionally impose a minimum priority fee, denoted in microLamports/computeUnit.
-  const flooredPriorityFeePerGas = parseUnits(process.env[`MIN_PRIORITY_FEE_PER_GAS_${opts.chainId}`] || "0", 6);
-  let microLamportsPerComputeUnit = toBN(
+  const microLamportsPerComputeUnit = toBN(
     totalPrioritizationFees / BigInt(Math.max(nonzeroPrioritizationFees.length, 1))
   );
-  if (microLamportsPerComputeUnit.lt(flooredPriorityFeePerGas)) {
-    microLamportsPerComputeUnit = flooredPriorityFeePerGas;
-  }
   return {
     baseFee: toBN(baseFeeResponse!.value!),
     microLamportsPerComputeUnit,


### PR DESCRIPTION
This is useful for bots that want to estimate the real gas price but want to submit with a much higher gas price.

To be paired with this relayer PR: https://github.com/across-protocol/relayer/pull/2414
