### PR TITLE
refactor: Centralise FundsDeposited/FilledRelay event unpacking

### DIFF
--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -227,15 +227,16 @@ export class SVMSpokePoolClient extends SpokePoolClient {
       };
     }
 
-    // Because we have additional context about this deposit, we can enrich it
-    // with additional information.
+    // Because we have additional context about this deposit, we can enrich it with additional information.
+    // outputToken is known to not be 0x0 on SVM SpokePool implementations.
+    const originChainId = this.chainId;
     return {
       found: true,
       deposit: {
         ...deposit,
+        originChainId,
         quoteBlockNumber: await this.getBlockNumber(Number(deposit.quoteTimestamp)),
-        originChainId: this.chainId,
-        fromLiteChain: this.isOriginLiteChain(deposit),
+        fromLiteChain: this.isOriginLiteChain({ ...deposit, originChainId }),
         toLiteChain: this.isDestinationLiteChain(deposit),
       },
     };

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -636,7 +636,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
           destinationChainId,
           depositor: toAddressType(event.depositor, event.originChainId),
           recipient: toAddressType(event.recipient, destinationChainId),
-          inputToken: toAddressType(event.inputToken, destinationChainId),
+          inputToken: toAddressType(event.inputToken, event.originChainId),
           outputToken: toAddressType(event.outputToken, destinationChainId),
           exclusiveRelayer: toAddressType(event.exclusiveRelayer, destinationChainId),
         } satisfies SlowFillRequestWithBlock;

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -13,13 +13,14 @@ import {
   assign,
   getRelayEventKey,
   isDefined,
-  getMessageHash,
   isSlowFill,
   validateFillForDeposit,
   chainIsEvm,
   chainIsProd,
   Address,
   toAddressType,
+  unpackDepositEvent,
+  unpackFillEvent,
 } from "../../utils";
 import { duplicateEvent, sortEventsAscendingInPlace } from "../../utils/EventUtils";
 import { CHAIN_IDs, ZERO_ADDRESS } from "../../constants";
@@ -39,7 +40,6 @@ import {
   SortableEvent,
   SpeedUpWithBlock,
   TokensBridged,
-  RelayExecutionEventInfo,
 } from "../../interfaces";
 import { BaseAbstractClient, UpdateFailureReason } from "../BaseAbstractClient";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
@@ -463,7 +463,9 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     return `${event.depositId.toString()}-${event.originChainId}`;
   }
 
-  protected canResolveZeroAddressOutputToken(deposit: DepositWithBlock): boolean {
+  protected canResolveZeroAddressOutputToken(
+    deposit: Pick<DepositWithBlock, "originChainId" | "inputToken" | "quoteBlockNumber" | "destinationChainId">
+  ): boolean {
     if (
       !this.hubPoolClient?.l2TokenHasPoolRebalanceRoute(
         deposit.inputToken,
@@ -519,39 +521,10 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     }
 
     // Performs the indexing of a deposit-like spoke pool event.
-    const originChainId = this.chainId;
     const queryDepositEvents = async (eventName: string) => {
-      const depositEvents = (queryResults[eventsToQuery.indexOf(eventName)] ?? []).map((_event) => {
-        const event = _event as Omit<
-          DepositWithBlock,
-          "originChainId" | "depositor" | "recipient" | "inputToken" | "outputToken" | "exclusiveRelayer"
-        > & {
-          depositor: string;
-          recipient: string;
-          inputToken: string;
-          outputToken: string;
-          exclusiveRelayer: string;
-        };
-        return {
-          ...event,
-          originChainId,
-          depositor: toAddressType(event.depositor, originChainId),
-          recipient: toAddressType(event.recipient, event.destinationChainId),
-          inputToken: toAddressType(event.inputToken, originChainId),
-          outputToken: toAddressType(event.outputToken, event.destinationChainId),
-          exclusiveRelayer: toAddressType(event.exclusiveRelayer, event.destinationChainId),
-          messageHash: getMessageHash(event.message),
-        } satisfies Omit<DepositWithBlock, "quoteBlockNumber" | "fromLiteChain" | "toLiteChain">;
-      });
-      if (depositEvents.length > 0) {
-        this.log(
-          "debug",
-          `Using ${depositEvents.length} newly queried ${eventName} deposit events for chain ${this.chainId}`,
-          {
-            earliestEvent: depositEvents[0].blockNumber,
-          }
-        );
-      }
+      const depositEvents = (queryResults[eventsToQuery.indexOf(eventName)] ?? []).map((event) =>
+        unpackDepositEvent(event, this.chainId)
+      );
 
       // For each deposit, resolve its quoteTimestamp to a block number on the HubPool.
       // Don't bother filtering for uniqueness; the HubPoolClient handles this efficienctly.
@@ -560,16 +533,17 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
         const quoteBlockNumber = quoteBlockNumbers[Number(event.quoteTimestamp)];
 
         // Derive and append the common properties that are not part of the onchain event.
+        const outputToken = event.outputToken.isZeroAddress()
+          ? this.getDestinationTokenForDeposit({ ...event, quoteBlockNumber })
+          : event.outputToken;
+
         const deposit = {
           ...event,
+          outputToken,
           quoteBlockNumber,
           fromLiteChain: this.isOriginLiteChain(event),
           toLiteChain: this.isDestinationLiteChain(event),
-        };
-
-        if (deposit.outputToken.isZeroAddress()) {
-          deposit.outputToken = this.getDestinationTokenForDeposit(deposit);
-        }
+        } satisfies DepositWithBlock;
 
         if (this.depositHashes[getRelayEventKey(deposit)] !== undefined) {
           // Sanity check that this event is not a duplicate, even though the relay data hash is a duplicate.
@@ -645,6 +619,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
 
     // Performs indexing of "requested slow fill"-like events.
     const queryRequestedSlowFillEvents = (eventName: string) => {
+      const destinationChainId = this.chainId;
       const slowFillRequests = (queryResults[eventsToQuery.indexOf(eventName)] ?? []).map((_event) => {
         const event = _event as Omit<
           SlowFillRequestWithBlock,
@@ -658,24 +633,21 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
         };
         return {
           ...event,
+          destinationChainId,
           depositor: toAddressType(event.depositor, event.originChainId),
-          recipient: toAddressType(event.recipient, this.chainId),
-          inputToken: toAddressType(event.inputToken, event.originChainId),
-          outputToken: toAddressType(event.outputToken, this.chainId),
-          exclusiveRelayer: toAddressType(event.exclusiveRelayer, this.chainId),
-        } as SlowFillRequestWithBlock;
+          recipient: toAddressType(event.recipient, destinationChainId),
+          inputToken: toAddressType(event.inputToken, destinationChainId),
+          outputToken: toAddressType(event.outputToken, destinationChainId),
+          exclusiveRelayer: toAddressType(event.exclusiveRelayer, destinationChainId),
+        } satisfies SlowFillRequestWithBlock;
       });
-      for (const event of slowFillRequests) {
-        const slowFillRequest = {
-          ...event,
-          destinationChainId: this.chainId,
-        };
 
-        const depositHash = getRelayEventKey({ ...slowFillRequest, destinationChainId: this.chainId });
+      for (const slowFillRequest of slowFillRequests) {
+        const depositHash = getRelayEventKey(slowFillRequest);
 
         // Sanity check that this event is not a duplicate.
         if (this.slowFillRequests[depositHash] !== undefined) {
-          duplicateEvents.push(event);
+          duplicateEvents.push(slowFillRequest);
           continue;
         }
 
@@ -690,45 +662,10 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
     });
 
     // Performs indexing of filled relay-like events.
-    const destinationChainId = this.chainId;
     const queryFilledRelayEvents = (eventName: string) => {
-      const fillEvents = (queryResults[eventsToQuery.indexOf(eventName)] ?? []).map((_event) => {
-        const event = _event as Omit<
-          FillWithBlock,
-          | "destinationChainId"
-          | "depositor"
-          | "recipient"
-          | "inputToken"
-          | "outputToken"
-          | "exclusiveRelayer"
-          | "relayer"
-          | "relayExecutionInfo"
-        > & {
-          depositor: string;
-          recipient: string;
-          inputToken: string;
-          outputToken: string;
-          exclusiveRelayer: string;
-          relayer: string;
-          relayExecutionInfo: Omit<RelayExecutionEventInfo, "updatedRecipient"> & { updatedRecipient: string };
-        };
-
-        return {
-          ...event,
-          destinationChainId,
-          depositor: toAddressType(event.depositor, event.originChainId),
-          recipient: toAddressType(event.recipient, destinationChainId),
-          inputToken: toAddressType(event.inputToken, event.originChainId),
-          outputToken: toAddressType(event.outputToken, destinationChainId),
-          exclusiveRelayer: toAddressType(event.exclusiveRelayer, destinationChainId),
-          relayer: toAddressType(event.relayer, event.repaymentChainId),
-          relayExecutionInfo: {
-            ...event.relayExecutionInfo,
-            updatedRecipient: toAddressType(event.relayExecutionInfo.updatedRecipient, this.chainId),
-          },
-        } satisfies FillWithBlock;
-      });
-
+      const fillEvents = (queryResults[eventsToQuery.indexOf(eventName)] ?? []).map((event) =>
+        unpackFillEvent(event, this.chainId)
+      );
       if (fillEvents.length > 0) {
         this.log("debug", `Using ${fillEvents.length} newly queried ${eventName} events for chain ${this.chainId}`, {
           earliestEvent: fillEvents[0].blockNumber,
@@ -858,7 +795,9 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @param deposit The deposit to retrieve the destination token for.
    * @returns The destination token.
    */
-  protected getDestinationTokenForDeposit(deposit: DepositWithBlock): Address {
+  protected getDestinationTokenForDeposit(
+    deposit: Pick<DepositWithBlock, "originChainId" | "inputToken" | "quoteBlockNumber" | "destinationChainId">
+  ): Address {
     if (!this.canResolveZeroAddressOutputToken(deposit)) {
       return toAddressType(ZERO_ADDRESS, CHAIN_IDs.MAINNET);
     }
@@ -900,7 +839,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @returns True if the deposit originates from a lite chain, false otherwise. If the hub pool client is not defined,
    *          this method will return false.
    */
-  protected isOriginLiteChain(deposit: DepositWithBlock): boolean {
+  protected isOriginLiteChain(deposit: Pick<DepositWithBlock, "originChainId" | "quoteTimestamp">): boolean {
     return this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.originChainId, deposit.quoteTimestamp) ?? false;
   }
 
@@ -910,7 +849,7 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
    * @returns True if the deposit is destined to a lite chain, false otherwise. If the hub pool client is not defined,
    *          this method will return false.
    */
-  protected isDestinationLiteChain(deposit: DepositWithBlock): boolean {
+  protected isDestinationLiteChain(deposit: Pick<DepositWithBlock, "destinationChainId" | "quoteTimestamp">): boolean {
     return (
       this.configStoreClient?.isChainLiteChainAtTimestamp(deposit.destinationChainId, deposit.quoteTimestamp) ?? false
     );

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,11 +1,21 @@
 import { encodeAbiParameters, Hex, keccak256 } from "viem";
 import { fixedPointAdjustment as fixedPoint } from "./common";
 import { MAX_SAFE_DEPOSIT_ID, ZERO_BYTES } from "../constants";
-import { Fill, FillType, RelayData, SlowFillLeaf } from "../interfaces";
+import {
+  DepositWithBlock,
+  Fill,
+  FillWithBlock,
+  FillType,
+  RelayData,
+  RelayExecutionEventInfo,
+  SlowFillLeaf,
+  SortableEvent,
+} from "../interfaces";
+import { svm } from "../arch";
 import { BigNumber } from "./BigNumberUtils";
 import { isMessageEmpty } from "./DepositUtils";
 import { chainIsSvm } from "./NetworkUtils";
-import { svm } from "../arch";
+import { toAddressType } from "./AddressUtils";
 
 export function isSlowFill(fill: Fill): boolean {
   return fill.relayExecutionInfo.fillType === FillType.SlowFill;
@@ -15,6 +25,92 @@ export function getSlowFillLeafLpFeePct(leaf: SlowFillLeaf): BigNumber {
   const { relayData, updatedOutputAmount } = leaf;
   return relayData.inputAmount.sub(updatedOutputAmount).mul(fixedPoint).div(relayData.inputAmount);
 }
+
+/**
+ * Given a SortableEvent type, unpack the available FundsDeposited fields.
+ * @note Some fields cannot be evaluated without additional context - i.e. quoteBlockNumber, {from,to}LiteChain.
+ * @param rawEvent emitted by FundsDeposited event.
+ * @param originChainId Deposit originChainId
+ * @returns A mostly-populated DepositWithBlock event.
+ */
+export function unpackDepositEvent(
+  rawEvent: SortableEvent,
+  originChainId: number
+): Omit<DepositWithBlock, "quoteBlockNumber" | "fromLiteChain" | "toLiteChain"> {
+  const event = rawEvent as Omit<
+    DepositWithBlock,
+    | "originChainId"
+    | "depositor"
+    | "recipient"
+    | "inputToken"
+    | "outputToken"
+    | "exclusiveRelayer"
+    | "quoteBlockNumber"
+    | "fromLiteChain"
+    | "toLiteChain"
+  > & {
+    depositor: string;
+    recipient: string;
+    inputToken: string;
+    outputToken: string;
+    exclusiveRelayer: string;
+  };
+
+  return {
+    ...event,
+    originChainId,
+    depositor: toAddressType(event.depositor, originChainId),
+    recipient: toAddressType(event.recipient, event.destinationChainId),
+    inputToken: toAddressType(event.inputToken, originChainId),
+    outputToken: toAddressType(event.outputToken, event.destinationChainId),
+    exclusiveRelayer: toAddressType(event.exclusiveRelayer, event.destinationChainId),
+    messageHash: getMessageHash(event.message),
+  } satisfies Omit<DepositWithBlock, "quoteBlockNumber" | "fromLiteChain" | "toLiteChain">;
+}
+
+/**
+ * Given a SortableEvent type, unpack the complete set of FilledRelay fields.
+ * @param rawEvent emitted by FundsDeposited event.
+ * @param originChainId Deposit originChainId
+ * @returns A mostly-populated DepositWithBlock event.
+ */
+export function unpackFillEvent(rawEvent: SortableEvent, destinationChainId: number): FillWithBlock {
+  const event = rawEvent as Omit<
+    FillWithBlock,
+    | "destinationChainId"
+    | "depositor"
+    | "recipient"
+    | "inputToken"
+    | "outputToken"
+    | "exclusiveRelayer"
+    | "relayer"
+    | "relayerExecutionInfo"
+  > & {
+    depositor: string;
+    recipient: string;
+    inputToken: string;
+    outputToken: string;
+    exclusiveRelayer: string;
+    relayer: string;
+    relayExecutionInfo: Omit<RelayExecutionEventInfo, "updatedRecipient"> & { updatedRecipient: string };
+  };
+
+  return {
+    ...event,
+    destinationChainId,
+    depositor: toAddressType(event.depositor, event.originChainId),
+    recipient: toAddressType(event.recipient, destinationChainId),
+    inputToken: toAddressType(event.inputToken, event.originChainId),
+    outputToken: toAddressType(event.outputToken, destinationChainId),
+    exclusiveRelayer: toAddressType(event.exclusiveRelayer, destinationChainId),
+    relayer: toAddressType(event.relayer, event.repaymentChainId),
+    relayExecutionInfo: {
+      ...event.relayExecutionInfo,
+      updatedRecipient: toAddressType(event.relayExecutionInfo.updatedRecipient, destinationChainId),
+    },
+  } satisfies FillWithBlock;
+}
+
 /**
  * Compute the RelayData hash for a fill. This can be used to determine the fill status.
  * @param relayData RelayData information that is used to complete a fill.

--- a/test/SpokeUtils.ts
+++ b/test/SpokeUtils.ts
@@ -10,9 +10,23 @@ import {
   EvmAddress,
   SvmAddress,
   getRelayDataHash,
+  unpackDepositEvent,
+  unpackFillEvent,
 } from "../src/utils";
+import { relayFillStatus } from "../src/arch/evm/SpokeUtils";
 import { arch } from "../src";
-import { expect } from "./utils";
+import {
+  expect,
+  deploySpokePoolWithToken,
+  deposit,
+  setupTokensForWallet,
+  ethers,
+  fillFromDeposit,
+  Contract,
+  BigNumber,
+  SignerWithAddress,
+} from "./utils";
+import { FillStatus } from "../src/interfaces";
 
 const random = () => Math.round(Math.random() * 1e8);
 const randomBytes = () => `0x${ethersUtils.randomBytes(48).join("").slice(0, 64)}`;
@@ -129,5 +143,272 @@ describe("SpokeUtils", function () {
     const relayHashWithMessageEvm = getRelayDataHash(mockDeposit, destinationChainId);
     expect(relayHashWithMessageSvm).to.eq("0x3feedd6e7fc3866a895cadde1cc9519a08109f9c78255e0fc6f5538097273344");
     expect(relayHashWithMessageEvm).to.eq("0x296700dda08c58e3b2ad530ee4821f4d0e8b75f26854d218a9aa559e21d7c3e3");
+  });
+
+  describe("unpackDepositEvent", function () {
+    let spokePool: Contract, erc20: Contract, destErc20: Contract, weth: Contract;
+    let depositor: SignerWithAddress, deploymentBlock: number;
+    let inputToken: EvmAddress, outputToken: EvmAddress;
+    let inputAmount: BigNumber, outputAmount: BigNumber;
+
+    beforeEach(async function () {
+      [, depositor] = await ethers.getSigners();
+
+      ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken());
+      await setupTokensForWallet(spokePool, depositor, [erc20, destErc20], weth, 10);
+
+      const balance = await erc20.connect(depositor).balanceOf(depositor.address);
+      inputToken = EvmAddress.from(erc20.address);
+      outputToken = EvmAddress.from(destErc20.address);
+      inputAmount = balance;
+      outputAmount = inputAmount.sub(toBN(1));
+    });
+
+    it("should unpack deposit event correctly from real contract event", async function () {
+      const destinationChainId = 137;
+
+      const depositEvent = await deposit(
+        spokePool,
+        destinationChainId,
+        depositor,
+        inputToken,
+        inputAmount,
+        outputToken,
+        outputAmount
+      );
+
+      // Get the raw event from the transaction
+      const filter = spokePool.filters.FundsDeposited();
+      const events = await spokePool.queryFilter(filter, deploymentBlock);
+      const rawEvent = events[events.length - 1];
+
+      const result = unpackDepositEvent(rawEvent, depositEvent.originChainId);
+
+      expect(result.originChainId).to.equal(depositEvent.originChainId);
+      expect(result.depositId.toString()).to.equal(depositEvent.depositId.toString());
+      expect(result.depositor.toString()).to.equal(depositEvent.depositor.toString());
+      expect(result.recipient.toString()).to.equal(depositEvent.recipient.toString());
+      expect(result.inputToken.toString()).to.equal(depositEvent.inputToken.toString());
+      expect(result.outputToken.toString()).to.equal(depositEvent.outputToken.toString());
+      expect(result.exclusiveRelayer.toString()).to.equal(depositEvent.exclusiveRelayer.toString());
+      expect(result.inputAmount.toString()).to.equal(depositEvent.inputAmount.toString());
+      expect(result.outputAmount.toString()).to.equal(depositEvent.outputAmount.toString());
+      expect(result.destinationChainId).to.equal(depositEvent.destinationChainId);
+      expect(result.fillDeadline).to.equal(depositEvent.fillDeadline);
+      expect(result.exclusivityDeadline).to.equal(depositEvent.exclusivityDeadline);
+      expect(result.message).to.equal(depositEvent.message);
+      expect(result.messageHash).to.equal(getMessageHash(depositEvent.message));
+      expect(result.quoteTimestamp).to.equal(depositEvent.quoteTimestamp);
+      expect(result.blockNumber).to.equal(rawEvent.blockNumber);
+      expect(result.txnIndex).to.equal(rawEvent.transactionIndex);
+      expect(result.txnRef.hash).to.equal(rawEvent.transactionHash);
+    });
+
+    it("should handle deposit with custom message", async function () {
+      const destinationChainId = 137;
+      const customMessage = "0x1234abcd";
+
+      const depositEvent = await deposit(
+        spokePool,
+        destinationChainId,
+        depositor,
+        inputToken,
+        inputAmount,
+        outputToken,
+        outputAmount,
+        { message: customMessage }
+      );
+
+      // Get the raw event from the transaction
+      const filter = spokePool.filters.FundsDeposited();
+      const events = await spokePool.queryFilter(filter, deploymentBlock);
+      const rawEvent = events[events.length - 1];
+
+      const result = unpackDepositEvent(rawEvent, depositEvent.originChainId);
+
+      expect(result.message).to.equal(customMessage);
+      expect(result.messageHash).to.equal(getMessageHash(customMessage));
+      expect(result.messageHash).to.not.equal(ZERO_BYTES);
+    });
+  });
+
+  describe("unpackFillEvent", function () {
+    let spokePool: Contract, erc20: Contract, destErc20: Contract, weth: Contract;
+    let depositor: SignerWithAddress, relayer: SignerWithAddress, deploymentBlock: number;
+    let inputToken: EvmAddress, outputToken: EvmAddress;
+    let inputAmount: BigNumber, outputAmount: BigNumber;
+
+    beforeEach(async function () {
+      const signers = await ethers.getSigners();
+      [, depositor, relayer] = signers;
+
+      ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken());
+      await setupTokensForWallet(spokePool, depositor, [erc20, destErc20], weth, 10);
+      await setupTokensForWallet(spokePool, relayer, [erc20, destErc20], weth, 10);
+
+      const balance = await erc20.connect(depositor).balanceOf(depositor.address);
+      inputToken = EvmAddress.from(erc20.address);
+      outputToken = EvmAddress.from(destErc20.address);
+      inputAmount = balance;
+      outputAmount = inputAmount.sub(toBN(1));
+    });
+
+    it("should unpack fill event correctly from real contract event", async function () {
+      const destinationChainId = 137;
+
+      // First create a deposit
+      const depositEvent = await deposit(
+        spokePool,
+        destinationChainId,
+        depositor,
+        inputToken,
+        inputAmount,
+        outputToken,
+        outputAmount
+      );
+
+      // Create fill data from the deposit
+      const fillData = fillFromDeposit(depositEvent, EvmAddress.from(relayer.address));
+
+      // Execute the fill
+      await destErc20.connect(relayer).approve(spokePool.address, outputAmount);
+      await spokePool
+        .connect(relayer)
+        .fillRelay(
+          fillData.depositor.toBytes32(),
+          fillData.recipient.toBytes32(),
+          fillData.exclusiveRelayer.toBytes32(),
+          fillData.inputToken.toBytes32(),
+          fillData.outputToken.toBytes32(),
+          fillData.inputAmount,
+          fillData.outputAmount,
+          fillData.originChainId,
+          fillData.destinationChainId,
+          fillData.depositId,
+          fillData.fillDeadline,
+          fillData.exclusivityDeadline,
+          fillData.message,
+          fillData.relayExecutionInfo.updatedRecipient,
+          fillData.relayExecutionInfo.updatedOutputAmount,
+          fillData.relayExecutionInfo.updatedMessage,
+          fillData.relayExecutionInfo.fillType
+        );
+
+      // Get the raw fill event from the transaction
+      const filter = spokePool.filters.FilledRelay();
+      const events = await spokePool.queryFilter(filter, deploymentBlock);
+      const rawEvent = events[events.length - 1];
+
+      const result = unpackFillEvent(rawEvent, destinationChainId);
+
+      expect(result.destinationChainId).to.equal(destinationChainId);
+      expect(result.depositId.toString()).to.equal(fillData.depositId.toString());
+      expect(result.depositor.toString()).to.equal(fillData.depositor.toString());
+      expect(result.recipient.toString()).to.equal(fillData.recipient.toString());
+      expect(result.inputToken.toString()).to.equal(fillData.inputToken.toString());
+      expect(result.outputToken.toString()).to.equal(fillData.outputToken.toString());
+      expect(result.exclusiveRelayer.toString()).to.equal(fillData.exclusiveRelayer.toString());
+      expect(result.relayer.toString()).to.equal(fillData.relayer.toString());
+      expect(result.inputAmount.toString()).to.equal(fillData.inputAmount.toString());
+      expect(result.outputAmount.toString()).to.equal(fillData.outputAmount.toString());
+      expect(result.originChainId).to.equal(fillData.originChainId);
+      expect(result.fillDeadline).to.equal(fillData.fillDeadline);
+      expect(result.exclusivityDeadline).to.equal(fillData.exclusivityDeadline);
+      expect(result.messageHash).to.equal(getMessageHash(fillData.message));
+      expect(result.repaymentChainId).to.equal(fillData.repaymentChainId);
+      expect(result.relayExecutionInfo.updatedRecipient.toString()).to.equal(
+        fillData.relayExecutionInfo.updatedRecipient.toString()
+      );
+      expect(result.relayExecutionInfo.updatedOutputAmount.toString()).to.equal(
+        fillData.relayExecutionInfo.updatedOutputAmount.toString()
+      );
+      expect(result.relayExecutionInfo.updatedMessage).to.equal(fillData.relayExecutionInfo.updatedMessage);
+      expect(result.relayExecutionInfo.updatedMessageHash).to.equal(fillData.relayExecutionInfo.updatedMessageHash);
+      expect(result.relayExecutionInfo.fillType).to.equal(fillData.relayExecutionInfo.fillType);
+      expect(result.blockNumber).to.equal(rawEvent.blockNumber);
+      expect(result.txnIndex).to.equal(rawEvent.transactionIndex);
+      expect(result.txnRef.hash).to.equal(rawEvent.transactionHash);
+
+      // Test RelayData hash computation and fill status
+      const relayDataHash = getRelayDataHash(fillData, destinationChainId);
+      expect(relayDataHash).to.be.a("string");
+      expect(relayDataHash).to.have.lengthOf(66); // 0x + 64 hex chars
+
+      // Check fill status before fill - should be Unfilled
+      const fillStatusBefore = await relayFillStatus(spokePool, fillData, rawEvent.blockNumber - 1, destinationChainId);
+      expect(fillStatusBefore).to.equal(FillStatus.Unfilled);
+
+      // Check fill status after fill - should be Filled
+      const fillStatusAfter = await relayFillStatus(spokePool, fillData, rawEvent.blockNumber, destinationChainId);
+      expect(fillStatusAfter).to.equal(FillStatus.Filled);
+    });
+
+    it("should verify RelayData hash consistency between deposit and fill", async function () {
+      const destinationChainId = 137;
+
+      // Create a deposit
+      const depositEvent = await deposit(
+        spokePool,
+        destinationChainId,
+        depositor,
+        inputToken,
+        inputAmount,
+        outputToken,
+        outputAmount
+      );
+
+      // Create fill data from the deposit
+      const fillData = fillFromDeposit(depositEvent, EvmAddress.from(relayer.address));
+
+      // Compute hash from deposit data
+      const depositRelayData = {
+        originChainId: depositEvent.originChainId,
+        depositor: depositEvent.depositor,
+        recipient: depositEvent.recipient,
+        inputToken: depositEvent.inputToken,
+        outputToken: depositEvent.outputToken,
+        inputAmount: depositEvent.inputAmount,
+        outputAmount: depositEvent.outputAmount,
+        depositId: depositEvent.depositId,
+        fillDeadline: depositEvent.fillDeadline,
+        exclusiveRelayer: depositEvent.exclusiveRelayer,
+        exclusivityDeadline: depositEvent.exclusivityDeadline,
+        message: depositEvent.message,
+      };
+
+      const depositHash = getRelayDataHash(depositRelayData, destinationChainId);
+      const fillHash = getRelayDataHash(fillData, destinationChainId);
+
+      // Hashes should be identical since they represent the same relay
+      expect(depositHash).to.equal(fillHash);
+
+      // Execute the fill
+      await destErc20.connect(relayer).approve(spokePool.address, outputAmount);
+      await spokePool
+        .connect(relayer)
+        .fillRelay(
+          fillData.depositor.toBytes32(),
+          fillData.recipient.toBytes32(),
+          fillData.exclusiveRelayer.toBytes32(),
+          fillData.inputToken.toBytes32(),
+          fillData.outputToken.toBytes32(),
+          fillData.inputAmount,
+          fillData.outputAmount,
+          fillData.originChainId,
+          fillData.destinationChainId,
+          fillData.depositId,
+          fillData.fillDeadline,
+          fillData.exclusivityDeadline,
+          fillData.message,
+          fillData.relayExecutionInfo.updatedRecipient,
+          fillData.relayExecutionInfo.updatedOutputAmount,
+          fillData.relayExecutionInfo.updatedMessage,
+          fillData.relayExecutionInfo.fillType
+        );
+
+      // Verify the fill status using the hash
+      const fillStatus = await relayFillStatus(spokePool, fillData, "latest", destinationChainId);
+      expect(fillStatus).to.equal(FillStatus.Filled);
+    });
   });
 });


### PR DESCRIPTION
This functionality has way more footgun than is desirable, so centralise it as a way of containing the badness, where it can be tested.

This should be updated subseuently with some additional type validation by grasphoper@.