### PR TITLE
improve: harden `deserializeMessage`

### DIFF
--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -737,7 +737,7 @@ describe("getAuxiliaryNativeTokenCost", function () {
       undefined,
       DEFAULT_LOGGER,
       "eth"
-    );
+    ) as SvmQuery;
 
     // Compose a valid AcrossPlusMessage with non-zero value_amount
     const valueAmount = 123456n;


### PR DESCRIPTION
When deserializing `AcrossPlusMessage`, add a 2nd way of deserializing the `value_amount` so that have higher confidence in `value_amount` being correct as we potentially will send that amount to the Depositor.

Supposed to protect from a scenario:
- receive messageBytes, deserialization shows low value_amount
- estimate low fee
- send messageBytes to SvmSpoke
- SvmSpoke's impl of deserialization is a bit different, so deserializes into a different value, which pulls money from relayer

Although this scenario is unlikely, this 2nd check is not costly so I think it's worth it.