### PR TITLE
fix: Make logger optional for SVM utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.40",
+  "version": "4.3.41",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -99,7 +99,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
    */
   private getBlockTime(slot?: bigint): Promise<{ slot: bigint; timestamp: number }> {
     const opts = isDefined(slot) ? { slot } : undefined;
-    return getNearestSlotTime(this.provider, this.logger, opts);
+    return getNearestSlotTime(this.provider, opts, this.logger);
   }
 
   // Grabs the most recent slot and caches it.

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -253,7 +253,7 @@ export async function findDeposit(
   }
 
   const provider = eventClient.getRpc();
-  const opts = undefined; // Inherit defaults
+  const opts = undefined;
   const { slot: currentSlot } = await getNearestSlotTime(provider, opts, logger);
 
   // If no slot is provided, use the current slot
@@ -408,7 +408,7 @@ export async function fillStatusArray(
   const missingResults: { index: number; fillStatus: FillStatus }[] = [];
 
   // Determine the toSlot to use for event reconstruction
-  const opts = undefined; // Inherit defaults
+  const opts = undefined;
   const toSlot = atHeight ? BigInt(atHeight) : (await getNearestSlotTime(provider, opts, logger)).slot;
 
   // @note: This path is mostly used for deposits past their fill deadline.
@@ -452,7 +452,7 @@ export async function findFillEvent(
   logger?: winston.Logger
 ): Promise<FillWithBlock | undefined> {
   assert(chainIsSvm(destinationChainId), "Destination chain must be an SVM chain");
-  const opts = undefined; // Inherit defaults
+  const opts = undefined;
   toSlot ??= Number((await getNearestSlotTime(svmEventsClient.getRpc(), opts, logger)).slot);
 
   // Get fillStatus PDA using relayData

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -68,14 +68,15 @@ export function toAddress(address: SdkAddress): Address<string> {
  */
 export async function getNearestSlotTime(
   provider: SVMProvider,
-  logger: winston.Logger,
-  opts: { slot: bigint } | { commitment: Commitment } = { commitment: "confirmed" }
+  opts: { slot: bigint } | { commitment: Commitment } = { commitment: "confirmed" },
+  logger?: winston.Logger,
 ): Promise<{ slot: bigint; timestamp: number }> {
   let timestamp: number | undefined;
   let slot = "slot" in opts ? opts.slot : await getSlot(provider, opts.commitment, logger);
+  const maxRetries = undefined; // Inherit defaults
 
   do {
-    timestamp = await getTimestampForSlot(provider, slot, logger);
+    timestamp = await getTimestampForSlot(provider, slot, maxRetries, logger);
   } while (!isDefined(timestamp) && --slot);
   assert(isDefined(timestamp), `Unable to resolve block time for SVM slot ${slot}`);
 
@@ -94,7 +95,7 @@ export async function getLatestFinalizedSlotWithBlock(
   maxLookback = 1000
 ): Promise<number> {
   const opts = { maxSupportedTransactionVersion: 0, transactionDetails: "none", rewards: false } as const;
-  const { slot: finalizedSlot } = await getNearestSlotTime(provider, logger, { commitment: "finalized" });
+  const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" }, logger);
   const endSlot = biMin(maxSlot, finalizedSlot);
 
   let slot = endSlot;

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -69,7 +69,7 @@ export function toAddress(address: SdkAddress): Address<string> {
 export async function getNearestSlotTime(
   provider: SVMProvider,
   opts: { slot: bigint } | { commitment: Commitment } = { commitment: "confirmed" },
-  logger?: winston.Logger,
+  logger?: winston.Logger
 ): Promise<{ slot: bigint; timestamp: number }> {
   let timestamp: number | undefined;
   let slot = "slot" in opts ? opts.slot : await getSlot(provider, opts.commitment, logger);

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -89,7 +89,8 @@ export abstract class BaseAbstractClient {
         throw new Error(`Invalid event search config from (${from}) > to (${to})`);
       }
     } else {
-      const { slot } = await getNearestSlotTime(provider, logger);
+      const opts = undefined; // Inherit defaults
+      const { slot } = await getNearestSlotTime(provider, opts, logger);
       to = Number(slot);
       if (to < from) {
         return UpdateFailureReason.AlreadyUpdated;

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1651,9 +1651,9 @@ export class BundleDataClient {
         deposit,
         spokePoolClient.chainId,
         spokePoolClient.svmEventsClient,
-        spokePoolClient.logger,
         spokePoolClient.deploymentBlock,
-        spokePoolClient.latestHeightSearched
+        spokePoolClient.latestHeightSearched,
+        spokePoolClient.logger
       );
     } else if (isEVMSpokePoolClient(spokePoolClient)) {
       return await findEvmFillEvent(

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -194,8 +194,9 @@ export class SVMSpokePoolClient extends SpokePoolClient {
    */
   public override async getTimestampForBlock(slot: number): Promise<number> {
     let _slot = BigInt(slot);
+    const maxRetries = undefined; // Inherit defaults
     do {
-      const timestamp = await getTimestampForSlot(this.svmEventsClient.getRpc(), _slot, this.logger);
+      const timestamp = await getTimestampForSlot(this.svmEventsClient.getRpc(), _slot, maxRetries, this.logger);
       if (isDefined(timestamp)) {
         return timestamp;
       }

--- a/test/SVMSpokePoolClient.fills.ts
+++ b/test/SVMSpokePoolClient.fills.ts
@@ -96,13 +96,16 @@ describe("SVMSpokePoolClient: Fills", function () {
     await mintTokens(signer, solanaClient, mint.address, BigInt(relayData.outputAmount));
     await sendCreateFill(solanaClient, signer, mint, decimals, relayData);
 
+    const { spyLogger: logger } = createSpyLogger();
+
     // Look for the fill event:
     let fill = await findFillEvent(
       formattedRelayData,
       CHAIN_IDs.SOLANA,
       spokePoolClient.svmEventsClient,
-      createSpyLogger().spyLogger,
-      spokePoolClient.deploymentBlock
+      spokePoolClient.deploymentBlock,
+      undefined,
+      logger
     );
     expect(fill).to.not.be.undefined;
     fill = fill!;
@@ -114,8 +117,9 @@ describe("SVMSpokePoolClient: Fills", function () {
       { ...formattedRelayData, depositId: BigNumber.from(depositId + 1) },
       CHAIN_IDs.SOLANA,
       spokePoolClient.svmEventsClient,
-      createSpyLogger().spyLogger,
-      spokePoolClient.deploymentBlock
+      spokePoolClient.deploymentBlock,
+      undefined,
+      logger
     );
     expect(missingFill).to.be.undefined;
   });


### PR DESCRIPTION
The API doesn't have a logger instance available, so don't require a logger.