### PR TITLE
improve: basic retry on hasCCTPMessageBeenProcessed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.60",
+  "version": "4.3.61",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1276,7 +1276,8 @@ export const hasCCTPV1MessageBeenProcessed = async (
   signer: KeyPairSigner,
   nonce: number,
   sourceDomain: number,
-  retriesRemaining: number = 2
+  nRetries: number = 0,
+  maxRetries: number = 2
 ): Promise<boolean> => {
   let noncePda: Address;
   try {
@@ -1299,8 +1300,11 @@ export const hasCCTPV1MessageBeenProcessed = async (
   try {
     return await simulateAndDecode(solanaClient, isNonceUsedIx, signer, parserFunction);
   } catch (e) {
-    if (retriesRemaining > 0) {
-      return hasCCTPV1MessageBeenProcessed(solanaClient, signer, nonce, sourceDomain, retriesRemaining--);
+    if (nRetries < maxRetries) {
+      const delaySeconds = 2 ** nRetries + Math.random();
+      await delay(delaySeconds);
+
+      return hasCCTPV1MessageBeenProcessed(solanaClient, signer, nonce, sourceDomain, ++nRetries);
     }
     throw e;
   }


### PR DESCRIPTION
The second `simulateAndDecode` in `hasCCTPV1MessageBeenProcessed` also throws errors transiently, so it's probably a good idea to retry on those.