### PR TITLE
feat(gasPriceOracle): Add basic utils for type0/type2 discrimination

### DIFF
--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -1,5 +1,6 @@
 import { type Chain, type Transport, PublicClient, FeeValuesEIP1559 } from "viem";
-import { BigNumber, isDefined } from "../utils";
+import { FeeData } from "@ethersproject/abstract-provider";
+import { BigNumber, bnZero, isDefined } from "../utils";
 
 export type InternalGasPriceEstimate = FeeValuesEIP1559;
 export type GasPriceEstimate = EvmGasPriceEstimate | SvmGasPriceEstimate;
@@ -21,6 +22,14 @@ export interface GasPriceFeed {
 export function isEVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is EvmGasPriceEstimate {
   const { maxFeePerGas, maxPriorityFeePerGas } = gasPrice as EvmGasPriceEstimate;
   return isDefined(maxFeePerGas) && isDefined(maxPriorityFeePerGas);
+}
+
+export function isType0Gas(gas: EvmGasPriceEstimate): boolean {
+  return gas.maxPriorityFeePerGas.eq(bnZero);
+}
+
+export function isType2Gas(gas: EvmGasPriceEstimate): boolean {
+  return gas.maxPriorityFeePerGas.gt(bnZero);
 }
 
 export function isSVMGasPrice(gasPrice: GasPriceEstimate): gasPrice is SvmGasPriceEstimate {

--- a/src/gasPriceOracle/types.ts
+++ b/src/gasPriceOracle/types.ts
@@ -1,5 +1,4 @@
 import { type Chain, type Transport, PublicClient, FeeValuesEIP1559 } from "viem";
-import { FeeData } from "@ethersproject/abstract-provider";
 import { BigNumber, bnZero, isDefined } from "../utils";
 
 export type InternalGasPriceEstimate = FeeValuesEIP1559;


### PR DESCRIPTION
This doesn't help with typing but does give a simple way of distinguishing between type0 and type2 gas price responses.