### PR TITLE
chore: Bump node & tsc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.19.2
+          node-version: 22.16.0
       - run: yarn install
       - run: yarn build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.19.2
+          node-version: 22.16.0
       - run: yarn install
       - run: yarn lint-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
 
       # Perform installs, run tests, run a build step, etc. here, as needed.
       - run: yarn
+        with:
+          node-version: "22.16.0"
 
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,17 +25,15 @@ jobs:
         id: release
         uses: manovotny/github-releases-for-automated-package-publishing-action@v2.0.1
 
-      # Perform installs, run tests, run a build step, etc. here, as needed.
-      - run: yarn
-        with:
-          node-version: "22.16.0"
-
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
           node-version: "22.16.0"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
+
+      # Perform installs, run tests, run a build step, etc. here, as needed.
+      - run: yarn
 
       # The last two steps will publish the package. Note that we're using
       # information from the `release` step above (I told you we'd use it

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.19.2"
+          node-version: "22.16.0"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           solana_version: ${{ steps.extract-versions.outputs.solana_version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.19.2
+          node-version: 22.16.0
       - run: yarn install
       - run: yarn test
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.43",
+  "version": "4.3.44-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=20.19.2"
+    "node": ">=22.16"
   },
   "scripts": {
     "build-bigint-buffer": "node scripts/build-bigint-buffer.js",
@@ -117,6 +117,7 @@
     "@solana/kit": "^2.1.0",
     "@solana/web3.js": "^1.31.0",
     "@types/mocha": "^10.0.1",
+    "@types/node": "^24.2.1",
     "@uma/sdk": "^0.34.10",
     "arweave": "^1.14.4",
     "async": "^3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3836,6 +3836,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
   integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
 
+"@types/node@^24.2.1":
+  version "24.2.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.2.1.tgz#83e41543f0a518e006594bb394e2cd961de56727"
+  integrity sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==
+  dependencies:
+    undici-types "~7.10.0"
+
 "@types/node@^8.0.0":
   version "8.10.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
@@ -15904,9 +15911,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@5:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 typical@^4.0.0:
   version "4.0.0"
@@ -15979,6 +15986,11 @@ undici-types@^7.3.0:
   version "7.4.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.4.0.tgz#19f31b649579a549957fb1810712dfaf84212b57"
   integrity sha512-4tv8DA1nBRW5kF2KBJZzEBjd66kDf3jArNVPoktdlv9Xsgw7EcIMu1bVbAXbX5IWuuZZ3YW3jIM2x85SPgMP6w==
+
+undici-types@~7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
+  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
 
 undici@^5.14.0:
   version "5.26.3"


### PR DESCRIPTION
Added @nodes/types on advice given in the TypeScript docs, based on
perceived incompatibilities around Buffer/Uint8Array-like types.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#notable-behavioral-changes