### PR TITLE
improve: add optional blockhash argument to some cctp functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.71",
+  "version": "4.3.72",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -86,7 +86,7 @@ import {
 } from "./";
 import { SvmCpiEventsClient } from "./eventsClient";
 import { SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, SVM_SLOT_SKIPPED, isSolanaError } from "./provider";
-import { AttestedCCTPMessage, SVMEventNames, SVMProvider } from "./types";
+import { AttestedCCTPMessage, SVMEventNames, SVMProvider, LatestBlockhash } from "./types";
 import {
   getEmergencyDeleteRootBundleRootBundleId,
   getNearestSlotTime,
@@ -1268,7 +1268,8 @@ export const hasCCTPV1MessageBeenProcessed = async (
   solanaClient: SVMProvider,
   signer: KeyPairSigner,
   nonce: number,
-  sourceDomain: number
+  sourceDomain: number,
+  latestBlockhash?: LatestBlockhash
 ): Promise<boolean> => {
   const noncePda = await getCCTPNoncePda(solanaClient, signer, nonce, sourceDomain);
   const isNonceUsedIx = MessageTransmitterClient.getIsNonceUsedInstruction({
@@ -1281,7 +1282,7 @@ export const hasCCTPV1MessageBeenProcessed = async (
     }
     return Boolean(buf[0]);
   };
-  return await simulateAndDecode(solanaClient, isNonceUsedIx, signer, parserFunction);
+  return await simulateAndDecode(solanaClient, isNonceUsedIx, signer, parserFunction, latestBlockhash);
 };
 
 /**

--- a/src/arch/svm/types.ts
+++ b/src/arch/svm/types.ts
@@ -9,6 +9,7 @@ import {
   SlotNotificationsApi,
   SolanaRpcApiFromTransport,
   UnixTimestamp,
+  type Blockhash,
 } from "@solana/kit";
 
 export type EventData =
@@ -68,4 +69,9 @@ export type AttestedCCTPMessage = {
   messageBytes: string;
   attestation: string;
   type: "transfer" | "message";
+};
+
+export type LatestBlockhash = {
+  blockhash: Blockhash;
+  lastValidBlockHeight: bigint;
 };

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -26,7 +26,7 @@ import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
 import { BigNumber, Address as SdkAddress, biMin, getMessageHash, isDefined, isUint8Array } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
-import { AttestedCCTPMessage, EventName, SVMEventNames, SVMProvider } from "./types";
+import { AttestedCCTPMessage, EventName, SVMEventNames, SVMProvider, LatestBlockhash } from "./types";
 import winston from "winston";
 
 export { isSolanaError } from "@solana/kit";
@@ -397,12 +397,16 @@ export function getRandomSvmAddress() {
  * @param signer - The signer of the transaction.
  * @returns The default transaction.
  */
-export const createDefaultTransaction = async (rpcClient: SVMProvider, signer: TransactionSigner) => {
-  const { value: latestBlockhash } = await rpcClient.getLatestBlockhash().send();
+export const createDefaultTransaction = async (
+  rpcClient: SVMProvider,
+  signer: TransactionSigner,
+  latestBlockhash?: LatestBlockhash
+) => {
+  latestBlockhash = isDefined(latestBlockhash) ? latestBlockhash : (await rpcClient.getLatestBlockhash().send()).value;
   return pipe(
     createTransactionMessage({ version: 0 }),
     (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx)
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash!, tx)
   );
 };
 
@@ -418,9 +422,13 @@ export const simulateAndDecode = async <P extends (buf: Buffer) => unknown>(
   solanaClient: SVMProvider,
   ix: IInstruction,
   signer: KeyPairSigner,
-  parser: P
+  parser: P,
+  latestBlockhash?: LatestBlockhash
 ): Promise<ReturnType<P>> => {
-  const simulationTx = appendTransactionMessageInstruction(ix, await createDefaultTransaction(solanaClient, signer));
+  const simulationTx = appendTransactionMessageInstruction(
+    ix,
+    await createDefaultTransaction(solanaClient, signer, latestBlockhash)
+  );
 
   const simulationResult = await solanaClient
     .simulateTransaction(getBase64EncodedWireTransaction(await signTransactionMessageWithSigners(simulationTx)), {
@@ -470,7 +478,8 @@ export const getCCTPNoncePda = async (
   solanaClient: SVMProvider,
   signer: KeyPairSigner,
   nonce: number,
-  sourceDomain: number
+  sourceDomain: number,
+  latestBlockhash?: LatestBlockhash
 ) => {
   const [messageTransmitterPda] = await getProgramDerivedAddress({
     programAddress: MessageTransmitterClient.MESSAGE_TRANSMITTER_PROGRAM_ADDRESS,
@@ -489,7 +498,7 @@ export const getCCTPNoncePda = async (
     throw new Error("Invalid buffer");
   };
 
-  return await simulateAndDecode(solanaClient, getNonceIx, signer, parserFunction);
+  return await simulateAndDecode(solanaClient, getNonceIx, signer, parserFunction, latestBlockhash);
 };
 
 /**


### PR DESCRIPTION
In practice, `hasCCTPV1MessageBeenProcessed` doesn't work for any large amount of messages since each call requires 2 separate calls to `getLatestBlockhash` (which subsequently gets us rate-limited). This lets us pass in an optional latest blockhash parameter to `simulateAndDecode` and `hasCCTPV1MessageBeenProcessed` which should significantly reduce the number of rpc queries we use.