### PR TITLE
feat: add `getAuxiliaryNativeTokenCost` to `QueryInterface` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.61",
+  "version": "4.3.62",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -161,6 +161,16 @@ export class QueryBase implements QueryInterface {
   }
 
   /**
+   * @notice Return the native token cost of filling a deposit beyond gas cost. We're not using msg.value in our fills,
+   * so return zero for EVM side
+   * @param deposit RelayData associated with Deposit we're estimating for
+   * @returns Native token cost
+   */
+  getAuxiliaryNativeTokenCost(_deposit: RelayData): BigNumber {
+    return bnZero;
+  }
+
+  /**
    * @notice Return L1 data fee for OP stack L2 transaction, which is based on L2 calldata.
    * @dev https://docs.optimism.io/stack/transactions/fees#l1-data-fee
    * @param unsignedTx L2 transaction that you want L1 data fee for

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -176,6 +176,7 @@ export class SvmQuery implements QueryInterface {
    * @notice Return the native token cost of filling a deposit beyond gas cost. If `value_amount` is specified in a message,
    * `value_amount` of SOL gets forwarded to the first Account. We account for that in Fill cost estimation
    * @param deposit RelayData associated with Deposit we're estimating for
+   * @throws If deposit.message is malformed (unable to be deserialized into `AcrossPlusMessage`)
    * @returns Native token cost
    */
   getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber {

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -5,12 +5,27 @@ import {
   fetchEncodedAccount,
   isSome,
 } from "@solana/kit";
-import { SVMProvider, SolanaVoidSigner, getFillRelayTx, toAddress, getAssociatedTokenAddress } from "../../arch/svm";
+import {
+  SVMProvider,
+  SolanaVoidSigner,
+  getFillRelayTx,
+  toAddress,
+  getAssociatedTokenAddress,
+  deserializeMessage,
+} from "../../arch/svm";
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";
 import { getGasPriceEstimate } from "../../gasPriceOracle";
 import { RelayData } from "../../interfaces";
-import { Address, BigNumber, BigNumberish, SvmAddress, TransactionCostEstimate, toBN } from "../../utils";
+import {
+  Address,
+  BigNumber,
+  BigNumberish,
+  SvmAddress,
+  TransactionCostEstimate,
+  isMessageEmpty,
+  toBN,
+} from "../../utils";
 import { Logger, QueryInterface, getDefaultRelayer } from "../relayFeeCalculator";
 import { SymbolMappingType } from "./";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
@@ -128,6 +143,19 @@ export class SvmQuery implements QueryInterface {
       tokenGasCost,
       gasPrice,
     };
+  }
+
+  /**
+   * @notice Return the native token cost of filling a deposit beyond gas cost. If `value_amount` is specified in a message,
+   * `value_amount` of SOL gets forwarded to the first Account. We account for that in Fill cost estimation
+   * @param deposit RelayData associated with Deposit we're estimating for
+   * @returns Native token cost
+   */
+  getAuxiliaryNativeTokenCost(deposit: RelayData): bigint {
+    // Notice. We return `message.value_amount` here instead of simulating the Transaction. The reason is, we choose to
+    // rely hard on Solana program to protect us from not taking more than `value_amount` rather than relying on
+    // simulation. Chain state may change between simulation and execution, so simulation alone is unreliable
+    return isMessageEmpty(deposit.message) ? BigInt(0) : deserializeMessage(deposit.message).value_amount;
   }
 
   /**

--- a/src/relayFeeCalculator/chain-queries/svmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/svmQuery.ts
@@ -23,6 +23,7 @@ import {
   BigNumberish,
   SvmAddress,
   TransactionCostEstimate,
+  bnZero,
   isMessageEmpty,
   toBN,
 } from "../../utils";
@@ -146,19 +147,6 @@ export class SvmQuery implements QueryInterface {
   }
 
   /**
-   * @notice Return the native token cost of filling a deposit beyond gas cost. If `value_amount` is specified in a message,
-   * `value_amount` of SOL gets forwarded to the first Account. We account for that in Fill cost estimation
-   * @param deposit RelayData associated with Deposit we're estimating for
-   * @returns Native token cost
-   */
-  getAuxiliaryNativeTokenCost(deposit: RelayData): bigint {
-    // Notice. We return `message.value_amount` here instead of simulating the Transaction. The reason is, we choose to
-    // rely hard on Solana program to protect us from not taking more than `value_amount` rather than relying on
-    // simulation. Chain state may change between simulation and execution, so simulation alone is unreliable
-    return isMessageEmpty(deposit.message) ? BigInt(0) : deserializeMessage(deposit.message).value_amount;
-  }
-
-  /**
    * @notice Return the gas cost of a simulated transaction
    * @param fillRelayTx FillRelay transaction
    * @param relayer SVM address of the relayer
@@ -182,6 +170,19 @@ export class SvmQuery implements QueryInterface {
       repaymentAddress
     );
     return toBN(await this.computeUnitEstimator(fillRelayTx));
+  }
+
+  /**
+   * @notice Return the native token cost of filling a deposit beyond gas cost. If `value_amount` is specified in a message,
+   * `value_amount` of SOL gets forwarded to the first Account. We account for that in Fill cost estimation
+   * @param deposit RelayData associated with Deposit we're estimating for
+   * @returns Native token cost
+   */
+  getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber {
+    // Notice. We return `message.value_amount` here instead of simulating the Transaction. The reason is, we choose to
+    // rely hard on Solana program to protect us from not taking more than `value_amount` rather than relying on
+    // simulation. Chain state may change between simulation and execution, so simulation alone is unreliable
+    return isMessageEmpty(deposit.message) ? bnZero : BigNumber.from(deserializeMessage(deposit.message).value_amount);
   }
 
   /**

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -46,7 +46,7 @@ export interface QueryInterface {
   ) => Promise<TransactionCostEstimate>;
   getTokenPrice: (tokenSymbol: string) => Promise<number>;
   getNativeGasCost: (deposit: RelayData & { destinationChainId: number }, relayer: Address) => Promise<BigNumber>;
-  getAuxiliaryNativeTokenCost(_deposit: RelayData): BigNumber;
+  getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber;
 }
 
 export const expectedCapitalCostsKeys = ["lowerBound", "upperBound", "cutoff", "decimals"];

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -46,6 +46,7 @@ export interface QueryInterface {
   ) => Promise<TransactionCostEstimate>;
   getTokenPrice: (tokenSymbol: string) => Promise<number>;
   getNativeGasCost: (deposit: RelayData & { destinationChainId: number }, relayer: Address) => Promise<BigNumber>;
+  getAuxiliaryNativeTokenCost(_deposit: RelayData): BigNumber;
 }
 
 export const expectedCapitalCostsKeys = ["lowerBound", "upperBound", "cutoff", "decimals"];

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -764,4 +764,35 @@ describe("getAuxiliaryNativeTokenCost", function () {
     const fee = svmQueries.getAuxiliaryNativeTokenCost(deposit);
     expect(fee.eq(BigNumber.from(valueAmount))).to.equal(true);
   });
+
+  it("throws for SVM queries when message is not AcrossPlus-encoded", function () {
+    const { rpc } = createDefaultSolanaClient();
+    const svmQueries = QueryBase__factory.create(
+      CHAIN_IDs.SOLANA,
+      rpc,
+      TOKEN_SYMBOLS_MAP,
+      SVM_DEFAULT_ADDRESS,
+      SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      undefined,
+      DEFAULT_LOGGER,
+      "eth"
+    );
+
+    const deposit: RelayData = {
+      originChainId: 1,
+      depositor: SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      recipient: SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      depositId: BigNumber.from(1),
+      inputToken: SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      inputAmount: BigNumber.from(1),
+      outputToken: SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      outputAmount: BigNumber.from(1),
+      message: "0x1234",
+      fillDeadline: 0,
+      exclusiveRelayer: SvmAddress.from(SVM_DEFAULT_ADDRESS),
+      exclusivityDeadline: 0,
+    };
+
+    expect(() => svmQueries.getAuxiliaryNativeTokenCost(deposit)).to.throw();
+  });
 });


### PR DESCRIPTION
To account for native token cost, like [`value_amount` in SVM Spoke](https://github.com/across-protocol/contracts/blob/f722857a9cd5edefb8fb33c70b2904a8822725e1/programs/svm-spoke/src/utils/message_utils.rs#L15)

We don't rely on TX simulation, but rather rely on contract enforcing the fixed relayer native token spend when passing in the `value_amount` as a part of `AcrossPlusMessage`