### PR TITLE
fix: price lookup coingecko by symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.52",
+  "version": "4.3.53",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -295,7 +295,7 @@ export class Coingecko {
       const result = await this.call<Record<string, CGTokenPrice>>(
         `simple/price?symbols=${symbol}&vs_currencies=${currency}&include_last_updated_at=true`
       );
-      const cgPrice = result?.[symbol.toLowerCase()];
+      const cgPrice = result?.[symbol.toLowerCase()] || result?.[symbol.toUpperCase()];
       if (cgPrice === undefined || !cgPrice?.[currency]) {
         const errMsg = `Failed to retrieve ${symbol}/${currency} price via Coingecko API`;
         this.logger.debug({


### PR DESCRIPTION
When fetching a Coingecko price by symbol, they are sometimes returned in uppercase... For example `gho`