### PR TITLE
feat: pass in recipient to svm cctp finalizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.24",
+  "version": "4.3.25",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.23",
+  "version": "4.3.24",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.25",
+  "version": "4.3.26",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1183,14 +1183,14 @@ export async function getAccountMetasForTokenlessMessage(
  * @param message The CCTP message.
  * @param hubChainId The chain ID of the hub.
  * @param tokenMessengerMinter The token messenger minter address.
- * @param recipient The ATA of the recipient address.
+ * @param recipientAta The ATA of the recipient address.
  * @returns The account metas for a deposit message.
  */
 async function getAccountMetasForDepositMessage(
   message: AttestedCCTPMessage,
   hubChainId: number,
   tokenMessengerMinter: Address,
-  recipient: SvmAddress
+  recipientAta: SvmAddress
 ): Promise<IAccountMeta<string>[]> {
   const l1Usdc = EvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[hubChainId]);
   const l2Usdc = SvmAddress.from(
@@ -1243,7 +1243,7 @@ async function getAccountMetasForDepositMessage(
     { address: tokenMinterPda, role: AccountRole.WRITABLE },
     { address: localTokenPda, role: AccountRole.WRITABLE },
     { address: tokenPairPda, role: AccountRole.READONLY },
-    { address: toAddress(recipient), role: AccountRole.WRITABLE },
+    { address: toAddress(recipientAta), role: AccountRole.WRITABLE },
     { address: custodyTokenAccountPda, role: AccountRole.WRITABLE },
     { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
     { address: tokenMessengerEventAuthorityPda, role: AccountRole.READONLY },
@@ -1257,7 +1257,7 @@ async function getAccountMetasForDepositMessage(
  * @param signer The signer of the transaction.
  * @param message The CCTP message.
  * @param hubChainId The chain ID of the hub.
- * @param recipient The ATA of the recipient address (used for token finalizations only).
+ * @param recipientAta The ATA of the recipient address (used for token finalizations only).
  * @returns The CCTP v1 receive message transaction.
  */
 export async function getCCTPV1ReceiveMessageTx(
@@ -1265,7 +1265,7 @@ export async function getCCTPV1ReceiveMessageTx(
   signer: KeyPairSigner,
   message: AttestedCCTPMessage,
   hubChainId: number,
-  recipient: SvmAddress
+  recipientAta: SvmAddress
 ) {
   const [messageTransmitterPda] = await getProgramDerivedAddress({
     programAddress: MessageTransmitterClient.MESSAGE_TRANSMITTER_PROGRAM_ADDRESS,
@@ -1295,7 +1295,7 @@ export async function getCCTPV1ReceiveMessageTx(
         message,
         hubChainId,
         TokenMessengerMinterClient.TOKEN_MESSENGER_MINTER_PROGRAM_ADDRESS,
-        recipient
+        recipientAta
       )
     : await getAccountMetasForTokenlessMessage(solanaClient, signer, message.messageBytes);
 
@@ -1326,7 +1326,7 @@ export async function getCCTPV1ReceiveMessageTx(
  * @param solanaClient The Solana client.
  * @param attestedMessages The CCTP messages to Solana.
  * @param signer A base signer to be converted into a Solana signer.
- * @param recipient The address of the recipient USDC ATA (token finalizations only).
+ * @param recipientAta The ATA of the recipient address (used for token finalizations only).
  * @param simulate Whether to simulate the transaction.
  * @param hubChainId The chain ID of the hub.
  * @returns A list of executed transaction signatures.
@@ -1336,12 +1336,12 @@ export function finalizeCCTPV1Messages(
   solanaClient: SVMProvider,
   attestedMessages: AttestedCCTPMessage[],
   signer: KeyPairSigner,
-  recipient: SvmAddress,
+  recipientAta: SvmAddress,
   simulate = false,
   hubChainId = 1
 ): Promise<string[]> {
   return mapAsync(attestedMessages, async (message) => {
-    const receiveMessageIx = await getCCTPV1ReceiveMessageTx(solanaClient, signer, message, hubChainId, recipient);
+    const receiveMessageIx = await getCCTPV1ReceiveMessageTx(solanaClient, signer, message, hubChainId, recipientAta);
 
     if (simulate) {
       const result = await solanaClient

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1183,6 +1183,7 @@ export async function getAccountMetasForTokenlessMessage(
  * @param message The CCTP message.
  * @param hubChainId The chain ID of the hub.
  * @param tokenMessengerMinter The token messenger minter address.
+ * @param recipient The ATA of the recipient address.
  * @returns The account metas for a deposit message.
  */
 async function getAccountMetasForDepositMessage(
@@ -1256,7 +1257,7 @@ async function getAccountMetasForDepositMessage(
  * @param signer The signer of the transaction.
  * @param message The CCTP message.
  * @param hubChainId The chain ID of the hub.
- * @param recipient The address of the recipient USDC ATA (token finalizations only).
+ * @param recipient The ATA of the recipient address (used for token finalizations only).
  * @returns The CCTP v1 receive message transaction.
  */
 export async function getCCTPV1ReceiveMessageTx(

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1189,7 +1189,7 @@ async function getAccountMetasForDepositMessage(
   message: AttestedCCTPMessage,
   hubChainId: number,
   tokenMessengerMinter: Address,
-  _recipient: SvmAddress
+  recipient: SvmAddress
 ): Promise<IAccountMeta<string>[]> {
   const l1Usdc = EvmAddress.from(TOKEN_SYMBOLS_MAP.USDC.addresses[hubChainId]);
   const l2Usdc = SvmAddress.from(
@@ -1221,13 +1221,6 @@ async function getAccountMetasForDepositMessage(
     seeds: ["custody", bs58.decode(l2Usdc.toBase58())],
   });
 
-  const tokenProgram = TOKEN_PROGRAM_ADDRESS;
-
-  const recipient = _recipient.eq(SvmAddress.from(SvmSpokeClient.SVM_SPOKE_PROGRAM_ADDRESS.toString()))
-    ? SvmAddress.from(await getStatePda(SvmSpokeClient.SVM_SPOKE_PROGRAM_ADDRESS))
-    : _recipient;
-  const vault = await getAssociatedTokenAddress(recipient, SvmAddress.from(l2Usdc.toBase58()), tokenProgram);
-
   // Define accounts dependent on deposit information.
   const [tokenPairPda] = await getProgramDerivedAddress({
     programAddress: tokenMessengerMinter,
@@ -1249,7 +1242,7 @@ async function getAccountMetasForDepositMessage(
     { address: tokenMinterPda, role: AccountRole.WRITABLE },
     { address: localTokenPda, role: AccountRole.WRITABLE },
     { address: tokenPairPda, role: AccountRole.READONLY },
-    { address: vault, role: AccountRole.WRITABLE },
+    { address: toAddress(recipient), role: AccountRole.WRITABLE },
     { address: custodyTokenAccountPda, role: AccountRole.WRITABLE },
     { address: TOKEN_PROGRAM_ADDRESS, role: AccountRole.READONLY },
     { address: tokenMessengerEventAuthorityPda, role: AccountRole.READONLY },


### PR DESCRIPTION
As of right now, we can only finalize messages destined to the svm spoke. This lets us pass in a `recipient` field to cctp deposit functions (which we already have when finalizing) so that we can also finalize EOA transfers.