### PR TITLE
chore: Import minimal/stripped uma/sdk functions for poolClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@solana/kit": "^2.1.0",
     "@solana/web3.js": "^1.31.0",
     "@types/mocha": "^10.0.1",
-    "@uma/sdk": "^0.34.10",
+    "@uma/contracts-node": "^0.4.26",
     "arweave": "^1.14.4",
     "async": "^3.2.5",
     "axios": "^0.27.2",

--- a/src/pool/poolClient.ts
+++ b/src/pool/poolClient.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import * as uma from "@uma/sdk";
+import * as uma from "./uma";
 import {
   bnZero,
   toBNWei,

--- a/src/pool/uma/across/constants.ts
+++ b/src/pool/uma/across/constants.ts
@@ -1,0 +1,2 @@
+export const SECONDS_PER_YEAR = 31557600; // based on 365.25 days per year
+export const DEFAULT_BLOCK_DELTA = 10; // look exchange rate up based on 10 block difference by default

--- a/src/pool/uma/across/index.ts
+++ b/src/pool/uma/across/index.ts
@@ -1,0 +1,2 @@
+export { default as TransactionManager } from "./transactionManager";
+export * as constants from "./constants";

--- a/src/pool/uma/across/transactionManager.ts
+++ b/src/pool/uma/across/transactionManager.ts
@@ -1,0 +1,73 @@
+import assert from "assert";
+import { Signer } from "ethers";
+import { TransactionRequest, TransactionReceipt } from "@ethersproject/abstract-provider";
+
+function makeKey(tx: TransactionRequest) {
+  return JSON.stringify(
+    Object.entries(tx).map(([key, value]) => {
+      return [key, (value || "").toString()];
+    })
+  );
+}
+
+type Config = {
+  confirmations?: number;
+};
+export type Emit = (event: string, key: string, data: TransactionReceipt | string | TransactionRequest | Error) => void;
+export default (config: Config, signer: Signer, emit: Emit = () => null) => {
+  assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+  const { confirmations = 3 } = config;
+  const requests = new Map<string, TransactionRequest>();
+  const submissions = new Map<string, string>();
+  const mined = new Map<string, TransactionReceipt>();
+  function request(unsignedTx: TransactionRequest) {
+    // this no longer calls signer.populateTransaction, to allow metamask to fill in missing details instead
+    // use overrides if you want to manually fill in other tx details, including the overrides.customData field.
+    const populated = unsignedTx;
+    const key = makeKey(populated);
+    assert(!requests.has(key), "Transaction already in progress");
+    requests.set(key, populated);
+    return key;
+  }
+  async function processRequest(key: string) {
+    const request = requests.get(key);
+    assert(request, "invalid request");
+    // always delete request, it should only be submitted once
+    requests.delete(key);
+    try {
+      const sent = await signer.sendTransaction(request);
+      submissions.set(key, sent.hash);
+      emit("submitted", key, sent.hash);
+    } catch (err) {
+      emit("error", key, err as Error);
+    }
+  }
+  async function processSubmission(key: string) {
+    const hash = submissions.get(key);
+    assert(hash, "invalid submission");
+    assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+    // we look for this transaction, but it may never find it if its sped up
+    const receipt = await signer.provider.getTransactionReceipt(hash).catch(() => undefined);
+    if (receipt == null) return;
+    if (receipt.confirmations < confirmations) return;
+    submissions.delete(key);
+    mined.set(key, receipt);
+    emit("mined", key, receipt);
+  }
+  async function isMined(key: string) {
+    return mined.get(key);
+  }
+  async function update() {
+    for (const key of Array.from(requests.keys())) {
+      await processRequest(key);
+    }
+    for (const key of Array.from(submissions.keys())) {
+      await processSubmission(key);
+    }
+  }
+  return {
+    request,
+    isMined,
+    update,
+  };
+};

--- a/src/pool/uma/clients/erc20/README.md
+++ b/src/pool/uma/clients/erc20/README.md
@@ -1,0 +1,29 @@
+# UMA SDK ERC20 Client
+
+Client to interface with ERC20 style tokens, based on Ethers and typechain.
+
+## Usage
+
+```js
+import {ethers} from 'ethers'
+
+// assume you have a url injected from env
+const provider = new ethers.providers.WebSocketProvider(env.CUSTOM_NODE_URL)
+
+// get the contract instance
+const erc20Address:string = // assume you have an emp address you want to connect to
+const erc20Instance:uma.clients.erc20.Instance = uma.clients.erc20.connect(erc20Address,provider)
+
+// gets all emp events, see ethers queryFilter for details on contructing the query.
+const events = await erc20Instance.queryFilter({})
+
+// returns EventState, defined in the emp client. This can contain user balances as well as approval limits.
+const state:uma.clients.erc20.EventState = uma.clients.erc20.getEventState(events)
+
+// Types
+types {Transfer,Approval, Instance, EventState} = uma.clients.erc20
+// Transfer and Approval are event types
+// Instance is the contract instance once connected
+// Event state describes what the state reconstruction based on contract events will look like
+
+```

--- a/src/pool/uma/clients/erc20/client.e2e.ts
+++ b/src/pool/uma/clients/erc20/client.e2e.ts
@@ -1,0 +1,26 @@
+require("dotenv").config();
+import assert from "assert";
+import * as Client from "./client";
+import { ethers } from "ethers";
+
+const address = "0xeca82185adCE47f39c684352B0439f030f860318";
+// these require integration testing, skip for ci
+describe("erc20", function () {
+  let client: Client.Instance;
+  let events: any;
+  test("inits", function () {
+    const provider = ethers.providers.getDefaultProvider(process.env.CUSTOM_NODE_URL);
+    client = Client.connect(address, provider);
+    assert.ok(client);
+  });
+  test("getEventState between", async function () {
+    events = await client.queryFilter({}, 12477952, 12477952 + 1000);
+    assert.ok(events.length);
+  });
+  test("getEventState", async function () {
+    const state = await Client.getEventState(events);
+    assert.ok(state.balances);
+    assert.ok(state.approvalsByOwner);
+    assert.ok(state.approvalsBySpender);
+  });
+});

--- a/src/pool/uma/clients/erc20/client.ts
+++ b/src/pool/uma/clients/erc20/client.ts
@@ -1,0 +1,66 @@
+import { ERC20Ethers, ERC20Ethers__factory } from "@uma/contracts-node";
+import { Event } from "ethers";
+import { set } from "lodash";
+import { Balances } from "../../utils";
+import type { Provider, GetEventType } from "../..";
+
+export type Instance = ERC20Ethers;
+const Factory = ERC20Ethers__factory;
+
+export function connect(address: string, provider: Provider): Instance {
+  return Factory.connect(address, provider);
+}
+
+export interface EventState {
+  // any address that created a position, regardless of if they have closed it
+  balances?: Balances;
+  // approvals are keyed both ways here for ease of lookup by either owner or spender
+  approvalsByOwner?: {
+    [owner: string]: {
+      [spender: string]: {
+        amount: string;
+      };
+    };
+  };
+  approvalsBySpender?: {
+    [spender: string]: {
+      [owner: string]: {
+        amount: string;
+      };
+    };
+  };
+}
+
+export type Transfer = GetEventType<Instance, "Transfer">;
+export type Approval = GetEventType<Instance, "Approval">;
+
+// takes all events and returns user balances and approvals
+function reduceEvents(state: EventState = {}, event: Event): EventState {
+  switch (event.event) {
+    case "Transfer": {
+      const typedEvent = event as Transfer;
+      const { from, to, value } = typedEvent.args;
+      const balances = Balances(state.balances || {});
+      balances.sub(from, value);
+      balances.add(to, value);
+      return {
+        ...state,
+        balances: balances.balances,
+      };
+    }
+    case "Approval": {
+      const typedEvent = event as Approval;
+      const { owner, spender, value } = typedEvent.args;
+      set(state, ["approvalsByOwner", owner, spender], value.toString());
+      set(state, ["approvalsBySpender", spender, owner], value.toString());
+      return {
+        ...state,
+      };
+    }
+  }
+  return state;
+}
+
+export function getEventState(events: Event[], initialState: EventState = {}): EventState {
+  return events.reduce(reduceEvents, initialState);
+}

--- a/src/pool/uma/clients/erc20/index.ts
+++ b/src/pool/uma/clients/erc20/index.ts
@@ -1,0 +1,1 @@
+export * from "./client";

--- a/src/pool/uma/clients/index.ts
+++ b/src/pool/uma/clients/index.ts
@@ -1,0 +1,1 @@
+export * as erc20 from "./erc20";

--- a/src/pool/uma/index.ts
+++ b/src/pool/uma/index.ts
@@ -1,0 +1,31 @@
+import { Contract, ethers, Event } from "ethers";
+import type { TypedEventFilterEthers as TypedEventFilter, TypedEventEthers as TypedEvent } from "@uma/contracts-node";
+
+export * as across from "./across";
+export * as clients from "./clients";
+export * as oracle from "./oracle";
+export * as utils from "./utils";
+
+export { type Provider } from "@ethersproject/providers";
+
+type Result = ethers.utils.Result;
+
+export interface Callable {
+  (...args: any[]): any;
+}
+
+export type SerializableEvent = Omit<
+  Event,
+  "decode" | "removeListener" | "getBlock" | "getTransaction" | "getTransactionReceipt"
+>;
+
+// this convoluted type is meant to cast events to the types you need based on the contract and event name
+// example: type NewContractRegistered = GetEventType<Registry,"NewContractRegistered">;
+// TODO: the any below is a hacky solution because some typechain types fail to resolve due to
+// incompatible TypedEventFilter and TypedEvent types. This will be fixed by upgrading typechain
+// to a version where Ethers events are exported as first class types.
+export type GetEventType<ContractType extends Contract, EventName extends string> = ReturnType<
+  ContractType["filters"][EventName] extends Callable ? ContractType["filters"][EventName] : never
+> extends TypedEventFilter<infer T, infer S>
+  ? TypedEvent<T & S extends Result ? T & S : any>
+  : never;

--- a/src/pool/uma/oracle/index.ts
+++ b/src/pool/uma/oracle/index.ts
@@ -1,0 +1,2 @@
+// Minimal oracle module - only export utils needed by poolClient
+export * as utils from "./utils";

--- a/src/pool/uma/oracle/utils.ts
+++ b/src/pool/uma/oracle/utils.ts
@@ -1,0 +1,38 @@
+import { BigNumberish } from "../../../utils";
+import sortedLastIndexBy from "lodash/sortedLastIndexBy";
+
+/**
+ * eventKey. Make a unique and sortable identifier string for an event
+ * Used by poolClient.ts lines 166, 246
+ *
+ * @param {Event} event
+ * @returns {string} - the unique id
+ */
+export function eventKey(event: {
+  blockNumber: BigNumberish;
+  transactionIndex: BigNumberish;
+  logIndex: BigNumberish;
+}): string {
+  return [
+    // we pad these because numbers of varying lengths will not sort correctly, ie "10" will incorrectly sort before "9", but "09" will be correct.
+    event.blockNumber.toString().padStart(16, "0"),
+    event.transactionIndex.toString().padStart(16, "0"),
+    event.logIndex?.toString().padStart(16, "0"),
+    // ~ is the last printable ascii char, so it does not interfere with sorting
+  ].join("~");
+}
+
+/**
+ * insertOrdered. Inserts items in an array maintaining sorted order, in this case lowest to highest. Does not check duplicates.
+ * Mainly used for caching all known events, in order of oldest to newest.
+ * Used by poolClient.ts line 181
+ *
+ * @param {T[]} array
+ * @param {T} element
+ * @param {Function} orderBy
+ */
+export function insertOrderedAscending<T>(array: T[], element: T, orderBy: (element: T) => string | number): T[] {
+  const index = sortedLastIndexBy(array, element, orderBy);
+  array.splice(index, 0, element);
+  return array;
+}

--- a/src/pool/uma/utils.test.ts
+++ b/src/pool/uma/utils.test.ts
@@ -1,0 +1,24 @@
+import * as utils from "./utils";
+import assert from "assert";
+test("Balances", function () {
+  const balances = utils.Balances();
+  assert.ok(balances);
+  balances.create("a", "100");
+  balances.create("b", "99");
+  let result = balances.get("a");
+  assert.equal(result, "100");
+  result = balances.get("b");
+  assert.equal(result, "99");
+
+  result = balances.sub("a", 1);
+  assert.equal(result, "99");
+
+  result = balances.sub("b", 1);
+  assert.equal(result, "98");
+
+  result = balances.add("b", 2);
+  assert.equal(result, "100");
+
+  const bals = balances.balances;
+  assert.equal(Object.keys(bals).length, 2);
+});

--- a/src/pool/uma/utils.ts
+++ b/src/pool/uma/utils.ts
@@ -1,0 +1,52 @@
+import assert from "assert";
+import { BigNumber, BigNumberish, delay as sleep } from "../../utils";
+
+export { delay as sleep } from "../../utils";
+
+// check if a value is not null or undefined, useful for numbers which could be 0.
+// "is" syntax: https://stackoverflow.com/questions/40081332/what-does-the-is-keyword-do-in-typescript
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+export function exists<T>(value: T | null | undefined): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}
+
+// useful for maintaining balances from events
+export type Balances = { [key: string]: string };
+export function Balances(balances: Balances = {}) {
+  function create(id: string, amount = "0") {
+    assert(!has(id), "balance already exists");
+    return set(id, amount);
+  }
+  function has(id: string) {
+    return exists(balances[id]);
+  }
+  function set(id: string, amount: string) {
+    balances[id] = amount;
+    return amount;
+  }
+  function add(id: string, amount: BigNumberish) {
+    return set(id, BigNumber.from(amount).add(getOrCreate(id)).toString());
+  }
+  function sub(id: string, amount: BigNumberish) {
+    return set(id, BigNumber.from(getOrCreate(id)).sub(amount).toString());
+  }
+  function get(id: string) {
+    assert(has(id), "balance does not exist");
+    return balances[id];
+  }
+  function getOrCreate(id: string) {
+    if (has(id)) return get(id);
+    return create(id);
+  }
+  return { create, add, sub, get, balances, set, has, getOrCreate };
+}
+
+// Loop forever but wait until execution is finished before starting next timer. Throw an error to break this
+// or add another utlity function if you need it to end on condition.
+export async function loop(fn: (...args: any[]) => any, delay: number, ...args: any[]) {
+  do {
+    await fn(...args);
+    await sleep(delay);
+    /* eslint-disable-next-line no-constant-condition */
+  } while (true);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,19 +672,6 @@
     ethers "^5.7.2"
     node-fetch "^2.6.7"
 
-"@eth-optimism/core-utils@^0.7.7":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.7.7.tgz#c993d45d2be7a1956284621ad18129a88880c658"
-  integrity sha512-JO3UvrlnOpeCKzDd/9mCd47n1FFjTOJtfG1JxUx24OfC/0yjZv6sKXDoMlZoDJArTQtCyyZ9QB7vulSFjOC6rA==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.5.1"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/providers" "^5.5.3"
-    "@ethersproject/web" "^5.5.1"
-    chai "^4.3.4"
-    ethers "^5.5.4"
-    lodash "^4.17.21"
-
 "@eth-optimism/sdk@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.3.1.tgz#f72b6f93b58e2a2943f10aca3be91dfc23d9839f"
@@ -884,7 +871,7 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
-"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.5.1", "@ethersproject/abstract-provider@^5.7.0":
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
   integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
@@ -897,7 +884,7 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
-"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.4.0", "@ethersproject/abstract-signer@^5.4.1", "@ethersproject/abstract-signer@^5.7.0":
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.4.1", "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
   integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
@@ -943,7 +930,7 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.4.0", "@ethersproject/bytes@^5.5.0", "@ethersproject/bytes@^5.7.0":
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.4.0", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
   integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
@@ -1060,7 +1047,7 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.4.2", "@ethersproject/providers@^5.4.4", "@ethersproject/providers@^5.5.3", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.1", "@ethersproject/providers@^5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.4.4", "@ethersproject/providers@^5.7.0", "@ethersproject/providers@^5.7.1", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -1189,7 +1176,7 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/wordlists" "^5.7.0"
 
-"@ethersproject/web@5.7.1", "@ethersproject/web@^5.5.1", "@ethersproject/web@^5.7.0", "@ethersproject/web@^5.7.1":
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0", "@ethersproject/web@^5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
   integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
@@ -1304,21 +1291,6 @@
     "@openzeppelin/contracts-upgradeable" "^4.8.1"
     ethers "^5.7.1"
 
-"@google-cloud/datastore@^8.2.1":
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/@google-cloud/datastore/-/datastore-8.7.0.tgz#30ae8353d59a4290f3cacb6eea0fdecbcdbc48ed"
-  integrity sha512-MuO2i3YiOJeqHLctthLWLKuXKk3pdyYtD6Dgu48RBuFo6bqPrz4+b2qMkqDLYHeOivtL2ZfmJerTimDEnXcCrQ==
-  dependencies:
-    "@google-cloud/promisify" "^4.0.0"
-    arrify "^2.0.1"
-    async-mutex "^0.5.0"
-    concat-stream "^2.0.0"
-    extend "^3.0.2"
-    google-gax "^4.0.5"
-    is "^3.3.0"
-    split-array-stream "^2.0.0"
-    stream-events "^1.0.5"
-
 "@google-cloud/kms@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/kms/-/kms-3.0.1.tgz#2e86889f2c08f13208afc5bd272a7f25326c9f17"
@@ -1343,11 +1315,6 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-3.0.1.tgz#8d724fb280f47d1ff99953aee0c1669b25238c2e"
   integrity sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==
-
-"@google-cloud/promisify@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
-  integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
 
 "@google-cloud/storage@^6.4.2":
   version "6.5.2"
@@ -1439,14 +1406,6 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@grpc/grpc-js@^1.10.9":
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.12.3.tgz#c3d654d722a73cc703a6d19048bc7127721d3213"
-  integrity sha512-iaxAZnANdCwMNpJlyhkI1W1jQZIDZKFNtU2OpQDdgd+pBcU3t7G+PT7svobkW4WSZTdis+CVV6y8KIwu83HDYQ==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.13"
-    "@js-sdsl/ordered-map" "^4.4.2"
-
 "@grpc/grpc-js@~1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.1.tgz#cfac092e61eac6fe0f80d22943f98e1ba45f02a2"
@@ -1465,16 +1424,6 @@
     long "^4.0.0"
     protobufjs "^7.0.0"
     yargs "^16.2.0"
-
-"@grpc/proto-loader@^0.7.13":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
-  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
-  dependencies:
-    lodash.camelcase "^4.3.0"
-    long "^5.0.0"
-    protobufjs "^7.2.5"
-    yargs "^17.7.2"
 
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
@@ -1577,11 +1526,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@js-sdsl/ordered-map@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
-  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@koa/cors@^3.1.0":
   version "3.4.3"
@@ -3509,11 +3453,6 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/caseless@*":
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.5.tgz#db9468cb1b1b5a925b8f34822f1669df0c5472f5"
-  integrity sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==
-
 "@types/chai@*", "@types/chai@^4.3.6":
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.6.tgz#7b489e8baf393d5dd1266fb203ddd4ea941259e6"
@@ -3734,13 +3673,6 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/lodash-es@^4.17.5":
-  version "4.17.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.6.tgz#c2ed4c8320ffa6f11b43eb89e9eaeec65966a0a0"
-  integrity sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.get@^4.4.7":
   version "4.4.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.7.tgz#1ea63d8b94709f6bc9e231f252b31440abe312cf"
@@ -3871,16 +3803,6 @@
     "@types/node" "*"
     safe-buffer "~5.1.1"
 
-"@types/request@^2.48.8":
-  version "2.48.12"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.12.tgz#0f590f615a10f87da18e9790ac94c29ec4c5ef30"
-  integrity sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
 "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -3948,11 +3870,6 @@
   integrity sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==
   dependencies:
     "@types/node" "*"
-
-"@types/tough-cookie@*":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
-  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/underscore@*":
   version "1.11.4"
@@ -4171,20 +4088,20 @@
     web3 "^1.6.0"
     winston "^3.2.1"
 
-"@uma/contracts-frontend@^0.4.25":
-  version "0.4.25"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.4.25.tgz#86fd9e07d0466e04be41c48856e292b0f0de0722"
-  integrity sha512-LfkMw0lO+H+hUPevoAFogVu5iJTXp+Q2ChddqiynvvrwZ/lrNHrOjj0uEX1winjJXTLFs78jBK1AsIkkYK2VTQ==
-
 "@uma/contracts-node@^0.4.0":
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.4.17.tgz#6abd815723c8344017eb5c302f6a5b0b690eeb4e"
   integrity sha512-e7cVJr3yhKrPZn1TAo/CCOt+QacJON6Mj71lcwHq/rnx+tgjujK2MsOhihytmb79ejPTKg1b5+2GIDL02ttrrQ==
 
-"@uma/contracts-node@^0.4.17", "@uma/contracts-node@^0.4.25":
+"@uma/contracts-node@^0.4.17":
   version "0.4.25"
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.4.25.tgz#d5c82f1f2c7e0dc2dec26fe876db73ba3f0689d7"
   integrity sha512-WaFojX4qyMmXpy5MBS7g0M0KnWESGusdSfTmlkZpCh65TksGaJwAyOM1YBRLL3xm3xSgxPoG+n6tTilSomUmOw==
+
+"@uma/contracts-node@^0.4.26":
+  version "0.4.26"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.4.26.tgz#2c967e10c41292eeaafeb6b458525138e06ea0d8"
+  integrity sha512-o+wzScJB9xVavQwQWkAA8ZXBT9tCqyrhJOBdcyxaKmTTZmPPjAW52V5IVKwcmEOykFOliDjvRtFZIfWjwzUwcA==
 
 "@uma/core@^2.18.0":
   version "2.56.0"
@@ -4232,26 +4149,6 @@
     ipfs-http-client "^49.0.2"
     mocha "^8.3.0"
     node-fetch "^2.6.1"
-
-"@uma/sdk@^0.34.10":
-  version "0.34.10"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.34.10.tgz#ae2bb4d1f5f4140aef0f7d6141620d70dbd57f35"
-  integrity sha512-Jo64XpbCxquuPIIktQCWFMNN/vCTyA1SbVXMrlmXgO7NAtPPMyPBlsKJr+N0/QrqymBQcO5wzdmo+EqJaeKIHw==
-  dependencies:
-    "@eth-optimism/core-utils" "^0.7.7"
-    "@ethersproject/abstract-signer" "^5.4.0"
-    "@ethersproject/providers" "^5.4.2"
-    "@google-cloud/datastore" "^8.2.1"
-    "@types/lodash-es" "^4.17.5"
-    "@uma/contracts-frontend" "^0.4.25"
-    "@uma/contracts-node" "^0.4.25"
-    axios "^1.6.0"
-    bluebird "^3.7.2"
-    bn.js "^4.11.9"
-    decimal.js "^10.3.1"
-    highland "^2.13.5"
-    immer "^9.0.7"
-    lodash-es "^4.17.21"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -4948,7 +4845,7 @@ arraybuffer.prototype.slice@^1.0.1:
     is-array-buffer "^3.0.2"
     is-shared-array-buffer "^1.0.2"
 
-arrify@^2.0.0, arrify@^2.0.1:
+arrify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
@@ -5030,13 +4927,6 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async-mutex@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.5.0.tgz#353c69a0b9e75250971a64ac203b0ebfddd75482"
-  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
-  dependencies:
-    tslib "^2.4.0"
 
 async-retry@^1.2.1, async-retry@^1.3.3:
   version "1.3.3"
@@ -5122,15 +5012,6 @@ axios@^1.4.0:
   integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
   dependencies:
     follow-redirects "^1.15.4"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.6.0:
-  version "1.7.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.8.tgz#1997b1496b394c21953e68c14aaa51b7b5de3d6e"
-  integrity sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==
-  dependencies:
-    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -6383,16 +6264,6 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
-  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
 concurrently@^9.1.2:
@@ -8166,7 +8037,7 @@ ethereumjs-wallet@^1.0.1:
     utf8 "^3.0.0"
     uuid "^8.3.2"
 
-ethers@5.7.2, ethers@^5.0.13, ethers@^5.4.2, ethers@^5.5.1, ethers@^5.5.4, ethers@^5.7.1, ethers@^5.7.2:
+ethers@5.7.2, ethers@^5.0.13, ethers@^5.4.2, ethers@^5.5.1, ethers@^5.7.1, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -8660,16 +8531,6 @@ form-data@^2.2.0, form-data@^2.3.3:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-form-data@^2.5.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.2.tgz#dc653743d1de2fcc340ceea38079daf6e9069fd2"
-  integrity sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-    safe-buffer "^5.2.1"
-
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -8896,31 +8757,12 @@ gaxios@^5.0.0, gaxios@^5.0.1:
     is-stream "^2.0.0"
     node-fetch "^2.6.7"
 
-gaxios@^6.0.0, gaxios@^6.1.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-6.7.1.tgz#ebd9f7093ede3ba502685e73390248bb5b7f71fb"
-  integrity sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==
-  dependencies:
-    extend "^3.0.2"
-    https-proxy-agent "^7.0.1"
-    is-stream "^2.0.0"
-    node-fetch "^2.6.9"
-    uuid "^9.0.1"
-
 gcp-metadata@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-5.0.1.tgz#8d1e785ee7fad554bc2a80c1f930c9a9518d2b00"
   integrity sha512-jiRJ+Fk7e8FH68Z6TLaqwea307OktJpDjmYnU7/li6ziwvVvU2RlrCyQo5vkdeP94chm0kcSCOOszvmuaioq3g==
   dependencies:
     gaxios "^5.0.0"
-    json-bigint "^1.0.0"
-
-gcp-metadata@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.1.0.tgz#9b0dd2b2445258e7597f2024332d20611cbd6b8c"
-  integrity sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==
-  dependencies:
-    gaxios "^6.0.0"
     json-bigint "^1.0.0"
 
 get-caller-file@^1.0.1:
@@ -9207,18 +9049,6 @@ google-auth-library@^8.0.1, google-auth-library@^8.0.2:
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-auth-library@^9.3.0:
-  version "9.15.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.15.0.tgz#1b009c08557929c881d72f953f17e839e91b009b"
-  integrity sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==
-  dependencies:
-    base64-js "^1.3.0"
-    ecdsa-sig-formatter "^1.0.11"
-    gaxios "^6.1.1"
-    gcp-metadata "^6.1.0"
-    gtoken "^7.0.0"
-    jws "^4.0.0"
-
 google-gax@^3.0.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-3.5.2.tgz#7c3ad61dbf366a55527b803caead276668b160d8"
@@ -9238,24 +9068,6 @@ google-gax@^3.0.1:
     protobufjs "7.1.2"
     protobufjs-cli "1.0.2"
     retry-request "^5.0.0"
-
-google-gax@^4.0.5:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-4.4.1.tgz#95a9cf7ee7777ac22d1926a45b5f886dd8beecae"
-  integrity sha512-Phyp9fMfA00J3sZbJxbbB4jC55b7DBjE3F6poyL3wKMEBVKA79q6BGuHcTiM28yOzVql0NDbRL8MLLh8Iwk9Dg==
-  dependencies:
-    "@grpc/grpc-js" "^1.10.9"
-    "@grpc/proto-loader" "^0.7.13"
-    "@types/long" "^4.0.0"
-    abort-controller "^3.0.0"
-    duplexify "^4.0.0"
-    google-auth-library "^9.3.0"
-    node-fetch "^2.7.0"
-    object-hash "^3.0.0"
-    proto3-json-serializer "^2.0.2"
-    protobufjs "^7.3.2"
-    retry-request "^7.0.0"
-    uuid "^9.0.1"
 
 google-p12-pem@^4.0.0:
   version "4.0.1"
@@ -9361,14 +9173,6 @@ gtoken@^6.1.0:
   dependencies:
     gaxios "^5.0.1"
     google-p12-pem "^4.0.0"
-    jws "^4.0.0"
-
-gtoken@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-7.1.0.tgz#d61b4ebd10132222817f7222b1e6064bd463fc26"
-  integrity sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==
-  dependencies:
-    gaxios "^6.0.0"
     jws "^4.0.0"
 
 handlebars@^4.0.1:
@@ -9642,13 +9446,6 @@ hi-base32@^0.5.1:
   resolved "https://registry.yarnpkg.com/hi-base32/-/hi-base32-0.5.1.tgz#1279f2ddae2673219ea5870c2121d2a33132857e"
   integrity sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==
 
-highland@^2.13.5:
-  version "2.13.5"
-  resolved "https://registry.yarnpkg.com/highland/-/highland-2.13.5.tgz#d55cd8ac3f67a00fad79918668d51493222cfcc2"
-  integrity sha512-dn2flPapIIAa4BtkB2ahjshg8iSJtrJtdhEb9/oiOrS5HMQTR/GuhFpqJ+11YBdtnl3AwWKvbZd1Uxr8uAmA7A==
-  dependencies:
-    util-deprecate "^1.0.2"
-
 highlight.js@^10.4.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -9871,11 +9668,6 @@ immediate@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==
-
-immer@^9.0.7:
-  version "9.0.12"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
-  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
 
 immutable@^4.0.0-rc.12:
   version "4.0.0"
@@ -10465,11 +10257,6 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-is@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
-  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -11408,11 +11195,6 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
-
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
@@ -12603,7 +12385,7 @@ node-environment-flags@1.0.6:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -13531,13 +13313,6 @@ proto3-json-serializer@^1.0.0:
   dependencies:
     protobufjs "^7.0.0"
 
-proto3-json-serializer@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz#5b705203b4d58f3880596c95fad64902617529dd"
-  integrity sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==
-  dependencies:
-    protobufjs "^7.2.5"
-
 protobufjs-cli@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/protobufjs-cli/-/protobufjs-cli-1.0.2.tgz#905fc49007cf4aaf3c45d5f250eb294eedeea062"
@@ -13595,24 +13370,6 @@ protobufjs@^7.0.0:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
   integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@^7.2.5, protobufjs@^7.3.2:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
-  integrity sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -13855,7 +13612,7 @@ readable-stream@^1.0.33:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^3.0.2, readable-stream@^3.1.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.0, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -14127,15 +13884,6 @@ retry-request@^5.0.0:
   dependencies:
     debug "^4.1.1"
     extend "^3.0.2"
-
-retry-request@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-7.0.2.tgz#60bf48cfb424ec01b03fca6665dee91d06dd95f3"
-  integrity sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==
-  dependencies:
-    "@types/request" "^2.48.8"
-    extend "^3.0.2"
-    teeny-request "^9.0.0"
 
 retry@0.13.1:
   version "0.13.1"
@@ -14923,13 +14671,6 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
-split-array-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/split-array-stream/-/split-array-stream-2.0.0.tgz#85a4f8bfe14421d7bca7f33a6d176d0c076a53b1"
-  integrity sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==
-  dependencies:
-    is-stream-ended "^0.1.4"
-
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
@@ -15470,17 +15211,6 @@ teeny-request@^8.0.0:
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"
     node-fetch "^2.6.1"
-    stream-events "^1.0.5"
-    uuid "^9.0.0"
-
-teeny-request@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-9.0.0.tgz#18140de2eb6595771b1b02203312dfad79a4716d"
-  integrity sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==
-  dependencies:
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.9"
     stream-events "^1.0.5"
     uuid "^9.0.0"
 
@@ -16126,7 +15856,7 @@ utf8@3.0.0, utf8@^3.0.0:
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
   integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
-util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -16178,11 +15908,6 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This permits dropping @uma/sdk as a dependency. This functionality is not actively maintained by the UMA team, so it makes sense to host it locally. Anything not required directly or indirectly by the poolClient was stripped out of the uma/sdk package on import.