### PR TITLE
improve(FormattingUtils): Default to 12 char shortened strings

### DIFF
--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -64,7 +64,7 @@ export const formatFeePct = (relayerFeePct: BN): string => {
  * @returns The shortened hexadecimal string.
  * @example createShortenedString("0x772871a444c6e4e9903d8533a5a13101b74037158123e6709470f0afbf6e7d94") -> "0x7787...7d94"
  */
-export function createShortenedString(hex: string, maxLength = 8, delimiter = ".."): string {
+export function createShortenedString(hex: string, maxLength = 12, delimiter = ".."): string {
   // If we have more maxLength then the hex size, we can simply
   // return the hex directly.
   if (hex.length <= maxLength) {

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -59,7 +59,7 @@ export const formatFeePct = (relayerFeePct: BN): string => {
 /**
  * Shortens a lengthy hexadecimal string to a shorter version with an ellipsis in the middle.
  * @param hex A hexadecimal string to be shortened.
- * @param maxLength The maximum length of the shortened string. Defaults to 8.
+ * @param maxLength The maximum length of the shortened string.
  * @param delimiter The delimiter to use in the middle of the shortened string. Defaults to "...".
  * @returns The shortened hexadecimal string.
  * @example createShortenedString("0x772871a444c6e4e9903d8533a5a13101b74037158123e6709470f0afbf6e7d94") -> "0x7787...7d94"

--- a/test/BlockExplorerUtils.test.ts
+++ b/test/BlockExplorerUtils.test.ts
@@ -6,14 +6,14 @@ describe("BlockExplorerUtils", () => {
     it("should return a valid block explorer link for a transaction hash", () => {
       const txHash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
       const chainId = 1;
-      const expectedLink = `<https://etherscan.io/tx/${txHash} | 0x1..def>`;
+      const expectedLink = `<https://etherscan.io/tx/${txHash} | 0x123..bcdef>`;
       expect(blockExplorerLink(txHash, chainId)).to.be.eq(expectedLink);
     });
 
     it("should return a valid block explorer link for an address", () => {
       const address = "0x1234567890abcdef1234567890abcdef12345678";
       const chainId = 1;
-      const expectedLink = `<https://etherscan.io/address/${address} | 0x1..678>`;
+      const expectedLink = `<https://etherscan.io/address/${address} | 0x123..45678>`;
       expect(blockExplorerLink(address, chainId)).to.be.eq(expectedLink);
     });
 
@@ -52,8 +52,8 @@ describe("BlockExplorerUtils", () => {
       ];
       const chainId = 1;
       const expectedLinks = [
-        "<https://etherscan.io/tx/0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef | 0x1..def>\n",
-        "<https://etherscan.io/address/0x1234567890abcdef1234567890abcdef12345678 | 0x1..678>\n",
+        "<https://etherscan.io/tx/0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef | 0x123..bcdef>\n",
+        "<https://etherscan.io/address/0x1234567890abcdef1234567890abcdef12345678 | 0x123..45678>\n",
       ].join("");
       expect(blockExplorerLinks(txHashesOrAddresses, chainId)).to.be.eq(expectedLinks);
     });


### PR DESCRIPTION
8 is too few when the first two are occupied by the 0x prefix and there are two .. chars in the middle.