### PR TITLE
feat: Add Binance price feed adapter to PriceClient

### DIFF
--- a/src/priceClient/README.md
+++ b/src/priceClient/README.md
@@ -10,8 +10,9 @@ The PriceClient aggregates user-defined preferential list of price feeds. This p
  - Currently supported price feeds:
      - CoinGecko (Free & Pro)
      - Across API
- - Candidates for future addition:
      - DefiLlama
+     - Binance (mapped pairs only — e.g. USDT/USDC via the `USDCUSDT` listing, with USDC anchored at 1 USD; unmapped tokens fall through to the next configured feed)
+ - Candidates for future addition:
      - On-chain lookups (i.e. Uniswap)
 
 This code can be independently used by bots, the frontend, and the backend Across API:

--- a/src/priceClient/adapters/binance.ts
+++ b/src/priceClient/adapters/binance.ts
@@ -1,0 +1,108 @@
+import assert from "assert";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
+import { msToS, PriceFeedAdapter, TokenPrice } from "../priceClient";
+import { BaseHTTPAdapter, BaseHTTPAdapterArgs } from "./baseAdapter";
+
+// Binance quotes pairs (base/quote) rather than USD legs, so each supported token address maps
+// either to a fixed USD anchor, or to a listed Binance pair whose top-of-book mid resolves the
+// token price in terms of that anchor. `invert` is set when the token is on the quote side of
+// the listing (i.e. the USD price is 1 / mid).
+export type BinancePairMapping = { fixed: number } | { symbol: string; invert: boolean };
+
+export type BinanceMappings = { [address: string]: BinancePairMapping };
+
+type BinanceArgs = BaseHTTPAdapterArgs & {
+  name?: string;
+  host?: string;
+  mappings?: BinanceMappings;
+};
+
+type BookTickerResponse = {
+  symbol: string;
+  bidPrice: string;
+  askPrice: string;
+};
+
+// USDC anchors the USD leg: Binance lists USDCUSDT (USDT per 1 USDC) but no USD pair for either
+// token, so USDC is pinned to 1.0 and USDT resolves to 1 / mid(USDCUSDT). This preserves the
+// exact Binance USDT/USDC ratio, which is what stablecoin swap-fill profitability checks consume.
+const DEFAULT_MAPPINGS: BinanceMappings = {
+  [TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET]]: { fixed: 1.0 },
+  [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]]: { symbol: "USDCUSDT", invert: true },
+};
+
+export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
+  readonly mappings: BinanceMappings;
+
+  constructor({
+    name = "Binance",
+    host = "data-api.binance.vision", // Public market-data mirror; api.binance.com is geo-restricted.
+    timeout = 5000, // ms
+    retries = 2,
+    mappings = DEFAULT_MAPPINGS,
+  }: BinanceArgs = {}) {
+    super(name, host, { timeout, retries });
+    this.mappings = Object.fromEntries(
+      Object.entries(mappings).map(([address, mapping]) => [address.toLowerCase(), mapping])
+    );
+  }
+
+  async getPriceByAddress(address: string, currency = "usd"): Promise<TokenPrice> {
+    const [tokenPrice] = await this.getPricesByAddress([address], currency);
+    assert(tokenPrice !== undefined, `${this.name} adapter has no mapping for token ${address}.`);
+    return tokenPrice;
+  }
+
+  // Addresses without a mapping are omitted from the response. The PriceClient treats omitted
+  // addresses as skipped and falls through to the next feed in its list, so this adapter can be
+  // installed ahead of general-purpose USD feeds to pin specific tokens to Binance pricing.
+  async getPricesByAddress(addresses: string[], currency = "usd"): Promise<TokenPrice[]> {
+    if (currency !== "usd") throw new Error(`Currency ${currency} not supported by ${this.name}`);
+
+    const supported = addresses.filter((address) => this.mappings[address.toLowerCase()] !== undefined);
+    const symbols = supported
+      .map((address) => this.mappings[address.toLowerCase()])
+      .filter((mapping): mapping is { symbol: string; invert: boolean } => "symbol" in mapping)
+      .map(({ symbol }) => symbol);
+
+    const mids: { [symbol: string]: number } = Object.fromEntries(
+      await Promise.all([...new Set(symbols)].map(async (symbol) => [symbol, await this.pairMid(symbol)]))
+    );
+
+    const timestamp = msToS(Date.now());
+    return supported.map((address) => {
+      const mapping = this.mappings[address.toLowerCase()];
+      let price: number;
+      if ("fixed" in mapping) {
+        price = mapping.fixed;
+      } else {
+        const mid = mids[mapping.symbol];
+        assert(mid !== undefined, `${this.name} missing pair mid for ${mapping.symbol}.`);
+        price = mapping.invert ? 1 / mid : mid;
+      }
+      return { address, price, timestamp };
+    });
+  }
+
+  private async pairMid(symbol: string): Promise<number> {
+    const response = await this.query("api/v3/ticker/bookTicker", { symbol });
+    if (!this.validateResponse(response)) {
+      throw new Error(`Unexpected ${this.name} response: ${JSON.stringify(response)}`);
+    }
+
+    const [bid, ask] = [Number(response.bidPrice), Number(response.askPrice)];
+    if (!isFinite(bid) || !isFinite(ask) || bid <= 0 || ask <= 0) {
+      throw new Error(
+        `Invalid ${this.name} bookTicker for ${symbol} (bidPrice ${response.bidPrice}, askPrice ${response.askPrice})`
+      );
+    }
+
+    return (bid + ask) / 2;
+  }
+
+  private validateResponse(response: unknown): response is BookTickerResponse {
+    if (response === null || typeof response !== "object") return false;
+    const { symbol, bidPrice, askPrice } = response as Record<string, unknown>;
+    return typeof symbol === "string" && typeof bidPrice === "string" && typeof askPrice === "string";
+  }
+}

--- a/src/priceClient/adapters/index.ts
+++ b/src/priceClient/adapters/index.ts
@@ -1,4 +1,5 @@
 export * as acrossApi from "./acrossApi";
+export * as binance from "./binance";
 export * as coingecko from "./coingecko";
 export * as defaultAdapter from "./default";
 export * as defiLlama from "./defiLlama";

--- a/test/priceClient.binance.test.ts
+++ b/test/priceClient.binance.test.ts
@@ -1,0 +1,105 @@
+import winston from "winston";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../src/constants";
+import { Logger, PriceClient, PriceFeedAdapter, TokenPrice, msToS } from "../src/priceClient/priceClient";
+import { binance } from "../src/priceClient/adapters";
+import { expect } from "./utils";
+
+const dummyLogger: Logger = winston.createLogger({
+  level: "debug",
+  transports: [new winston.transports.Console()],
+});
+
+const USDC = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET];
+const USDT = TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET];
+const UNMAPPED = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+class MockBinancePriceFeed extends binance.PriceFeed {
+  public requestLog: { path: string; symbol: unknown }[] = [];
+  public response: unknown = { symbol: "USDCUSDT", bidPrice: "1.0003", askPrice: "1.0005" };
+
+  protected override query(path: string, urlArgs?: Record<string, unknown>): Promise<unknown> {
+    this.requestLog.push({ path, symbol: urlArgs?.symbol });
+    return Promise.resolve(this.response);
+  }
+}
+
+describe("Binance PriceFeed adapter", function () {
+  let feed: MockBinancePriceFeed;
+
+  beforeEach(function () {
+    feed = new MockBinancePriceFeed();
+  });
+
+  it("prices USDT via the inverted USDCUSDT mid and anchors USDC at 1.0", async function () {
+    const before = msToS(Date.now());
+    const prices = await feed.getPricesByAddress([USDC, USDT]);
+
+    expect(feed.requestLog.length).to.equal(1);
+    expect(feed.requestLog[0]).to.deep.equal({ path: "api/v3/ticker/bookTicker", symbol: "USDCUSDT" });
+
+    const usdc = prices.find(({ address }) => address === USDC);
+    const usdt = prices.find(({ address }) => address === USDT);
+    expect(usdc?.price).to.equal(1.0);
+    expect(usdt?.price).to.equal(1 / 1.0004); // mid of 1.0003/1.0005, inverted.
+    prices.forEach(({ timestamp }) => expect(timestamp).to.be.at.least(before));
+  });
+
+  it("makes no HTTP request when only fixed-price tokens are requested", async function () {
+    const [usdc] = await feed.getPricesByAddress([USDC]);
+    expect(usdc.price).to.equal(1.0);
+    expect(feed.requestLog.length).to.equal(0);
+  });
+
+  it("resolves addresses case-insensitively", async function () {
+    const address = USDT.toUpperCase().replace("0X", "0x");
+    const [usdt] = await feed.getPricesByAddress([address]);
+    expect(usdt.address).to.equal(address);
+    expect(usdt.price).to.equal(1 / 1.0004);
+  });
+
+  it("omits unmapped addresses from the response", async function () {
+    const prices = await feed.getPricesByAddress([UNMAPPED, USDT]);
+    expect(prices.length).to.equal(1);
+    expect(prices[0].address).to.equal(USDT);
+  });
+
+  it("throws on getPriceByAddress for an unmapped address", async function () {
+    await expect(feed.getPriceByAddress(UNMAPPED)).to.be.rejectedWith(/no mapping/);
+  });
+
+  it("rejects non-usd currencies", async function () {
+    await expect(feed.getPricesByAddress([USDT], "eur")).to.be.rejectedWith(/not supported/);
+  });
+
+  it("throws on a malformed bookTicker response", async function () {
+    feed.response = { symbol: "USDCUSDT", bidPrice: 1.0003 }; // askPrice missing, bidPrice not a string.
+    await expect(feed.getPricesByAddress([USDT])).to.be.rejectedWith(/Unexpected Binance response/);
+  });
+
+  it("throws on a non-positive bookTicker price", async function () {
+    feed.response = { symbol: "USDCUSDT", bidPrice: "0", askPrice: "1.0005" };
+    await expect(feed.getPricesByAddress([USDT])).to.be.rejectedWith(/Invalid Binance bookTicker/);
+  });
+
+  it("supports custom pair mappings", async function () {
+    const custom = new MockBinancePriceFeed({
+      mappings: { [UNMAPPED]: { symbol: "USDCUSDT", invert: false } },
+    });
+    const [price] = await custom.getPricesByAddress([UNMAPPED]);
+    expect(price.price).to.equal(1.0004);
+  });
+
+  it("falls through to the next PriceClient feed for unmapped tokens", async function () {
+    const fallbackPrice: TokenPrice = { address: UNMAPPED, price: 42, timestamp: msToS(Date.now()) };
+    const fallback: PriceFeedAdapter = {
+      name: "fallback",
+      getPriceByAddress: () => Promise.resolve(fallbackPrice),
+      getPricesByAddress: () => Promise.resolve([fallbackPrice]),
+    };
+    const pc = new PriceClient(dummyLogger, [feed, fallback], true);
+
+    const prices = await pc.getPricesByAddress([USDT, UNMAPPED]);
+    expect(prices.find(({ address }) => address === USDT)?.price).to.equal(1 / 1.0004);
+    expect(prices.find(({ address }) => address === UNMAPPED)?.price).to.equal(42);
+  });
+});


### PR DESCRIPTION
## What

Adds `binance.PriceFeed`, a new PriceClient adapter sourcing prices from Binance market data (`data-api.binance.vision`, the public mirror — `api.binance.com` is geo-restricted).

Binance quotes pairs (base/quote), not USD legs, so the adapter maps each supported token address either to a **fixed USD anchor** or to a **listed pair** whose top-of-book mid (`(bid+ask)/2` from `/api/v3/ticker/bookTicker`) resolves its price. Default mappings:

- USDC (mainnet) → anchored at `1.0`
- USDT (mainnet) → `1 / mid(USDCUSDT)`

This preserves the exact Binance USDT/USDC ratio — the quantity stablecoin swap-fill profitability checks consume. Conventions (host, bookTicker mid, USDCUSDT inversion) deliberately mirror quote-api's `api/_binance.ts` so API quoting and relayer-side checks share a common reference.

**Fall-through for unmapped tokens:** addresses without a mapping are omitted from the response, which `PriceClient.updatePrices` already treats as "skipped → try the next feed" (covered by existing tests). The adapter can therefore be installed *ahead of* the general-purpose USD feeds to pin specific tokens to Binance pricing, e.g. in the relayer's ProfitClient:

```ts
new PriceClient(logger, [
  new binance.PriceFeed(),          // USDT/USDC at Binance rates; everything else falls through
  new acrossApi.PriceFeed(...),
  new coingecko.PriceFeed(...),
  new defiLlama.PriceFeed(),
]);
```

Custom pairs can be added via the `mappings` constructor arg.

## Why

The API quotes AVAX USDT → Base USDC internalized swaps at Binance + 5 bps, but the relayer prices profitability off Across API/CoinGecko/DefiLlama — feed skew between the two can reject (or accept) fills the quote intended. Per Slack discussion, this adapter is the building block for the relayer to probe Binance directly. Wiring it into the relayer's ProfitClient is a follow-up in across-protocol/relayer.

## Testing

- New `test/priceClient.binance.test.ts`: 10 cases covering default/custom mappings, inversion math, case-insensitive address lookups, unmapped-address omission + PriceClient fall-through, malformed/non-positive responses, non-USD rejection, and the no-HTTP-for-fixed-anchor path. All pass.
- Existing `priceClient.test.ts` (9 cases) still passes; `tsc --noEmit`, eslint, and prettier clean on changed files.

Slack context: https://umaproject.slack.com/archives/C0A538XAY8Z/p1783701461063109

🤖 Generated with [Claude Code](https://claude.com/claude-code)