### PR TITLE
check tostring tag on public key instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.36",
+  "version": "4.3.37",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -125,7 +125,8 @@ export function parseEventData(eventData: any): any {
   }
 
   if (typeof eventData === "object") {
-    if (eventData.constructor.name === "PublicKey") {
+    const stringTag = Object.prototype.toString.call(eventData);
+    if (stringTag.includes("PublicKey")) {
       return address(eventData.toString());
     }
     if (BN.isBN(eventData)) {


### PR DESCRIPTION
related to ACX-4258

## motivation
When decoding event data, the method we use to determine if an object is an instance of PublicKey is to check the constructor name. Possibly due to minifying issues in the frontend, this is no longer reliable.
We can instead call the toStringTag symbol on the object which won't get stripped since it's explicitly defined in the class definition in`@solana/web3.js`
