### PR TITLE
improve(solanaProvider): Remove retry debug logs

### DIFF
--- a/src/providers/solana/retryRpcFactory.ts
+++ b/src/providers/solana/retryRpcFactory.ts
@@ -78,18 +78,6 @@ export class RetrySolanaRpcFactory extends SolanaClusterRpcFactory {
         const jitter = 1 + 2 * Math.random(); // Range jitter from [1, 3]s to offset problem where there are many
         // concurrent retry requests sent at the same time.
         const delayS = this.isRateLimitResponse(error) ? exponentialBackoff + jitter : retryDelaySeconds;
-
-        // Log retry attempt if logger is available
-        this.logger.debug({
-          at: "RetryRpcFactory",
-          message: "Retrying Solana RPC call",
-          provider: getOriginFromURL(this.clusterUrl),
-          method,
-          retryAttempt: retryAttempt,
-          retryDelaySeconds: delayS,
-          error: error?.toString(),
-        });
-
         await delay(delayS);
       }
     }

--- a/src/providers/solana/retryRpcFactory.ts
+++ b/src/providers/solana/retryRpcFactory.ts
@@ -4,7 +4,6 @@ import { SolanaClusterRpcFactory } from "./baseRpcFactories";
 import { RateLimitedSolanaRpcFactory } from "./rateLimitedRpcFactory";
 import { isSolanaError } from "../../arch/svm";
 import { delay } from "../../utils";
-import { getOriginFromURL } from "../../utils/NetworkUtils";
 import { Logger } from "winston";
 
 // This factory adds retry logic on top of the RateLimitedSolanaRpcFactory.


### PR DESCRIPTION
Retries happen a lot and they are very noisy, we probably don't need these anymore now that we verify the retry logic mostly is doing what its supposed to do
