### PR TITLE
feat(SVMProvider): Add getSlot wrapper function

### DIFF
--- a/e2e/testGetSlot.e2e.ts
+++ b/e2e/testGetSlot.e2e.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env ts-node
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { program } from "commander";
+import winston from "winston";
+import { CachedSolanaRpcFactory } from "../src/providers/solana/cachedRpcFactory";
+import { ClusterUrl, type Commitment } from "@solana/kit";
+import { getSlot } from "../src/arch/svm/SpokeUtils";
+
+/**
+ * USAGE EXAMPLES:
+ *
+ * Basic usage (default settings):
+ *   npx ts-node testGetSlot.e2e.ts
+ *
+ * Test with specific endpoint:
+ *   npx ts-node testGetSlot.e2e.ts -e https://api.devnet.solana.com
+ *
+ * Test with more iterations:
+ *   npx ts-node testGetSlot.e2e.ts -n 20
+ *
+ * Test with different commitment level:
+ *   npx ts-node testGetSlot.e2e.ts -c finalized
+ */
+
+// Configure winston logger
+const logger = winston.createLogger({
+  level: "debug",
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.colorize(),
+    winston.format.printf(({ timestamp, level, message, ...meta }) => {
+      const metaStr = Object.keys(meta).length ? JSON.stringify(meta, null, 2) : "";
+      return `${timestamp} [${level}]: ${message} ${metaStr}`;
+    })
+  ),
+  transports: [new winston.transports.Console()],
+});
+
+interface TestOptions {
+  endpoint: string;
+  retries: number;
+  retryDelay: number;
+  chainId: number;
+  iterations: number;
+  commitment: Commitment;
+}
+
+async function testGetSlot(
+  rpcClient: any,
+  commitment: Commitment,
+  iteration: number
+): Promise<{
+  iteration: number;
+  slot: string;
+  success: boolean;
+  commitment: Commitment;
+  time: number;
+  error?: string;
+}> {
+  console.log(`--- Iteration ${iteration} (commitment: ${commitment}) ---`);
+  const startTime = Date.now();
+
+  try {
+    const slot = await getSlot(rpcClient, commitment, logger);
+    const elapsedTime = Date.now() - startTime;
+
+    console.log(`✅ Slot ${slot.toString()} (commitment: ${commitment}) (${elapsedTime}ms)`);
+    return {
+      iteration,
+      slot: slot.toString(),
+      success: true,
+      commitment,
+      time: elapsedTime,
+    };
+  } catch (error: unknown) {
+    const elapsedTime = Date.now() - startTime;
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    console.log(`❌ Failed: ${errorMsg} (${elapsedTime}ms)`);
+    return {
+      iteration,
+      slot: "unknown",
+      success: false,
+      commitment,
+      error: errorMsg,
+      time: elapsedTime,
+    };
+  }
+}
+
+async function runTest(options: TestOptions) {
+  console.log("🚀 Starting getSlot E2E Test");
+  console.log("Configuration:", {
+    endpoint: options.endpoint,
+    retries: options.retries,
+    retryDelay: options.retryDelay,
+    iterations: options.iterations,
+    commitment: options.commitment,
+  });
+
+  // Create the RPC factory
+  const rpcFactory = new CachedSolanaRpcFactory(
+    "test-get-slot",
+    undefined, // redisClient
+    options.retries,
+    options.retryDelay,
+    10, // maxConcurrency
+    0, // pctRpcCallsLogged
+    logger,
+    options.endpoint as ClusterUrl,
+    options.chainId
+  );
+
+  const rpcClient = rpcFactory.createRpcClient();
+
+  console.log(`\n📡 Running ${options.iterations} sequential tests...\n`);
+
+  const testStartTime = Date.now();
+  const results: Array<{
+    iteration: number;
+    slot: string;
+    success: boolean;
+    commitment: Commitment;
+    time: number;
+    error?: string;
+  }> = [];
+
+  for (let i = 0; i < options.iterations; i++) {
+    const result = await testGetSlot(rpcClient, options.commitment, i + 1);
+    results.push(result);
+  }
+
+  const totalTime = Date.now() - testStartTime;
+
+  // Print summary
+  console.log("\n📊 Test Summary:");
+  console.log("================");
+  const successful = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+  const retried = results.filter((r) => r.time > 1000); // We know an attempt retried if it took > 1 second
+  const retryCount = retried.length;
+  const retriedSuccessfully = retried.filter((r) => r.success).length;
+  const avgTime = results.reduce((sum, r) => sum + r.time, 0) / results.length;
+  const longestTime = results.reduce((max, r) => Math.max(max, r.time), 0);
+  const retriedAvgTime = retried.reduce((sum, r) => sum + r.time, 0) / retried.length;
+  const retriedLongestTime = retried.reduce((max, r) => Math.max(max, r.time), 0);
+
+  console.log(`Successful: ${successful} / ${options.iterations}`);
+  console.log(`Failed: ${failed} / ${options.iterations}`);
+  console.log(`Average time per call: ${avgTime.toFixed(0)}ms`);
+  console.log(`Longest time per call: ${longestTime.toFixed(0)}ms`);
+  console.log(`Retried: ${retryCount} / ${options.iterations}`);
+  console.log(`Retried successfully: ${retriedSuccessfully} / ${retryCount}`);
+  console.log(`Retried unsuccessfully: ${retryCount - retriedSuccessfully} / ${retryCount}`);
+  console.log(`Retried average time: ${retriedAvgTime.toFixed(0)}ms`);
+  console.log(`Retried longest time: ${retriedLongestTime.toFixed(0)}ms`);
+  console.log(`Total test time: ${totalTime}ms`);
+
+  if (failed > 0) {
+    console.log("\n❌ Failed tests:");
+    results
+      .filter((r) => !r.success)
+      .forEach((r) => {
+        console.log(`  Iteration ${r.iteration}: ${r.error}`);
+      });
+
+    // Show error patterns
+    const errorPatterns = new Map<string, number>();
+    results
+      .filter((r) => !r.success && r.error)
+      .forEach((r) => {
+        const errorType = r.error!.split(":")[0].trim();
+        errorPatterns.set(errorType, (errorPatterns.get(errorType) || 0) + 1);
+      });
+
+    console.log("\n🔍 Error patterns:");
+    errorPatterns.forEach((count, pattern) => {
+      console.log(`  ${pattern}: ${count} occurrences`);
+    });
+  }
+}
+
+// CLI setup
+program.name("test-get-slot").description("Test getSlot function with configurable commitment parameter");
+
+program
+  .option("-e, --endpoint <url>", "Solana RPC endpoint URL", "https://api.mainnet-beta.solana.com")
+  .option("-r, --retries <number>", "Number of retries on failure", "2")
+  .option("-d, --retry-delay <seconds>", "Delay between retries in seconds", "1")
+  .option("-i, --chain-id <number>", "Chain ID for Solana", "101")
+  .option("-n, --iterations <number>", "Number of test iterations", "10")
+  .option("-c, --commitment <commitment>", "Commitment level (processed, confirmed, finalized)", "confirmed")
+  .action(async (options) => {
+    // Validate commitment parameter
+    const validCommitments: Commitment[] = ["processed", "confirmed", "finalized"];
+    if (!validCommitments.includes(options.commitment as Commitment)) {
+      console.error(`Invalid commitment level: ${options.commitment}. Valid options: ${validCommitments.join(", ")}`);
+      process.exit(1);
+    }
+
+    const testOptions: TestOptions = {
+      endpoint: options.endpoint,
+      retries: parseInt(options.retries),
+      retryDelay: parseFloat(options.retryDelay),
+      chainId: parseInt(options.chainId),
+      iterations: parseInt(options.iterations),
+      commitment: options.commitment as Commitment,
+    };
+
+    await runTest(testOptions);
+  });
+
+program.parse();

--- a/e2e/testTimestampForSlot.e2e.ts
+++ b/e2e/testTimestampForSlot.e2e.ts
@@ -57,7 +57,7 @@ async function testNearestSlotTime(
   const startTime = Date.now();
 
   try {
-    const { slot, timestamp } = await getNearestSlotTime(rpcClient);
+    const { slot, timestamp } = await getNearestSlotTime(rpcClient, logger);
     const elapsedTime = Date.now() - startTime;
 
     console.log(`✅ Slot ${slot} -> ${timestamp} (${new Date(timestamp * 1000).toISOString()}) (${elapsedTime}ms)`);

--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -6,6 +6,7 @@ import { getCurrentTime } from "../../utils/TimeUtils";
 import { CHAIN_IDs } from "../../constants";
 import { SVMProvider } from "./";
 import { getNearestSlotTime } from "./utils";
+import winston from "winston";
 
 interface SVMBlock extends Block {}
 
@@ -32,6 +33,7 @@ function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0, _provid
 
 export class SVMBlockFinder extends BlockFinder<SVMBlock> {
   constructor(
+    private readonly logger: winston.Logger,
     private readonly provider: SVMProvider,
     private readonly blocks: SVMBlock[] = []
   ) {
@@ -97,7 +99,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
    */
   private getBlockTime(slot?: bigint): Promise<{ slot: bigint; timestamp: number }> {
     const opts = isDefined(slot) ? { slot } : undefined;
-    return getNearestSlotTime(this.provider, opts);
+    return getNearestSlotTime(this.provider, this.logger, opts);
   }
 
   // Grabs the most recent slot and caches it.

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -72,7 +72,7 @@ export async function getNearestSlotTime(
   opts: { slot: bigint } | { commitment: Commitment } = { commitment: "confirmed" }
 ): Promise<{ slot: bigint; timestamp: number }> {
   let timestamp: number | undefined;
-  let slot = "slot" in opts ? opts.slot : await getSlot(provider, opts.commitment, logger).send();
+  let slot = "slot" in opts ? opts.slot : await getSlot(provider, opts.commitment, logger);
 
   do {
     timestamp = await getTimestampForSlot(provider, slot, logger);
@@ -89,11 +89,12 @@ export async function getNearestSlotTime(
  */
 export async function getLatestFinalizedSlotWithBlock(
   provider: SVMProvider,
+  logger: winston.Logger,
   maxSlot: bigint,
   maxLookback = 1000
 ): Promise<number> {
   const opts = { maxSupportedTransactionVersion: 0, transactionDetails: "none", rewards: false } as const;
-  const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" });
+  const { slot: finalizedSlot } = await getNearestSlotTime(provider, logger, { commitment: "finalized" });
   const endSlot = biMin(maxSlot, finalizedSlot);
 
   let slot = endSlot;

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -102,7 +102,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     eventSearchConfig: MakeOptional<EventSearchConfig, "to"> = { from: 0, maxLookBack: 0 },
     readonly configStoreVersion: number
   ) {
-    super(eventSearchConfig);
+    super(logger, eventSearchConfig);
     this.firstHeightToSearch = eventSearchConfig.from;
     this.latestHeightSearched = 0;
   }

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -2,6 +2,7 @@ import { providers } from "ethers";
 import { CachingMechanismInterface } from "../interfaces";
 import { EventSearchConfig, isDefined, MakeOptional } from "../utils";
 import { getNearestSlotTime, SVMProvider } from "../arch/svm";
+import winston from "winston";
 
 export enum UpdateFailureReason {
   NotReady,
@@ -27,6 +28,7 @@ export abstract class BaseAbstractClient {
    * @param cachingMechanism The caching mechanism to use for this client. If not provided, the client will not rely on an external cache.
    */
   constructor(
+    readonly logger: winston.Logger,
     readonly eventSearchConfig: MakeOptional<EventSearchConfig, "to"> = { from: 0, maxLookBack: 0 },
     protected cachingMechanism?: CachingMechanismInterface
   ) {
@@ -72,7 +74,7 @@ export abstract class BaseAbstractClient {
       if (provider instanceof providers.Provider) {
         to = await provider.getBlockNumber();
       } else {
-        const { slot } = await getNearestSlotTime(provider);
+        const { slot } = await getNearestSlotTime(provider, this.logger);
         to = Number(slot);
       }
       if (to < from) {

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1651,6 +1651,7 @@ export class BundleDataClient {
         deposit,
         spokePoolClient.chainId,
         spokePoolClient.svmEventsClient,
+        spokePoolClient.logger,
         spokePoolClient.deploymentBlock,
         spokePoolClient.latestHeightSearched
       );

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -41,7 +41,11 @@ export async function getWidestPossibleExpectedBlockRange(
     assert(isSVMSpokePoolClient(spokePoolClient));
 
     const maxSlot = resolveEndBlock(chainId, idx); // Respect any configured buffer for Solana.
-    return getLatestFinalizedSlotWithBlock(spokePoolClient.svmEventsClient.getRpc(), BigInt(maxSlot));
+    return getLatestFinalizedSlotWithBlock(
+      spokePoolClient.svmEventsClient.getRpc(),
+      spokePoolClient.logger,
+      BigInt(maxSlot)
+    );
   };
 
   const latestPossibleBundleEndBlockNumbers = await Promise.all(

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -120,7 +120,7 @@ export class HubPoolClient extends BaseAbstractClient {
     },
     cachingMechanism?: CachingMechanismInterface
   ) {
-    super(eventSearchConfig, cachingMechanism);
+    super(logger, eventSearchConfig, cachingMechanism);
     this.latestHeightSearched = Math.min(deploymentBlock - 1, 0);
     this.firstHeightToSearch = eventSearchConfig.from;
 

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -195,7 +195,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
   public override async getTimestampForBlock(slot: number): Promise<number> {
     let _slot = BigInt(slot);
     do {
-      const timestamp = await getTimestampForSlot(this.svmEventsClient.getRpc(), _slot);
+      const timestamp = await getTimestampForSlot(this.svmEventsClient.getRpc(), _slot, this.logger);
       if (isDefined(timestamp)) {
         return timestamp;
       }

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -217,7 +217,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
    * Finds a deposit based on its deposit ID on the SVM chain.
    */
   public async findDeposit(depositId: BigNumber): Promise<DepositSearchResult> {
-    const deposit = await findDeposit(this.svmEventsClient, depositId);
+    const deposit = await findDeposit(this.svmEventsClient, depositId, this.logger);
     if (!deposit) {
       return {
         found: false,
@@ -244,7 +244,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
    * Retrieves the fill status for a given relay data from the SVM chain.
    */
   public override relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus> {
-    return relayFillStatus(this.programId, relayData, this.chainId, this.svmEventsClient, atHeight);
+    return relayFillStatus(this.programId, relayData, this.chainId, this.svmEventsClient, this.logger, atHeight);
   }
 
   /**
@@ -260,6 +260,6 @@ export class SVMSpokePoolClient extends SpokePoolClient {
   ): Promise<(FillStatus | undefined)[]> {
     // @note: deploymentBlock actually refers to the deployment slot. Also, blockTag should be a slot number.
     destinationChainId ??= this.chainId;
-    return fillStatusArray(this.programId, relayData, destinationChainId, this.svmEventsClient, atHeight, this.logger);
+    return fillStatusArray(this.programId, relayData, destinationChainId, this.svmEventsClient, this.logger, atHeight);
   }
 }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -114,7 +114,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     public deploymentBlock: number,
     eventSearchConfig: MakeOptional<EventSearchConfig, "to"> = { from: 0, maxLookBack: 0 }
   ) {
-    super(eventSearchConfig);
+    super(logger, eventSearchConfig);
     this.firstHeightToSearch = eventSearchConfig.from;
     this.latestHeightSearched = 0;
     this.configStoreClient = hubPoolClient?.configStoreClient;

--- a/test/BaseAbstractClient.test.ts
+++ b/test/BaseAbstractClient.test.ts
@@ -1,15 +1,15 @@
 import { BaseAbstractClient } from "../src/clients/BaseAbstractClient";
-import { expect } from "./utils";
+import { createSpyLogger, expect } from "./utils";
 
 class TestAbstractClient extends BaseAbstractClient {}
 
 describe("Test that the BaseAbstractClient class works as expected", () => {
   it("Test that the constructor works as expected", () => {
-    const client = new TestAbstractClient();
+    const client = new TestAbstractClient(createSpyLogger().spyLogger);
     expect(client).to.be.instanceOf(TestAbstractClient);
   });
   it("Test that the isUpdated variable works as expected", () => {
-    const client = new TestAbstractClient();
+    const client = new TestAbstractClient(createSpyLogger().spyLogger);
     expect(client.isUpdated).to.not.be.undefined;
     expect(client.isUpdated).to.be.false;
     client.isUpdated = true;

--- a/test/SVMSpokePoolClient.fills.ts
+++ b/test/SVMSpokePoolClient.fills.ts
@@ -101,6 +101,7 @@ describe("SVMSpokePoolClient: Fills", function () {
       formattedRelayData,
       CHAIN_IDs.SOLANA,
       spokePoolClient.svmEventsClient,
+      createSpyLogger().spyLogger,
       spokePoolClient.deploymentBlock
     );
     expect(fill).to.not.be.undefined;
@@ -113,6 +114,7 @@ describe("SVMSpokePoolClient: Fills", function () {
       { ...formattedRelayData, depositId: BigNumber.from(depositId + 1) },
       CHAIN_IDs.SOLANA,
       spokePoolClient.svmEventsClient,
+      createSpyLogger().spyLogger,
       spokePoolClient.deploymentBlock
     );
     expect(missingFill).to.be.undefined;
@@ -205,7 +207,7 @@ describe("SVMSpokePoolClient: Fills", function () {
 
   it("Closes the fill pda after the fill deadline has passed", async () => {
     const provider = solanaClient.rpc;
-    const { timestamp } = await getNearestSlotTime(provider);
+    const { timestamp } = await getNearestSlotTime(provider, createSpyLogger().spyLogger);
 
     await setCurrentTime(signer, solanaClient, timestamp);
     const newRelayData = {


### PR DESCRIPTION
We are seeing errors that look to be coming from direct calls to `provider.getSlot` so this wrapper function will better log errors that go through that function. Eventually we can add better error handling once we better understand this RPC endpoint behavior.

Secondarily, this PR adds a `logger` param to the `arch.svm.SpokeUtils` functions to log about error codes more
