### PR TITLE
fix(BundleDataClient): resolve paused chain end blocks against the same bundle as their peers

### DIFF
--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -72,13 +72,16 @@ export async function getWidestPossibleExpectedBlockRange(
   );
 
   return chainIds.map((chainId: number, index) => {
-    const lastEndBlockForChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(
-      chainIds,
-      latestMainnetBlock,
-      chainId
-    );
+    // Resolve the previous bundle's end block for this chain. In optimistic mode we assume any pending proposal will
+    // pass liveness, so the reference is the latest *proposed* bundle rather than the latest fully executed one.
+    // @dev: Every branch below must resolve its reference the same way. Mixing references lets a chain that takes one
+    // of the paused branches freeze at a stale end block while its peers advance off a newer bundle, which regresses
+    // that chain's end block relative to the previous bundle.
+    const lastEndBlockForChain = optimistic
+      ? clients.hubPoolClient.getOptimisticBundleEndBlockForChain(chainIds, latestMainnetBlock, chainId)
+      : clients.hubPoolClient.getLatestBundleEndBlockForChain(chainIds, latestMainnetBlock, chainId);
 
-    // If chain is disabled, re-use the latest bundle end block for the chain as both the start
+    // If chain is disabled, re-use the previous bundle end block for the chain as both the start
     // and end block.
     if (!enabledChains.includes(chainId)) {
       return [lastEndBlockForChain, lastEndBlockForChain];
@@ -87,19 +90,16 @@ export async function getWidestPossibleExpectedBlockRange(
     // If the latest block hasn't advanced enough from the previous proposed end block, then re-use it. It will
     // be regarded as disabled by the Dataworker clients. Otherwise, add 1 to the previous proposed end block.
     if (lastEndBlockForChain >= latestPossibleBundleEndBlockNumbers[index]) {
-      // @dev: Without this check, then `getNextBundleStartBlockNumber` could return `latestBlock+1` even when the
-      // latest block for the chain hasn't advanced, resulting in an invalid range being produced.
+      // @dev: Without this check, then the start block could be `latestBlock+1` even when the latest block for the
+      // chain hasn't advanced, resulting in an invalid range being produced.
       return [lastEndBlockForChain, lastEndBlockForChain];
     }
 
     // Chain has advanced far enough including the buffer, return range from previous proposed end block + 1 to
     // latest block for chain minus buffer.
-    return [
-      optimistic
-        ? clients.hubPoolClient.getOptimisticBundleStartBlockNumber(chainIds, latestMainnetBlock, chainId)
-        : clients.hubPoolClient.getNextBundleStartBlockNumber(chainIds, latestMainnetBlock, chainId),
-      latestPossibleBundleEndBlockNumbers[index],
-    ];
+    // @dev: This assumes that chain ID's are only added to the chain ID list over time, and that chains are never
+    // deleted, matching `get{Next,OptimisticBundle}StartBlockNumber`.
+    return [lastEndBlockForChain > 0 ? lastEndBlockForChain + 1 : 0, latestPossibleBundleEndBlockNumbers[index]];
   });
 }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -786,11 +786,13 @@ export class HubPoolClient extends BaseAbstractClient {
     return endBlock > 0 ? endBlock + 1 : 0;
   }
 
-  // @dev Returns the start block of the next bundle assuming that if there is a currently outstanding root bundle proposal, it will pass liveness.
-  getOptimisticBundleStartBlockNumber(chainIdList: number[], latestMainnetBlock: number, chainId: number): number {
-    // If there is no pending root bundle, then return block ranges based on the latest fully executed root bundle.
+  // @dev Returns the end block of the previous bundle for `chainId`, assuming that if there is a currently outstanding
+  // root bundle proposal, it will pass liveness. This is the optimistic counterpart to
+  // `getLatestBundleEndBlockForChain`.
+  getOptimisticBundleEndBlockForChain(chainIdList: number[], latestMainnetBlock: number, chainId: number): number {
+    // If there is no pending root bundle, then return the end block of the latest fully executed root bundle.
     if (!this.hasPendingProposal()) {
-      return this.getNextBundleStartBlockNumber(chainIdList, latestMainnetBlock, chainId);
+      return this.getLatestBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId);
     }
     // We cannot normally index `this.proposedRootBundles` since a bundle there may have been previously disputed, so only index `this.proposedRootBundles`
     // if we have a pending proposal, since this must mean that the pending root bundle is the most recent proposed root bundle.
@@ -802,7 +804,12 @@ export class HubPoolClient extends BaseAbstractClient {
     }
 
     // Otherwise, get the bundle end block for the optimistic bundle.
-    const optimisticEndBlock = this.getBundleEndBlockForChain(latestProposedBundle, chainId, chainIdList);
+    return this.getBundleEndBlockForChain(latestProposedBundle, chainId, chainIdList);
+  }
+
+  // @dev Returns the start block of the next bundle assuming that if there is a currently outstanding root bundle proposal, it will pass liveness.
+  getOptimisticBundleStartBlockNumber(chainIdList: number[], latestMainnetBlock: number, chainId: number): number {
+    const optimisticEndBlock = this.getOptimisticBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId);
 
     // As above, this assumes that chain ID's are only added to the chain ID list over time, and that chains are never
     // deleted.

--- a/test/BundleDataClient.blockRanges.ts
+++ b/test/BundleDataClient.blockRanges.ts
@@ -1,0 +1,181 @@
+import { AcrossConfigStoreClient as ConfigStoreClient, HubPoolClient } from "../src/clients";
+import { getWidestPossibleExpectedBlockRange } from "../src/clients/BundleDataClient/utils/PoolRebalanceUtils";
+import { SpokePoolClient } from "../src/clients/SpokePoolClient";
+import { Clients } from "../src/interfaces";
+import * as constants from "./constants";
+import {
+  BigNumber,
+  Contract,
+  SignerWithAddress,
+  buildPoolRebalanceLeafTree,
+  buildPoolRebalanceLeaves,
+  createSpyLogger,
+  deployConfigStore,
+  ethers,
+  expect,
+  toBN,
+  toBNWei,
+  winston,
+} from "./utils";
+import { setupHubPool } from "./fixtures/HubPool.Fixture";
+
+let hubPool: Contract, timer: Contract;
+let l1Token_1: Contract, l1Token_2: Contract;
+let dataworker: SignerWithAddress, owner: SignerWithAddress;
+let logger: winston.Logger;
+
+let hubPoolClient: HubPoolClient;
+let configStoreClient: ConfigStoreClient;
+
+// The chain that stays enabled throughout, and the chain that gets disabled mid-liveness.
+const enabledChainId = constants.originChainId;
+const disabledChainId = constants.destinationChainId;
+const chainIds = [enabledChainId, disabledChainId];
+
+// Bundle end blocks for the fully executed bundle and for the bundle left in liveness.
+const executedBundleEndBlocks = [100, 200];
+const pendingBundleEndBlocks = [150, 250];
+
+const endBlockBuffers = [0, 0];
+
+async function constructSimpleTree(runningBalance: BigNumber) {
+  const netSendAmount = runningBalance.mul(toBN(-1));
+  const bundleLpFees = toBNWei(1);
+  const leaves = buildPoolRebalanceLeaves(
+    [enabledChainId, disabledChainId], // Where funds are getting sent.
+    [[l1Token_1.address, l1Token_2.address], [l1Token_2.address]], // l1Token.
+    [[bundleLpFees, bundleLpFees.mul(toBN(2))], [bundleLpFees.mul(toBN(2))]], // bundleLpFees.
+    [[netSendAmount, netSendAmount.mul(toBN(2))], [netSendAmount.mul(toBN(2))]], // netSendAmounts.
+    [[runningBalance, runningBalance.mul(toBN(2))], [runningBalance.mul(toBN(3))]], // runningBalances.
+    [0, 0] // groupId. Doesn't matter for this test.
+  );
+
+  const tree = await buildPoolRebalanceLeafTree(leaves);
+  return { leaves, tree };
+}
+
+// getWidestPossibleExpectedBlockRange only reads `latestHeightSearched` off the spoke clients, and only for chains
+// that are enabled, so a minimal stub is sufficient here.
+function stubSpokeClients(heights: { [chainId: number]: number }): { [chainId: number]: SpokePoolClient } {
+  return Object.fromEntries(
+    Object.entries(heights).map(([chainId, latestHeightSearched]) => [
+      chainId,
+      { latestHeightSearched } as unknown as SpokePoolClient,
+    ])
+  );
+}
+
+describe("BundleDataClient: widest possible block ranges", function () {
+  beforeEach(async function () {
+    ({ hubPool, l1Token_1, l1Token_2, timer, owner, dataworker } = await setupHubPool(
+      ethers,
+      constants.MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
+      constants.MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF
+    ));
+
+    logger = createSpyLogger().spyLogger;
+    const { configStore, deploymentBlock: fromBlock } = await deployConfigStore(owner, [l1Token_1, l1Token_2]);
+    configStoreClient = new ConfigStoreClient(logger, configStore, { from: fromBlock }, constants.CONFIG_STORE_VERSION);
+    await configStoreClient.update();
+
+    hubPoolClient = new HubPoolClient(logger, hubPool, configStoreClient);
+
+    // Propose and fully execute one bundle, then leave a second bundle in liveness. This reproduces the state the
+    // proposer sees when it chains a proposal off a bundle that has not been executed yet.
+    const { tree: executedTree, leaves: executedLeaves } = await constructSimpleTree(toBNWei(100));
+    const { tree: pendingTree } = await constructSimpleTree(toBNWei(100));
+
+    await hubPoolClient.update();
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle(
+        executedBundleEndBlocks,
+        1,
+        executedTree.getHexRoot(),
+        constants.mockTreeRoot,
+        constants.mockTreeRoot
+      );
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+    await hubPool
+      .connect(dataworker)
+      .executeRootBundle(...Object.values(executedLeaves[0]), executedTree.getHexProof(executedLeaves[0]));
+
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle(
+        pendingBundleEndBlocks,
+        1,
+        pendingTree.getHexRoot(),
+        constants.mockTreeRoot,
+        constants.mockTreeRoot
+      );
+    await hubPoolClient.update();
+
+    expect(hubPoolClient.hasPendingProposal()).to.equal(true);
+  });
+
+  it("freezes a disabled chain at the pending proposal's end block in optimistic mode", async function () {
+    // The enabled chain has advanced well past the pending proposal's end block.
+    const spokeClients = stubSpokeClients({ [enabledChainId]: 1000 });
+    const latestMainnetBlock = await hubPool.provider.getBlockNumber();
+
+    const blockRanges = await getWidestPossibleExpectedBlockRange(
+      chainIds,
+      spokeClients,
+      endBlockBuffers,
+      { hubPoolClient, configStoreClient } as Clients,
+      latestMainnetBlock,
+      [enabledChainId], // disabledChainId is absent, i.e. disabled.
+      true // optimistic
+    );
+
+    // The enabled chain chains off the pending proposal...
+    expect(blockRanges[0]).to.deep.equal([pendingBundleEndBlocks[0] + 1, 1000]);
+
+    // ...so the disabled chain must freeze at the pending proposal's end block too. Freezing it at the latest *fully
+    // executed* bundle instead would regress this chain's end block below what the pending bundle already recorded.
+    expect(blockRanges[1]).to.deep.equal([pendingBundleEndBlocks[1], pendingBundleEndBlocks[1]]);
+    expect(blockRanges[1][1]).to.be.at.least(executedBundleEndBlocks[1]);
+  });
+
+  it("freezes a disabled chain at the fully executed end block in non-optimistic mode", async function () {
+    const spokeClients = stubSpokeClients({ [enabledChainId]: 1000 });
+    const latestMainnetBlock = await hubPool.provider.getBlockNumber();
+
+    const blockRanges = await getWidestPossibleExpectedBlockRange(
+      chainIds,
+      spokeClients,
+      endBlockBuffers,
+      { hubPoolClient, configStoreClient } as Clients,
+      latestMainnetBlock,
+      [enabledChainId],
+      false // non-optimistic, i.e. how a bundle already in liveness is evaluated.
+    );
+
+    // Both chains reference the latest fully executed bundle, so the pending proposal is ignored on both branches.
+    expect(blockRanges[0]).to.deep.equal([executedBundleEndBlocks[0] + 1, 1000]);
+    expect(blockRanges[1]).to.deep.equal([executedBundleEndBlocks[1], executedBundleEndBlocks[1]]);
+  });
+
+  it("does not produce an inverted range when an enabled chain has not advanced past the pending proposal", async function () {
+    // The enabled chain's head sits between the executed and the pending bundle end blocks.
+    const spokeHeight = pendingBundleEndBlocks[0] - 10;
+    expect(spokeHeight).to.be.greaterThan(executedBundleEndBlocks[0]);
+    const spokeClients = stubSpokeClients({ [enabledChainId]: spokeHeight });
+    const latestMainnetBlock = await hubPool.provider.getBlockNumber();
+
+    const blockRanges = await getWidestPossibleExpectedBlockRange(
+      chainIds,
+      spokeClients,
+      endBlockBuffers,
+      { hubPoolClient, configStoreClient } as Clients,
+      latestMainnetBlock,
+      [enabledChainId],
+      true // optimistic
+    );
+
+    // The chain is paused rather than given a start block above its end block.
+    expect(blockRanges[0]).to.deep.equal([pendingBundleEndBlocks[0], pendingBundleEndBlocks[0]]);
+    expect(blockRanges[0][0]).to.be.at.most(blockRanges[0][1]);
+  });
+});

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -466,6 +466,77 @@ describe("HubPoolClient: RootBundle Events", function () {
     expect(hubPoolClient.getNextBundleStartBlockNumber(secondChainIdList, 0, secondChainIdList[0])).to.equal(0);
   });
 
+  it("returns optimistic root bundle end block while a proposal is in liveness", async function () {
+    const { tree: tree1, leaves: leaves1 } = await constructSimpleTree(toBNWei(100));
+    const { tree: tree2, leaves: leaves2 } = await constructSimpleTree(toBNWei(100));
+
+    await configStoreClient.update();
+    await hubPoolClient.update();
+
+    const chainIdList = [leaves1[0].chainId.toNumber()];
+    const chainId = chainIdList[0];
+
+    // Propose and fully execute a first root bundle, so that there is a latest fully executed bundle to fall back on.
+    const firstBundleEndBlock = 11;
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle([firstBundleEndBlock], 1, tree1.getHexRoot(), constants.mockTreeRoot, constants.mockTreeRoot);
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves1[0]), tree1.getHexProof(leaves1[0]));
+    await hubPoolClient.update();
+
+    let latestMainnetBlock = await hubPool.provider.getBlockNumber();
+    expect(hubPoolClient.hasPendingProposal()).to.equal(false);
+
+    // With no proposal in liveness, the optimistic reference matches the fully executed one.
+    expect(hubPoolClient.getLatestBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      firstBundleEndBlock
+    );
+    expect(hubPoolClient.getOptimisticBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      firstBundleEndBlock
+    );
+
+    // Propose a second root bundle and leave it in liveness: proposed, but not yet executed.
+    const secondBundleEndBlock = 66;
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle([secondBundleEndBlock], 1, tree2.getHexRoot(), constants.mockTreeRoot, constants.mockTreeRoot);
+    await hubPoolClient.update();
+    latestMainnetBlock = await hubPool.provider.getBlockNumber();
+    expect(hubPoolClient.hasPendingProposal()).to.equal(true);
+
+    // The fully executed reference still points at the first bundle, but the optimistic reference advances to the
+    // pending proposal. A paused chain frozen at the former would regress against the pending bundle's end block.
+    expect(hubPoolClient.getLatestBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      firstBundleEndBlock
+    );
+    expect(hubPoolClient.getOptimisticBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      secondBundleEndBlock
+    );
+
+    // Each start block stays consistent with the end block reference it is derived from.
+    expect(hubPoolClient.getNextBundleStartBlockNumber(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      firstBundleEndBlock + 1
+    );
+    expect(hubPoolClient.getOptimisticBundleStartBlockNumber(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      secondBundleEndBlock + 1
+    );
+
+    // Once the pending proposal is executed, both references agree again.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves2[0]), tree2.getHexProof(leaves2[0]));
+    await hubPoolClient.update();
+    latestMainnetBlock = await hubPool.provider.getBlockNumber();
+
+    expect(hubPoolClient.hasPendingProposal()).to.equal(false);
+    expect(hubPoolClient.getLatestBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      secondBundleEndBlock
+    );
+    expect(hubPoolClient.getOptimisticBundleEndBlockForChain(chainIdList, latestMainnetBlock, chainId)).to.equal(
+      secondBundleEndBlock
+    );
+  });
+
   it("gets most recent CrossChainContractsSet event for chainID", async function () {
     const adapter = randomAddress();
     const spokePool1 = randomAddress();


### PR DESCRIPTION
## Motivation

Our own disputer disputed a live bundle at 17:53:23 UTC today ([tx `0xc98383…05693`](https://etherscan.io/tx/0xc983831f318a527be0a918c96e872bfa4089f6438cca3a53620d88d4c9d05693)). Blast (`81457`) was the only chain of 31 whose proposed end block moved *backwards* — `38570088` → `38567388`, a 2,700 block regression — while every other chain advanced normally.

[UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#determining-block-range-for-root-bundle-proposal) makes that invariant unconditional:

> Note that the above rules require that the `bundleEvaluationBlockNumbers` for each `chainId` are greater than or equal to the preceding [valid proposal's](#valid-bundle-proposals) `bundleEvaluationBlockNumbers` for the same `chainId`.

## Cause

`getWidestPossibleExpectedBlockRange` resolved the previous bundle end block from **two different bundles within one call**:

| Branch | Reference before this PR |
|---|---|
| chain in `DISABLED_CHAINS` | latest **fully executed** bundle |
| chain hasn't advanced past the buffer | latest **fully executed** bundle |
| chain advanced (`optimistic = true`) | latest **proposed** bundle |

The proposer passes `optimistic = true`, so while a proposal sits in liveness the enabled chains chain off it, but a paused chain is pinned to the bundle *before* it. Those two references are identical for a long-disabled chain, which is why this never bit before — Boba, Redstone, Aleph Zero and Scroll have carried the same frozen value for many bundles. A chain disabled *between* two bundles is the case where they diverge, and the freeze then regresses the chain against a proposal that was already accepted and executed.

Timeline of the incident, for the record:

| Mainnet block | Time (UTC) | Event | Blast end block |
|---|---|---|---|
| 25689746 | 17:18 − 30m | bundle proposed | `38567388` |
| 25689824 | 16:08:59 | `81457` added to `DISABLED_CHAINS` | — |
| 25690167 | 17:18:11 | bundle proposed, mainnet range `[25689701, 25690148]` | `38570088` |
| 25690322 | 17:49:11 | ↑ fully executed | — |
| 25690323 | 17:49:23 | bundle proposed | `38567388` ← regression |

At 17:47:53, when the proposer built the last row, block 25690167 was still in liveness — so the enabled chains started from it while Blast fell back to 25689746.

## Changes

`PoolRebalanceUtils`: resolve the reference **once**, honouring `optimistic`, and derive the start block from it so the branches cannot diverge. A paused chain is now no more and no less optimistic than its peers — if the pending proposal is disputed, the whole proposal is rebuilt anyway, exactly as it already is for every enabled chain.

`HubPoolClient`: add `getOptimisticBundleEndBlockForChain`, the optimistic counterpart to `getLatestBundleEndBlockForChain`, and express `getOptimisticBundleStartBlockNumber` in terms of it. That refactor is behaviour-preserving: both paths already applied the same `endBlock > 0 ? endBlock + 1 : 0` guard over the same reference, so `lastEndBlockForChain > 0 ? lastEndBlockForChain + 1 : 0` at the call site is exactly what `get{Next,OptimisticBundle}StartBlockNumber` returned.

This also fixes a second latent bug on the not-advanced branch. In optimistic mode, a chain whose head sat between the executed and the pending end block would compare against the executed reference, fall through, and be handed a start block above its end block — an inverted range. It is now correctly paused instead.

## Testing

New `test/BundleDataClient.blockRanges.ts` covers the function directly — it had no test coverage before. Reverting only the `PoolRebalanceUtils` change fails two of the three:

```
1) freezes a disabled chain at the pending proposal's end block in optimistic mode
   AssertionError: expected [ 200, 200 ] to deeply equal [ 250, 250 ]
2) does not produce an inverted range when an enabled chain has not advanced past the pending proposal
   AssertionError: expected [ 151, 140 ] to deeply equal [ 150, 150 ]
```

The first is this incident in miniature; the second is the inverted range. The non-optimistic case is asserted separately and is unchanged by this PR.

Also adds `returns optimistic root bundle end block while a proposal is in liveness` to `HubPoolClient.RootBundleEvents.ts`, the first coverage of the optimistic reference.

`yarn lint-check` clean, `tsc --project tsconfig.build.json` clean, 38 passing across the HubPoolClient, ConfigStore and new block-range suites.

## Deliberately out of scope — a question for reviewers

There is a second divergence here that I don't think should be resolved by an agent, because it is a spec question rather than a consistency one. UMIP-157 gives two rules for a disabled chain's end block that can disagree:

> if a chain exists in DISABLED_CHAINS, the proposed bundle must reuse the bundle end block from the last valid proposal before it was added. Specifically, if a chain exists in DISABLED_CHAINS at the "mainnet" end block (chain ID 1) for a particular proposal, the end block for that chain should be identical to its value in the latest executed bundle.

The `DISABLED_CHAINS` update landed at block 25689824, *inside* the `[25689701, 25690148]` mainnet range of the 17:18:11 proposal. This implementation evaluates the enabled set at the mainnet bundle **start** block (`getEnabledChains(mainnetBundleStartBlock)`), so that proposal still treated Blast as enabled and advanced it. Read against the UMIP's "at the mainnet **end** block" clause, it arguably should have frozen Blast at `38567388`, in which case both clauses would have agreed on that value indefinitely and nothing would have diverged.

I have not touched that, and this PR deliberately carries `38570088` forward rather than returning to `38567388`. Carrying forward is the funds-safe direction regardless of how the spec question is settled: the 17:18:11 bundle already computed refunds over Blast up to `38570088`, so re-recording a lower end block would re-cover `38567389`–`38570088` if Blast were ever re-enabled, i.e. duplicate refunds. Whether the enabled set should instead be evaluated at the mainnet end block is worth a maintainer's call, and may warrant a UMIP clarification either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
