### PR TITLE
improve(utils): Define v2.5 upgrade blocks

### DIFF
--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -263,9 +263,6 @@ export async function findFillBlock(
   highBlockNumber?: number
 ): Promise<number | undefined> {
   const { provider } = spokePool;
-  highBlockNumber ??= await provider.getBlockNumber();
-  assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} >= ${highBlockNumber})`);
-
   // In production the chainId returned from the provider matches 1:1 with the actual chainId. Querying the provider
   // object saves an RPC query because the chainId is cached by StaticJsonRpcProvider instances. In hre, the SpokePool
   // may be configured with a different chainId than what is returned by the provider.
@@ -280,6 +277,8 @@ export async function findFillBlock(
   // For a subset of older SpokePools, their deployment ABIs did not include the fillStatus mapping.
   // Bound any searches by the blocks where fillStatus was added.
   lowBlockNumber = Math.max(lowBlockNumber, SPOKEPOOL_UPGRADE_BLOCKS[destinationChainId] ?? lowBlockNumber);
+  highBlockNumber ??= await provider.getBlockNumber();
+  assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} >= ${highBlockNumber})`);
 
   // Make sure the relay was completed within the block range supplied by the caller.
   const [initialFillStatus, finalFillStatus] = (

--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -266,11 +266,6 @@ export async function findFillBlock(
   highBlockNumber ??= await provider.getBlockNumber();
   assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} >= ${highBlockNumber})`);
 
-  // For a subset of older SpokePools, their deployment ABIs did not include the fillStatus mapping.
-  // Bound any searches by the blocks where fillStatus was added.
-  const { chainId } = await spokePool.provider.getNetwork();
-  lowBlockNumber = Math.max(lowBlockNumber, SPOKEPOOL_UPGRADE_BLOCKS[chainId] ?? lowBlockNumber);
-
   // In production the chainId returned from the provider matches 1:1 with the actual chainId. Querying the provider
   // object saves an RPC query because the chainId is cached by StaticJsonRpcProvider instances. In hre, the SpokePool
   // may be configured with a different chainId than what is returned by the provider.
@@ -281,6 +276,10 @@ export async function findFillBlock(
     relayData.originChainId !== destinationChainId,
     `Origin & destination chain IDs must not be equal (${destinationChainId})`
   );
+
+  // For a subset of older SpokePools, their deployment ABIs did not include the fillStatus mapping.
+  // Bound any searches by the blocks where fillStatus was added.
+  lowBlockNumber = Math.max(lowBlockNumber, SPOKEPOOL_UPGRADE_BLOCKS[destinationChainId] ?? lowBlockNumber);
 
   // Make sure the relay was completed within the block range supplied by the caller.
   const [initialFillStatus, finalFillStatus] = (

--- a/src/arch/evm/SpokeUtils.ts
+++ b/src/arch/evm/SpokeUtils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { BytesLike, Contract, PopulatedTransaction, providers } from "ethers";
-import { CHAIN_IDs } from "../../constants";
+import { CHAIN_IDs, SPOKEPOOL_UPGRADE_BLOCKS } from "../../constants";
 import {
   Deposit,
   FillStatus,
@@ -265,6 +265,11 @@ export async function findFillBlock(
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
   assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} >= ${highBlockNumber})`);
+
+  // For a subset of older SpokePools, their deployment ABIs did not include the fillStatus mapping.
+  // Bound any searches by the blocks where fillStatus was added.
+  const { chainId } = await spokePool.provider.getNetwork();
+  lowBlockNumber = Math.max(lowBlockNumber, SPOKEPOOL_UPGRADE_BLOCKS[chainId] ?? lowBlockNumber);
 
   // In production the chainId returned from the provider matches 1:1 with the actual chainId. Querying the provider
   // object saves an RPC query because the chainId is cached by StaticJsonRpcProvider instances. In hre, the SpokePool

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -11,6 +11,7 @@ import { DepositWithBlock, FillStatus, RelayData } from "../../interfaces";
 import {
   BigNumber,
   DepositSearchResult,
+  getMessageHash,
   getNetworkName,
   InvalidFill,
   MakeOptional,
@@ -194,18 +195,29 @@ export class EVMSpokePoolClient extends SpokePoolClient {
       };
     }
 
+    const spreadEvent = spreadEventWithBlockNumber(event) as Omit<
+      DepositWithBlock,
+      "inputToken" | "outputToken" | "depositor" | "recipient" | "exclusiveRelayer"
+    > & {
+      inputToken: string;
+      outputToken: string;
+      depositor: string;
+      recipient: string;
+      exclusiveRelayer: string;
+    };
     deposit = {
-      ...spreadEventWithBlockNumber(event),
-      inputToken: toAddressType(event.args.inputToken, event.args.originChainId),
-      outputToken: toAddressType(event.args.outputToken, event.args.destinationChainId),
-      depositor: toAddressType(event.args.depositor, this.chainId),
-      recipient: toAddressType(event.args.recipient, event.args.destinationChainId),
-      exclusiveRelayer: toAddressType(event.args.exclusiveRelayer, event.args.destinationChainId),
+      ...spreadEvent,
+      inputToken: toAddressType(spreadEvent.inputToken, spreadEvent.originChainId),
+      outputToken: toAddressType(spreadEvent.outputToken, spreadEvent.destinationChainId),
+      depositor: toAddressType(spreadEvent.depositor, this.chainId),
+      recipient: toAddressType(spreadEvent.recipient, spreadEvent.destinationChainId),
+      exclusiveRelayer: toAddressType(spreadEvent.exclusiveRelayer, spreadEvent.destinationChainId),
       originChainId: this.chainId,
-      quoteBlockNumber: await this.getBlockNumber(Number(event.args["quoteTimestamp"])),
+      quoteBlockNumber: await this.getBlockNumber(spreadEvent.quoteTimestamp),
+      messageHash: getMessageHash(spreadEvent.message),
       fromLiteChain: true, // To be updated immediately afterwards.
       toLiteChain: true, // To be updated immediately afterwards.
-    } as DepositWithBlock;
+    };
 
     if (deposit.outputToken.isZeroAddress()) {
       deposit.outputToken = this.getDestinationTokenForDeposit(deposit);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -94,8 +94,9 @@ export const CUSTOM_GAS_TOKENS = {
   [CHAIN_IDs.LENS_SEPOLIA]: "GHO",
 };
 
-// Blocks where SpokePools were upgraded from v2 to v2.5.
-// This is where the fillStatus mapping was introduced.
+// Blocks where SpokePools were upgraded from v2 to v2.5. This is where the fillStatus mapping
+// was introduced. This mapping should only be updated on subsequent upgrades where there are
+// breaking changes and the exact upgrade block is required to bound certain queries.
 export const SPOKEPOOL_UPGRADE_BLOCKS = {
   [CHAIN_IDs.ARBITRUM]: 183082059,
   [CHAIN_IDs.BASE]: 10874747,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,3 +93,14 @@ export const CUSTOM_GAS_TOKENS = {
   [CHAIN_IDs.LENS]: "GHO",
   [CHAIN_IDs.LENS_SEPOLIA]: "GHO",
 };
+
+// Blocks where SpokePools were upgraded from v2 to v2.5.
+// This is where the fillStatus mapping was introduced.
+export const SPOKEPOOL_UPGRADE_BLOCKS = {
+  [CHAIN_IDs.ARBITRUM]: 183082059,
+  [CHAIN_IDs.BASE]: 10874747,
+  [CHAIN_IDs.MAINNET]: 19277695,
+  [CHAIN_IDs.OPTIMISM]: 116469982,
+  [CHAIN_IDs.POLYGON]: 53793776,
+  [CHAIN_IDs.ZK_SYNC]: 27157340,
+};


### PR DESCRIPTION
This is required to set the lower bound for some older SpokePool fillStatus binary searches.