### PR TITLE
improve(RetrySolanaRpcFactory): Throw on Solana errors that don't throw errors

### DIFF
--- a/e2e/testTimestampForSlot.e2e.ts
+++ b/e2e/testTimestampForSlot.e2e.ts
@@ -62,7 +62,7 @@ async function testNearestSlotTime(
   const startTime = Date.now();
 
   try {
-    const { slot, timestamp } = await getNearestSlotTime(rpcClient, logger);
+    const { slot, timestamp } = await getNearestSlotTime(rpcClient, { commitment: "confirmed" }, logger);
     const elapsedTime = Date.now() - startTime;
 
     console.log(`✅ Slot ${slot} -> ${timestamp} (${new Date(timestamp * 1000).toISOString()}) (${elapsedTime}ms)`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.44",
+  "version": "4.3.45",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.45",
+  "version": "4.3.46",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/providers/solana/cachedRpcFactory.ts
+++ b/src/providers/solana/cachedRpcFactory.ts
@@ -42,7 +42,7 @@ export class CachedSolanaRpcFactory extends SolanaClusterRpcFactory {
 
   public createTransport(): RpcTransport {
     return async <TResponse>(...args: Parameters<RpcTransport>): Promise<TResponse> => {
-      const { method, params } = args[0].payload as { method: string; params?: unknown[] };
+      const { method, params = [] } = args[0].payload as { method: string; params?: unknown[] };
       const cacheType = this.redisClient ? this.cacheType(method) : CacheType.NONE;
 
       if (cacheType === CacheType.NONE) {

--- a/src/providers/solana/cachedRpcFactory.ts
+++ b/src/providers/solana/cachedRpcFactory.ts
@@ -42,7 +42,7 @@ export class CachedSolanaRpcFactory extends SolanaClusterRpcFactory {
 
   public createTransport(): RpcTransport {
     return async <TResponse>(...args: Parameters<RpcTransport>): Promise<TResponse> => {
-      const { method, params = [] } = args[0].payload as { method: string; params?: unknown[] };
+      const { method, params } = args[0].payload as { method: string; params?: unknown[] };
       const cacheType = this.redisClient ? this.cacheType(method) : CacheType.NONE;
 
       if (cacheType === CacheType.NONE) {


### PR DESCRIPTION
I think there are some Solana errors returned by `transportCall()` that don't throw errors, causing us to avoid falling back or retrying on these errors
