### PR TITLE
improve: move cctp try/catches downstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.70",
+  "version": "4.3.71",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1260,6 +1260,9 @@ export async function getFillRelayDelegatePda(
  * @param nonce The nonce to check.
  * @param sourceDomain The source domain.
  * @returns True if the message has been processed, false otherwise.
+ * @dev This function intentionally does not have error handling for `getCCTPNoncePda` nor `simulateAndDecode` since
+ * the error handling would have to account for the asynchronous opening/closing of PDAs, which is better handled downstream,
+ * where the caller of this function has more context.
  */
 export const hasCCTPV1MessageBeenProcessed = async (
   solanaClient: SVMProvider,

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -58,7 +58,6 @@ import {
   chainIsProd,
   chainIsSvm,
   chunk,
-  delay,
   getMessageHash,
   isDefined,
   isUnsafeDepositId,
@@ -1266,9 +1265,7 @@ export const hasCCTPV1MessageBeenProcessed = async (
   solanaClient: SVMProvider,
   signer: KeyPairSigner,
   nonce: number,
-  sourceDomain: number,
-  nRetries: number = 0,
-  maxRetries: number = 2
+  sourceDomain: number
 ): Promise<boolean> => {
   const noncePda = await getCCTPNoncePda(solanaClient, signer, nonce, sourceDomain);
   const isNonceUsedIx = MessageTransmitterClient.getIsNonceUsedInstruction({

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1276,6 +1276,11 @@ export const hasCCTPV1MessageBeenProcessed = async (
   } catch (e) {
     return false;
   }
+  // If the nonce PDA has been closed, then return false.
+  const encodedNoncePda = await fetchEncodedAccount(solanaClient, noncePda);
+  if (!encodedNoncePda.exists) {
+    return false;
+  }
   const isNonceUsedIx = MessageTransmitterClient.getIsNonceUsedInstruction({
     nonce: nonce,
     usedNonces: noncePda,


### PR DESCRIPTION
I think we need to be stricter on the return values of `hasCCTPV1MessageBeenProcessed`. It looks like in practice, this function returns a lot of false negatives due to RPC issues like rate-limiting and other `fetch failed` errors and not because of Solana program errors. I argue that handling for the try/catch here should be done downstream.