### PR TITLE
fix(address): guard the TVM branch of toAddressType against malformed input

### DIFF
--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -127,14 +127,17 @@ export function isValidEvmAddress(address: string): boolean {
  * @todo: Change this to `toAddress` once we remove the other `toAddress` function.
  */
 export function toAddressType(address: string, chainId: number): Address {
-  const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
-
   // Validate before constructing so a malformed value (which may originate from unverified on-chain event data)
   // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. The TVM branch validates the input
   // string rather than rawAddress: for a TRON address bs58.decode yields the 25-byte Base58Check payload
   // (0x41 prefix + address + checksum), not the canonical address, so rawAddress is the wrong input here.
   if (chainIsTvm(chainId) && TvmAddress.validate(address)) return TvmAddress.from(address);
-  else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
+
+  // Decode only after the TVM case has concluded. TVM never consumes rawAddress, and decoding eagerly throws on the
+  // 41-prefixed hex form of a TRON address: it is valid per TvmAddress.validate(), but is not valid base58, since
+  // the alphabet excludes '0'.
+  const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
+  if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
 
   return new RawAddress(rawAddress);

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -119,6 +119,29 @@ export function isValidEvmAddress(address: string): boolean {
   }
 }
 
+// Checks whether a string is a valid TVM address, in either of the two forms `TvmAddress.from()` accepts.
+// Deliberately separate from `TvmAddress.validate()`, which takes bytes like its EVM/SVM counterparts:
+//   - the 4-byte Base58Check checksum is carried by the encoded form, not by the canonical 20-byte (or zero-padded
+//     32-byte) representation that `validate()` governs and the `TvmAddress` constructor consumes, so `validate()`
+//     is not the right place to check it;
+//   - `TvmAddress.from()` throws on malformed input (TronWeb's decoder raises on non-Base58 characters and on bad
+//     lengths), so callers need a total predicate to gate it.
+// Never throws.
+export function isValidTvmAddress(address: string): boolean {
+  // Base58Check (`T…`) or 41-prefixed hex: TronWeb verifies the prefix and the checksum. `TronWeb.isAddress()`
+  // wraps all decoding in try/catch and returns false for any malformed input (verified against tronweb@6.2.2).
+  if (!address.startsWith("0x")) {
+    return TronWeb.isAddress(address);
+  }
+  // 0x-hex: hold to the same rule as the decoded representation. arrayify throws on malformed hex (odd length,
+  // non-hex characters), which means the value is not an address at all.
+  try {
+    return TvmAddress.validate(utils.arrayify(address));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Creates the proper address type given the input chain ID corresponding to the address's origin network.
  * @param address Stringified address type to convert. Can be either hex encoded or base58 encoded.
@@ -130,9 +153,10 @@ export function toAddressType(address: string, chainId: number): Address {
   const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
 
   // Validate before constructing so a malformed value (which may originate from unverified on-chain event data)
-  // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. The TVM branch validates the input
-  // string rather than rawAddress: TRON uses Base58Check, which the plain bs58.decode above cannot verify.
-  if (chainIsTvm(chainId) && TvmAddress.validate(address)) return TvmAddress.from(address);
+  // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. TVM validates the input string:
+  // for a TRON address the bs58.decode above yields the 25-byte Base58Check payload rather than the canonical
+  // address, so it is not the right input to `TvmAddress.validate()`.
+  if (chainIsTvm(chainId) && isValidTvmAddress(address)) return TvmAddress.from(address);
   else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
 
@@ -349,24 +373,12 @@ export class TvmAddress extends Address {
     super(rawAddress);
   }
 
-  // Validates either a raw address (the 20-byte internal form, or a 32-byte value with the upper 12 bytes zeroed)
-  // or an address string. String validation is checksum-aware: TRON Base58Check addresses are verified via
-  // TronWeb (prefix + checksum), and 0x-hex addresses are checked against the raw-byte rule. Never throws.
-  static validate(address: string | Uint8Array): boolean {
-    if (typeof address !== "string") {
-      return address.length === 20 || (address.length === 32 && address.slice(0, 12).every((field) => field === 0));
-    }
-
-    if (!address.startsWith("0x")) {
-      // TRON Base58Check (or 41-prefixed hex): TronWeb verifies the prefix and 4-byte checksum.
-      return TronWeb.isAddress(address);
-    }
-
-    try {
-      return TvmAddress.validate(utils.arrayify(address));
-    } catch {
-      return false;
-    }
+  // Validates the decoded representation: the 20-byte address, or a 32-byte value with the upper 12 bytes zeroed.
+  // String inputs are checked by `isValidTvmAddress()`, which can additionally verify the Base58Check checksum.
+  static validate(rawAddress: Uint8Array): boolean {
+    return (
+      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).every((field) => field === 0))
+    );
   }
 
   override isTVM(): this is TvmAddress {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -129,17 +129,11 @@ export function isValidEvmAddress(address: string): boolean {
 export function toAddressType(address: string, chainId: number): Address {
   const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
 
-  // Address inputs may originate from unverified on-chain event data, so a malformed value must never abort
-  // decoding by throwing here. Mirror the EVM/SVM branches: attempt the typed parse and fall through to a
-  // non-throwing RawAddress on failure. The TVM branch uses TvmAddress.from() (rather than validating rawAddress
-  // above) to preserve TRON base58check parsing, guarded so it cannot throw.
-  if (chainIsTvm(chainId)) {
-    try {
-      return TvmAddress.from(address);
-    } catch {
-      // Malformed TVM address; fall through to RawAddress.
-    }
-  } else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
+  // Validate before constructing so a malformed value (which may originate from unverified on-chain event data)
+  // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. The TVM branch validates the input
+  // string rather than rawAddress: TRON uses Base58Check, which the plain bs58.decode above cannot verify.
+  if (chainIsTvm(chainId) && TvmAddress.validate(address)) return TvmAddress.from(address);
+  else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
 
   return new RawAddress(rawAddress);
@@ -355,10 +349,22 @@ export class TvmAddress extends Address {
     super(rawAddress);
   }
 
-  static validate(rawAddress: Uint8Array): boolean {
-    return (
-      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).every((field) => field === 0))
-    );
+  // Validates either a raw address (the 20-byte internal form, or a 32-byte value with the upper 12 bytes zeroed)
+  // or an address string. String validation is checksum-aware: TRON Base58Check addresses are verified via
+  // TronWeb (prefix + checksum), and 0x-hex addresses are checked against the raw-byte rule. Never throws.
+  static validate(address: string | Uint8Array): boolean {
+    if (typeof address === "string") {
+      if (!address.startsWith("0x")) {
+        // TRON Base58Check (or 41-prefixed hex): TronWeb verifies the prefix and 4-byte checksum.
+        return TronWeb.isAddress(address);
+      }
+      try {
+        return TvmAddress.validate(utils.arrayify(address));
+      } catch {
+        return false;
+      }
+    }
+    return address.length == 20 || (address.length === 32 && address.slice(0, 12).every((field) => field === 0));
   }
 
   override isTVM(): this is TvmAddress {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -353,18 +353,20 @@ export class TvmAddress extends Address {
   // or an address string. String validation is checksum-aware: TRON Base58Check addresses are verified via
   // TronWeb (prefix + checksum), and 0x-hex addresses are checked against the raw-byte rule. Never throws.
   static validate(address: string | Uint8Array): boolean {
-    if (typeof address === "string") {
-      if (!address.startsWith("0x")) {
-        // TRON Base58Check (or 41-prefixed hex): TronWeb verifies the prefix and 4-byte checksum.
-        return TronWeb.isAddress(address);
-      }
-      try {
-        return TvmAddress.validate(utils.arrayify(address));
-      } catch {
-        return false;
-      }
+    if (typeof address !== "string") {
+      return address.length === 20 || (address.length === 32 && address.slice(0, 12).every((field) => field === 0));
     }
-    return address.length == 20 || (address.length === 32 && address.slice(0, 12).every((field) => field === 0));
+
+    if (!address.startsWith("0x")) {
+      // TRON Base58Check (or 41-prefixed hex): TronWeb verifies the prefix and 4-byte checksum.
+      return TronWeb.isAddress(address);
+    }
+
+    try {
+      return TvmAddress.validate(utils.arrayify(address));
+    } catch {
+      return false;
+    }
   }
 
   override isTVM(): this is TvmAddress {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -363,6 +363,10 @@ export class TvmAddress extends Address {
       return TronWeb.isAddress(address);
     }
 
+    // 0x-hex: hold it to the same rule as the decoded representation. The try/catch is strictly for arrayify(),
+    // which throws on odd-length ("0xabc") and non-hex ("0xnothex") input; the recursive validate() call operates
+    // on bytes and cannot throw. utils.isHexString() would not be a sufficient guard on its own, since it accepts
+    // odd-length hex that arrayify still rejects. This mirrors isValidEvmAddress() above.
     try {
       return TvmAddress.validate(utils.arrayify(address));
     } catch {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -133,9 +133,6 @@ export function toAddressType(address: string, chainId: number): Address {
   // (0x41 prefix + address + checksum), not the canonical address, so rawAddress is the wrong input here.
   if (chainIsTvm(chainId) && TvmAddress.validate(address)) return TvmAddress.from(address);
 
-  // Decode only after the TVM case has concluded. TVM never consumes rawAddress, and decoding eagerly throws on the
-  // 41-prefixed hex form of a TRON address: it is valid per TvmAddress.validate(), but is not valid base58, since
-  // the alphabet excludes '0'.
   const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
   if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
@@ -366,15 +363,15 @@ export class TvmAddress extends Address {
       return TronWeb.isAddress(address);
     }
 
-    // 0x-hex: hold it to the same rule as the decoded representation. The try/catch is strictly for arrayify(),
-    // which throws on odd-length ("0xabc") and non-hex ("0xnothex") input; the recursive validate() call operates
-    // on bytes and cannot throw. utils.isHexString() would not be a sufficient guard on its own, since it accepts
-    // odd-length hex that arrayify still rejects. This mirrors isValidEvmAddress() above.
+    // arrayify throws on odd-length and non-hex input.
+    let rawAddress: Uint8Array;
     try {
-      return TvmAddress.validate(utils.arrayify(address));
+      rawAddress = utils.arrayify(address);
     } catch {
       return false;
     }
+
+    return TvmAddress.validate(rawAddress);
   }
 
   override isTVM(): this is TvmAddress {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -119,29 +119,6 @@ export function isValidEvmAddress(address: string): boolean {
   }
 }
 
-// Checks whether a string is a valid TVM address, in either of the two forms `TvmAddress.from()` accepts.
-// Deliberately separate from `TvmAddress.validate()`, which takes bytes like its EVM/SVM counterparts:
-//   - the 4-byte Base58Check checksum is carried by the encoded form, not by the canonical 20-byte (or zero-padded
-//     32-byte) representation that `validate()` governs and the `TvmAddress` constructor consumes, so `validate()`
-//     is not the right place to check it;
-//   - `TvmAddress.from()` throws on malformed input (TronWeb's decoder raises on non-Base58 characters and on bad
-//     lengths), so callers need a total predicate to gate it.
-// Never throws.
-export function isValidTvmAddress(address: string): boolean {
-  // Base58Check (`T…`) or 41-prefixed hex: TronWeb verifies the prefix and the checksum. `TronWeb.isAddress()`
-  // wraps all decoding in try/catch and returns false for any malformed input (verified against tronweb@6.2.2).
-  if (!address.startsWith("0x")) {
-    return TronWeb.isAddress(address);
-  }
-  // 0x-hex: hold to the same rule as the decoded representation. arrayify throws on malformed hex (odd length,
-  // non-hex characters), which means the value is not an address at all.
-  try {
-    return TvmAddress.validate(utils.arrayify(address));
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Creates the proper address type given the input chain ID corresponding to the address's origin network.
  * @param address Stringified address type to convert. Can be either hex encoded or base58 encoded.
@@ -153,10 +130,10 @@ export function toAddressType(address: string, chainId: number): Address {
   const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
 
   // Validate before constructing so a malformed value (which may originate from unverified on-chain event data)
-  // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. TVM validates the input string:
-  // for a TRON address the bs58.decode above yields the 25-byte Base58Check payload rather than the canonical
-  // address, so it is not the right input to `TvmAddress.validate()`.
-  if (chainIsTvm(chainId) && isValidTvmAddress(address)) return TvmAddress.from(address);
+  // falls through to a non-throwing RawAddress, matching the EVM/SVM branches. The TVM branch validates the input
+  // string rather than rawAddress: for a TRON address bs58.decode yields the 25-byte Base58Check payload
+  // (0x41 prefix + address + checksum), not the canonical address, so rawAddress is the wrong input here.
+  if (chainIsTvm(chainId) && TvmAddress.validate(address)) return TvmAddress.from(address);
   else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
 
@@ -373,12 +350,24 @@ export class TvmAddress extends Address {
     super(rawAddress);
   }
 
-  // Validates the decoded representation: the 20-byte address, or a 32-byte value with the upper 12 bytes zeroed.
-  // String inputs are checked by `isValidTvmAddress()`, which can additionally verify the Base58Check checksum.
-  static validate(rawAddress: Uint8Array): boolean {
-    return (
-      rawAddress.length == 20 || (rawAddress.length === 32 && rawAddress.slice(0, 12).every((field) => field === 0))
-    );
+  // Validates either a raw address (the 20-byte internal form, or a 32-byte value with the upper 12 bytes zeroed)
+  // or an address string. String validation is checksum-aware: TRON Base58Check addresses are verified via
+  // TronWeb (prefix + checksum), and 0x-hex addresses are checked against the raw-byte rule. Never throws.
+  static validate(address: string | Uint8Array): boolean {
+    if (typeof address !== "string") {
+      return address.length === 20 || (address.length === 32 && address.slice(0, 12).every((field) => field === 0));
+    }
+
+    if (!address.startsWith("0x")) {
+      // TRON Base58Check (or 41-prefixed hex): TronWeb verifies the prefix and 4-byte checksum.
+      return TronWeb.isAddress(address);
+    }
+
+    try {
+      return TvmAddress.validate(utils.arrayify(address));
+    } catch {
+      return false;
+    }
   }
 
   override isTVM(): this is TvmAddress {

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -129,8 +129,17 @@ export function isValidEvmAddress(address: string): boolean {
 export function toAddressType(address: string, chainId: number): Address {
   const rawAddress = address.startsWith("0x") ? utils.arrayify(address) : bs58.decode(address);
 
-  if (chainIsTvm(chainId)) return TvmAddress.from(address);
-  else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
+  // Address inputs may originate from unverified on-chain event data, so a malformed value must never abort
+  // decoding by throwing here. Mirror the EVM/SVM branches: attempt the typed parse and fall through to a
+  // non-throwing RawAddress on failure. The TVM branch uses TvmAddress.from() (rather than validating rawAddress
+  // above) to preserve TRON base58check parsing, guarded so it cannot throw.
+  if (chainIsTvm(chainId)) {
+    try {
+      return TvmAddress.from(address);
+    } catch {
+      // Malformed TVM address; fall through to RawAddress.
+    }
+  } else if (chainIsEvm(chainId) && EvmAddress.validate(rawAddress)) return new EvmAddress(rawAddress);
   else if (chainIsSvm(chainId) && SvmAddress.validate(rawAddress)) return new SvmAddress(rawAddress);
 
   return new RawAddress(rawAddress);

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -7,6 +7,7 @@ import {
   TvmAddress,
   toAddressType,
   isValidEvmAddress,
+  isValidTvmAddress,
 } from "../src/utils";
 import { CHAIN_IDs } from "../src/constants";
 import { expect, ethers } from "./utils";
@@ -337,32 +338,44 @@ describe("Address Utils: Address Type", function () {
         expect(TvmAddress.validate(new Uint8Array(15))).to.be.false;
         expect(TvmAddress.validate(new Uint8Array(21))).to.be.false;
       });
+    });
 
+    describe("isValidTvmAddress", function () {
       it("Accepts a valid TRON Base58Check string", function () {
-        expect(TvmAddress.validate(tronBase58)).to.be.true;
+        expect(isValidTvmAddress(tronBase58)).to.be.true;
       });
 
       it("Accepts a valid 0x-hex address string", function () {
-        expect(TvmAddress.validate(hex20)).to.be.true;
+        expect(isValidTvmAddress(hex20)).to.be.true;
       });
 
       it("Rejects a malformed 0x-hex string (non-zero upper bytes)", function () {
-        expect(TvmAddress.validate("0xff" + "00".repeat(31))).to.be.false;
+        expect(isValidTvmAddress("0xff" + "00".repeat(31))).to.be.false;
+      });
+
+      it("Rejects hex that cannot be decoded at all", function () {
+        // arrayify throws on odd-length and non-hex input; the string is not an address, so this is a `false`
+        // rather than a propagated throw.
+        for (const input of ["0xabc", "0xnothex", "0x"]) {
+          expect(() => isValidTvmAddress(input)).to.not.throw();
+          expect(isValidTvmAddress(input)).to.be.false;
+        }
       });
 
       it("Rejects a string that fails the Base58Check checksum", function () {
         // A random 25-byte payload encoded as plain Base58 will, with overwhelming probability, fail the
-        // 4-byte Base58Check checksum that TronWeb verifies.
-        expect(TvmAddress.validate(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
+        // 4-byte Base58Check checksum that TronWeb verifies. This is the check `TvmAddress.validate()` does not
+        // perform: the checksum is absent from the canonical representation that validate() is defined over.
+        expect(isValidTvmAddress(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
       });
 
       it("Rejects garbage strings without throwing", function () {
         // TronWeb's internal decode58 throws on non-Base58 characters, but TronWeb.isAddress() wraps all
-        // decoding in try/catch and returns false (verified against tronweb@6.2.2), so validate() never throws.
-        const garbage = ["T!!!not-base58-0OIl", "", " ", "Tshort", "0x", "🚀".repeat(17)];
+        // decoding in try/catch and returns false (verified against tronweb@6.2.2), so this never throws.
+        const garbage = ["T!!!not-base58-0OIl", "", " ", "Tshort", "🚀".repeat(17)];
         for (const input of garbage) {
-          expect(() => TvmAddress.validate(input)).to.not.throw();
-          expect(TvmAddress.validate(input)).to.be.false;
+          expect(() => isValidTvmAddress(input)).to.not.throw();
+          expect(isValidTvmAddress(input)).to.be.false;
         }
       });
     });

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -337,6 +337,24 @@ describe("Address Utils: Address Type", function () {
         expect(TvmAddress.validate(new Uint8Array(15))).to.be.false;
         expect(TvmAddress.validate(new Uint8Array(21))).to.be.false;
       });
+
+      it("Accepts a valid TRON Base58Check string", function () {
+        expect(TvmAddress.validate(tronBase58)).to.be.true;
+      });
+
+      it("Accepts a valid 0x-hex address string", function () {
+        expect(TvmAddress.validate(hex20)).to.be.true;
+      });
+
+      it("Rejects a malformed 0x-hex string (non-zero upper bytes)", function () {
+        expect(TvmAddress.validate("0xff" + "00".repeat(31))).to.be.false;
+      });
+
+      it("Rejects a string that fails the Base58Check checksum", function () {
+        // A random 25-byte payload encoded as plain Base58 will, with overwhelming probability, fail the
+        // 4-byte Base58Check checksum that TronWeb verifies.
+        expect(TvmAddress.validate(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
+      });
     });
 
     describe("toAddressType integration", function () {

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -355,6 +355,16 @@ describe("Address Utils: Address Type", function () {
         // 4-byte Base58Check checksum that TronWeb verifies.
         expect(TvmAddress.validate(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
       });
+
+      it("Rejects garbage strings without throwing", function () {
+        // TronWeb's internal decode58 throws on non-Base58 characters, but TronWeb.isAddress() wraps all
+        // decoding in try/catch and returns false (verified against tronweb@6.2.2), so validate() never throws.
+        const garbage = ["T!!!not-base58-0OIl", "", " ", "Tshort", "0x", "🚀".repeat(17)];
+        for (const input of garbage) {
+          expect(() => TvmAddress.validate(input)).to.not.throw();
+          expect(TvmAddress.validate(input)).to.be.false;
+        }
+      });
     });
 
     describe("toAddressType integration", function () {

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -7,7 +7,6 @@ import {
   TvmAddress,
   toAddressType,
   isValidEvmAddress,
-  isValidTvmAddress,
 } from "../src/utils";
 import { CHAIN_IDs } from "../src/constants";
 import { expect, ethers } from "./utils";
@@ -338,44 +337,41 @@ describe("Address Utils: Address Type", function () {
         expect(TvmAddress.validate(new Uint8Array(15))).to.be.false;
         expect(TvmAddress.validate(new Uint8Array(21))).to.be.false;
       });
-    });
 
-    describe("isValidTvmAddress", function () {
       it("Accepts a valid TRON Base58Check string", function () {
-        expect(isValidTvmAddress(tronBase58)).to.be.true;
+        expect(TvmAddress.validate(tronBase58)).to.be.true;
       });
 
       it("Accepts a valid 0x-hex address string", function () {
-        expect(isValidTvmAddress(hex20)).to.be.true;
+        expect(TvmAddress.validate(hex20)).to.be.true;
       });
 
       it("Rejects a malformed 0x-hex string (non-zero upper bytes)", function () {
-        expect(isValidTvmAddress("0xff" + "00".repeat(31))).to.be.false;
-      });
-
-      it("Rejects hex that cannot be decoded at all", function () {
-        // arrayify throws on odd-length and non-hex input; the string is not an address, so this is a `false`
-        // rather than a propagated throw.
-        for (const input of ["0xabc", "0xnothex", "0x"]) {
-          expect(() => isValidTvmAddress(input)).to.not.throw();
-          expect(isValidTvmAddress(input)).to.be.false;
-        }
+        expect(TvmAddress.validate("0xff" + "00".repeat(31))).to.be.false;
       });
 
       it("Rejects a string that fails the Base58Check checksum", function () {
         // A random 25-byte payload encoded as plain Base58 will, with overwhelming probability, fail the
-        // 4-byte Base58Check checksum that TronWeb verifies. This is the check `TvmAddress.validate()` does not
-        // perform: the checksum is absent from the canonical representation that validate() is defined over.
-        expect(isValidTvmAddress(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
+        // 4-byte Base58Check checksum that TronWeb verifies.
+        expect(TvmAddress.validate(bs58.encode(ethers.utils.randomBytes(25)))).to.be.false;
+      });
+
+      it("Rejects hex that cannot be decoded at all", function () {
+        // arrayify throws on odd-length and non-hex input. The string is not an address, so this must surface as
+        // a false rather than a propagated throw.
+        for (const input of ["0xabc", "0xnothex", "0x"]) {
+          expect(() => TvmAddress.validate(input)).to.not.throw();
+          expect(TvmAddress.validate(input)).to.be.false;
+        }
       });
 
       it("Rejects garbage strings without throwing", function () {
         // TronWeb's internal decode58 throws on non-Base58 characters, but TronWeb.isAddress() wraps all
-        // decoding in try/catch and returns false (verified against tronweb@6.2.2), so this never throws.
-        const garbage = ["T!!!not-base58-0OIl", "", " ", "Tshort", "🚀".repeat(17)];
+        // decoding in try/catch and returns false (verified against tronweb@6.2.2), so validate() never throws.
+        const garbage = ["T!!!not-base58-0OIl", "", " ", "Tshort", "0x", "🚀".repeat(17)];
         for (const input of garbage) {
-          expect(() => isValidTvmAddress(input)).to.not.throw();
-          expect(isValidTvmAddress(input)).to.be.false;
+          expect(() => TvmAddress.validate(input)).to.not.throw();
+          expect(TvmAddress.validate(input)).to.be.false;
         }
       });
     });

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -388,6 +388,21 @@ describe("Address Utils: Address Type", function () {
         expect(addr).to.be.instanceOf(TvmAddress);
         expect(addr.toNative()).to.equal(tronBase58);
       });
+
+      it("Returns a TvmAddress for 41-prefixed hex input that is not valid base58", function () {
+        // Fixed rather than random: this hex ends in '0', which the base58 alphabet excludes. Decoding rawAddress
+        // before the TVM branch had concluded therefore threw "Non-base58 character" on a perfectly valid TVM
+        // address. A random fixture would only trip that path ~92% of the time.
+        const hex41 = "41e552f6487585c2b58bc2c9bb4492bc1f17132cd0";
+        const expected = "TWsm8HtU2A5eEzoT8ev8yaoFjHsXLLrckb";
+        expect(TronWeb.address.fromHex(hex41)).to.equal(expected);
+        expect(TvmAddress.validate(hex41)).to.be.true;
+        expect(() => bs58.decode(hex41)).to.throw(/Non-base58 character/);
+
+        const addr = toAddressType(hex41, CHAIN_IDs.TRON);
+        expect(addr).to.be.instanceOf(TvmAddress);
+        expect(addr.toNative()).to.equal(expected);
+      });
     });
 
     describe("eq", function () {

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -41,6 +41,20 @@ describe("Address Utils: Address Type", function () {
       expect(EvmAddress.validate(arrayify(invalidEvmAddress))).to.be.false;
       expect(() => toAddressType(invalidEvmAddress, CHAIN_IDs.MAINNET)).to.throw;
     });
+    it("Falls through instead of throwing for malformed TVM addresses", function () {
+      // A 32-byte value with non-zero upper bytes is not a valid TVM (or EVM) address. Because address inputs can
+      // come from unverified on-chain event data, the TVM branch must fall through to a non-throwing type rather
+      // than throw, exactly like the EVM/SVM branches.
+      const malformed = "0xff" + randomBytes(31).slice(2);
+      expect(TvmAddress.validate(arrayify(malformed))).to.be.false;
+      expect(() => toAddressType(malformed, CHAIN_IDs.TRON)).to.not.throw();
+      expect(toAddressType(malformed, CHAIN_IDs.TRON).isTVM()).to.be.false;
+    });
+    it("Coerces valid TVM addresses to TvmAddress", function () {
+      // 20-byte and zero-padded 32-byte inputs are valid and should still resolve to a TvmAddress.
+      expect(toAddressType(randomBytes(20), CHAIN_IDs.TRON).isTVM()).to.be.true;
+      expect(toAddressType(EVM_ZERO_PAD + randomBytes(20).slice(2), CHAIN_IDs.TRON).isTVM()).to.be.true;
+    });
     it("Rejects padded SVM (suspect EVM) addresses", function () {
       const rawAddress = arrayify(EVM_ZERO_PAD + randomBytes(20).slice(2));
       expect(rawAddress.slice(0, 12).every((field: number) => field === 0)).to.be.true;


### PR DESCRIPTION
## Summary

Hardens the TVM branch of `toAddressType()` so that a malformed address value routed to it cannot throw during decoding.

`toAddressType()` is applied to address fields decoded from on-chain event data, which are not validated before being passed in. The EVM and SVM branches already validate the decoded value and fall through to a non-throwing `RawAddress` when it isn't a valid address. The **TVM branch did not** — it called `TvmAddress.from()` unconditionally, which throws for anything that isn't a valid 20-byte / zero-padded 32-byte address. As a result a single malformed value routed to the TVM branch could abort decoding by throwing.

This came out of a security triage.

## Change

- `toAddressType()`'s TVM branch now follows the same shape as its EVM/SVM neighbours — `chainIsTvm(chainId) && TvmAddress.validate(address)`, no try/catch. A malformed value falls through to `RawAddress`.
- `TvmAddress.validate()` accepts `string | Uint8Array`:
  - **`Uint8Array`** — unchanged from `master`: 20 bytes, or 32 with the upper 12 zeroed. This is the branch the `TvmAddress` constructor and `Address.isValidOn()` use, so their behaviour is untouched.
  - **string, Base58Check (`T…`) or 41-prefixed hex** — verified via `TronWeb.isAddress` (prefix + 4-byte checksum).
  - **string, `0x`-hex** — held to the raw-byte rule; undecodable hex returns `false` rather than throwing.
- The decode of `rawAddress` now happens **after** the TVM branch concludes, rather than ahead of every branch. This is a behaviour fix, not a tidy-up: the 41-prefixed hex form of a TRON address is accepted by `TvmAddress.validate()`, but is usually not valid Base58 (the alphabet excludes `0`), so decoding eagerly threw `Non-base58 character` on a perfectly valid TVM address. Both accepted forms now resolve to the same `TvmAddress`.
- `TvmAddress.validate()`'s `try/catch` wraps only the `utils.arrayify()` call, which is the sole operation that can throw; the byte-branch recursion it guards cannot.
- This also lands the checksum validation flagged as a future nicety when TRON support was added (#1364).
- Adds regression tests: malformed input falls through (no throw), valid 20-byte / zero-padded inputs coerce to `TvmAddress`, and the string forms (valid Base58Check, valid hex, malformed hex, undecodable hex, failed checksum, garbage strings).

### Why the TVM branch validates the string, not `rawAddress`

For a TRON address, the `bs58.decode` at the top of `toAddressType` yields the 25-byte Base58Check payload — `[0x41][20-byte address][4-byte checksum]` — not the canonical address. So `rawAddress` is simply the wrong input for the TVM branch, and the string is the form the checksum is meaningful on.

Note the union does **not** widen what the constructor accepts. `new TvmAddress(...)` passes a `Uint8Array`, hits the byte branch, and still rejects the 25-byte payload — verified directly. An earlier revision of this PR argued otherwise and split the string check into a separate helper on that basis; that reasoning was wrong and has been reverted.

An earlier revision also claimed the Base58Check checksum "cannot be verified from the plain `bs58.decode`". That is **false** — the checksum does survive it, and sha256d over the leading 21 bytes reproduces the stored 4 exactly (verified). Corrected here for the record.

Separately, `TvmAddress.from()` does throw on malformed input (TronWeb's decoder raises `Non-base58 character` and `Invalid address provided`), so the guard is load-bearing rather than belt-and-braces.

## Scope of the guarantee (deliberately narrow)

The fix is placed in `toAddressType()`, so it covers **all six** call sites in `unpackFillEvent()`, not just the one reported. `repaymentChainId` drives the family selection for `relayer` (`SpokeUtils.ts:108`), but `originChainId` is equally attacker-supplied in `relayData`, making `depositor` and `inputToken` (lines 103, 105) an equivalent entry point. Both are closed.

`toAddressType()` is **not** a total function after this change, and intentionally so. Two throw paths remain, both predating this PR:

1. `AddressUtils.ts:136` — `bs58.decode` / `utils.arrayify` throw on a non-`0x` string containing non-Base58 characters, or on odd-length hex. (These run after the TVM branch as of this PR, so they are no longer reachable for a valid TVM address; they still gate the EVM/SVM/`RawAddress` paths.)
2. `new RawAddress(rawAddress)` — a *valid* Base58 string that decodes to more than 32 bytes throws in the `Address` base constructor (`Address … cannot be longer than 32 bytes`).

Neither is reachable from event ingestion: ethers renders `bytes32` event args as well-formed `0x` + 64 hex, and SVM addresses arrive as Base58 of exactly 32 bytes. Both verified by direct probe.

They are left throwing on purpose. Making this function total would require inventing an `Address` for input that has no address in it, and the obvious candidate — a zero/empty `RawAddress` — is actively unsafe, because the zero address is a load-bearing sentinel:

- `SpokePoolClient.ts:540` (and `EVMSpokePoolClient.ts:197`) treat a zero `outputToken` as "resolve the destination token", substituting a **real** token address;
- `DepositUtils.ts:220 invalidOutputToken()` treats zero as "invalid";
- `HubPoolClient.ts:218/262` treat a zero `l2Token` as unsupported.

So a fabricated fallback would silently reinterpret "undecodable" as a meaningful value — and for `relayer`, would put a fabricated address into repayment logic. That is strictly worse than throwing.

The correct boundary for "no single undecodable event can stall ingestion" is therefore the event layer, not the address constructor: drop and log the offending event rather than fabricating a field. That is the follow-up below.

## Follow-ups (not in this PR)

Defense-in-depth, deliberately separate because it is a behaviour change worth its own review — silently dropping events can mask decode regressions and create data gaps in the dataworker:

- wrap per-event decoding (`unpackFillEvent`) so an undecodable event is dropped/logged rather than rejecting the batch (`SpokePoolClient.ts:673` currently maps over every event with no `try/catch` — the file has none);
- give the fleet updater per-chain error isolation instead of a single `Promise.all`.

#1518 (open, stacked on this branch) adds `tryToAddressType()` — a total counterpart returning `Address | undefined` — so callers handling unverified strings can express decode failure without `toAddressType()` fabricating an address. It deliberately does not make `toAddressType()` itself total, for the sentinel reasons set out above.

## Test

`yarn hardhat test test/AddressUtils.ts` — 61 passing. Against `master` at `6fc3b53` (merged in, clean): 87 passing across `AddressUtils` + `Tvm.TransactionUtils` + `SpokeUtils` + `BlockUtils`; lint, prettier and `build:types` clean. Full `yarn test` requires `solana-test-validator` and was left to CI.

Behaviour confirmed by direct probe: on `master`, a `bytes32` of `0xff…ff` with `chainId=728126428` throws; on this branch the same input returns a `RawAddress`, a valid zero-padded value still coerces to `TvmAddress`, and so does a Base58Check `T…` string.

