### PR TITLE
fix(BlockUtils): sample the block range that exists, and divide by it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.17",
+  "version": "4.4.18",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/evm/BlockUtils.ts
+++ b/src/arch/evm/BlockUtils.ts
@@ -61,12 +61,20 @@ export async function averageBlockTime(
   // If the caller was not specific about highBlock, resolve it via the RPC provider. Subtract an offset
   // to account for various RPC provider sync issues that might occur when querting the latest block.
   if (!isDefined(highBlock)) {
-    highBlock = await provider.getBlockNumber();
-    highBlock -= highBlockOffset ?? defaultHighBlockOffset;
+    const latestBlock = await provider.getBlockNumber();
+    highBlock = latestBlock - (highBlockOffset ?? defaultHighBlockOffset);
+
+    // The offset presumes a chain with more blocks than the offset itself. Below that it puts the entire
+    // sample window at or before genesis, leaving nothing to measure, so fall back to the head.
+    if (highBlock <= 0) {
+      highBlock = latestBlock;
+    }
   }
   blockRange ??= defaultBlockRange;
 
-  const earliestBlockNumber = highBlock - blockRange;
+  // Clamp the window to blocks that exist. A negative block number is not an error to ethers: it resolves
+  // relative to the head, which slides the window instead of starting it at genesis.
+  const earliestBlockNumber = Math.max(highBlock - blockRange, 0);
   const [firstBlock, lastBlock] = await Promise.all([
     provider.getBlock(earliestBlockNumber),
     provider.getBlock(highBlock),
@@ -79,10 +87,16 @@ export async function averageBlockTime(
     }
   });
 
-  const average = (lastBlock.timestamp - firstBlock.timestamp) / blockRange;
-  blockTimes[chainId] = { timestamp: now, average, blockRange };
+  // Divide by the range actually sampled, which is narrower than blockRange on a chain holding less
+  // history than that. Dividing by the requested range instead under-reports the block time in proportion
+  // to how much of the window does not exist, and reports 0 when none of it does.
+  const sampledRange = lastBlock.number - firstBlock.number;
+  assert(sampledRange > 0, `averageBlockTime: no block range to sample on ${getNetworkName(chainId)}`);
 
-  return { average, blockRange };
+  const average = (lastBlock.timestamp - firstBlock.timestamp) / sampledRange;
+  blockTimes[chainId] = { timestamp: now, average, blockRange: sampledRange };
+
+  return { average, blockRange: sampledRange };
 }
 
 async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0, provider: Provider): Promise<number> {

--- a/test/BlockUtils.test.ts
+++ b/test/BlockUtils.test.ts
@@ -1,0 +1,131 @@
+import { Provider } from "@ethersproject/abstract-provider";
+import { averageBlockTime } from "../src/arch/evm";
+import { expect } from "./utils";
+
+// averageBlockTime memoises per chainId for 15 minutes, so every case needs a chain of its own. These are
+// deliberately not real chain IDs: a known one would be pre-seeded in the cache, and an OP stack one would
+// inherit Optimism's seeded average.
+let nextChainId = 9_900_001;
+
+const BLOCK_TIME = 12;
+const GENESIS_TIMESTAMP = 1_700_000_000;
+
+type FakeProvider = {
+  provider: Provider;
+  chainId: number;
+  requestedBlocks: number[];
+};
+
+/**
+ * A provider backed by a synthetic chain of `height + 1` blocks, spaced BLOCK_TIME apart. Supply a chainId
+ * to present a second view of a chain already seen by averageBlockTime.
+ */
+function fakeProvider(height: number, chainId = nextChainId++): FakeProvider {
+  const requestedBlocks: number[] = [];
+
+  const provider = {
+    getNetwork: () => Promise.resolve({ chainId, name: `chain-${chainId}` }),
+    getBlockNumber: () => Promise.resolve(height),
+    getBlock: (blockTag: number) => {
+      requestedBlocks.push(blockTag);
+
+      // Mirror ethers, which does not reject a negative block number but resolves it relative to the head,
+      // clamping at genesis.
+      const number = blockTag < 0 ? Math.max(height + blockTag, 0) : blockTag;
+      return Promise.resolve(number > height ? null : { number, timestamp: GENESIS_TIMESTAMP + number * BLOCK_TIME });
+    },
+  } as unknown as Provider;
+
+  return { provider, chainId, requestedBlocks };
+}
+
+describe("BlockUtils: averageBlockTime", () => {
+  it("averages over the requested range when the chain is long enough to hold it", async () => {
+    const { provider, requestedBlocks } = fakeProvider(5000);
+
+    const { average, blockRange } = await averageBlockTime(provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(120);
+    // 10 blocks back off the head, then 120 back from there.
+    expect(requestedBlocks).to.have.members([4870, 4990]);
+  });
+
+  it("honours an explicit highBlock and blockRange", async () => {
+    const { provider, requestedBlocks } = fakeProvider(5000);
+
+    const { average, blockRange } = await averageBlockTime(provider, { highBlock: 1000, blockRange: 50 });
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(50);
+    expect(requestedBlocks).to.have.members([950, 1000]);
+  });
+
+  it("starts the window at genesis and divides by the range actually sampled", async () => {
+    // 120 blocks exist, so the window can only reach back 109 blocks from the offset head, not 120.
+    // Pre-clamp it ran from block -11, which ethers resolves against the head: the sample collapsed to
+    // blocks 108-109 while the divisor stayed 120, reporting 1/120th of the real block time. Clamping the
+    // window alone is not enough either -- dividing 109 blocks of history by 120 reports 10.9s/block.
+    const { provider, requestedBlocks } = fakeProvider(119);
+
+    const { average, blockRange } = await averageBlockTime(provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(109);
+    expect(requestedBlocks).to.have.members([0, 109]);
+  });
+
+  it("falls back to the head on a chain shorter than the head offset", async () => {
+    // The offset guards against RPC providers lagging the head. With only 6 blocks it would instead put the
+    // whole window at or before genesis and leave nothing to sample.
+    const { provider, requestedBlocks } = fakeProvider(5);
+
+    const { average, blockRange } = await averageBlockTime(provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(5);
+    expect(requestedBlocks).to.have.members([0, 5]);
+  });
+
+  it("samples a two-block chain", async () => {
+    const { provider } = fakeProvider(1);
+
+    const { average, blockRange } = await averageBlockTime(provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(1);
+  });
+
+  it("rejects a chain with no block range to sample", async () => {
+    // A single block carries no block time. Reporting 0 propagates as an Infinity block estimate into every
+    // caller that divides by the average.
+    const { provider } = fakeProvider(0);
+
+    const error = await averageBlockTime(provider).then(
+      () => undefined,
+      (err: Error) => err
+    );
+
+    expect(error?.message).to.contain("no block range to sample");
+  });
+
+  it("does not memoise a rejected computation", async () => {
+    const { provider, chainId } = fakeProvider(0);
+    await averageBlockTime(provider).catch(() => undefined);
+
+    // The same chain, once it has some history. A memoised failure would pin the bad answer for 15 minutes.
+    const { average } = await averageBlockTime(fakeProvider(200, chainId).provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+  });
+
+  it("memoises per chain", async () => {
+    const { provider, requestedBlocks } = fakeProvider(5000);
+
+    const first = await averageBlockTime(provider);
+    const second = await averageBlockTime(provider);
+
+    expect(second).to.deep.equal(first);
+    expect(requestedBlocks.length).to.equal(2); // Only the first call reached the provider.
+  });
+});


### PR DESCRIPTION
Draft, for review. Follow-up to the flaky relayer test in across-protocol/relayer#3669 — this is the upstream cause of it.

## The bug

`averageBlockTime` samples a fixed window — `latest - highBlockOffset` back `blockRange` blocks — and divides the elapsed time by `blockRange`. Both halves break on a chain holding less history than the window.

ethers does not reject a negative block number: it resolves one relative to the head and clamps at genesis. So on a short chain the window does not start at genesis as intended, it *slides*. At height 119 the requested range `109 → -11` resolves to `109 → 108` — two blocks — while the divisor stays at the requested 120. A 12s/block chain gets reported at 0.1s/block:

| Chain height | Window requested | Window sampled | Reported (real = 12s/block) |
| --- | --- | --- | --- |
| 5000 | 4990 → 4870 | 4990 → 4870 | `12` ✅ |
| 119 | 109 → -11 | 109 → 108 | `0.1` |
| 120 | 110 → -10 | 110 → 110 | `0` |
| 125 | 115 → -5 | 115 → 120 | `-0.5` (low block above high block) |
| ≤ 10 | ≤ 0 → negative | 0 → 0 | `0` |

None of this is reachable on a production chain, which is always longer than the window. It is reachable in tests, and there it is *sticky*: the result is memoised per chainId for 15 minutes, so a single bad measurement on a young chain pins a nonsense block time for everything that follows in the process.

Zero is the worst of the three, because `estimateBlocksElapsed` and `AcrossConfigStoreClient.update` both divide by the average. An `Infinity` block estimate walks `EVMBlockFinder` off the front of the chain, which then fails with the unrelated `timestamp is before block 0`.

## The change

- Clamp the low end of the window at genesis rather than letting ethers reinterpret it.
- Fall back to the head when the offset alone would put the window at or before genesis. The offset exists to absorb RPC providers lagging the head, which is not a concern on a chain of six blocks.
- Divide by the range actually sampled.
- A one-block chain has no block time to report, so `assert` rather than returning zero. The assert precedes the cache write, so a chain that is briefly too short does not get pinned for 15 minutes.

**One thing to check in review:** `blockRange`, in both the returned object and the cache entry, now describes the range *sampled* rather than the range *requested*. The two are equal whenever the history is there, so it is only visible on a short chain, and no caller in this repo or in `relayer` does arithmetic with it — `finalizer/utils/linea/l2ToL1.ts` is the only one that takes the whole object and it only logs it. Happy to keep returning the requested value if you would rather not move that goalpost.

## Tests

`test/BlockUtils.test.ts`, 8 cases over a synthetic provider whose `getBlock` reproduces ethers' negative-block-tag semantics, one chainId per case to sidestep the memoisation. Five fail on `master`:

```
1) starts the window at genesis and divides by the range actually sampled
     AssertionError: expected 0.1 to equal 12
2) falls back to the head on a chain shorter than the head offset
     AssertionError: expected +0 to equal 12
3) samples a two-block chain
     AssertionError: expected +0 to equal 12
4) rejects a chain with no block range to sample
     AssertionError: ... (undefined and string) ...
5) does not memoise a rejected computation
     AssertionError: expected +0 to equal 12
```

The three that pin existing behaviour — full window, explicit `highBlock`/`blockRange`, memoisation — pass either way.

`yarn hardhat test` over the 45 non-Solana test files: **348 passing** on this branch and **348 passing** on `master`, so nothing else moves. (The Solana files need `solana-test-validator`, which I don't have locally; CI covers them.) `eslint` and `prettier` clean on both changed files.

## Verified against the relayer

Built this branch's `dist/cjs` into `relayer`'s `node_modules` and ran the block-time-sensitive files — `test/Relayer*.ts`, `ConfigStoreClient`, `Dataworker.loadData.deposit`, `Dataworker.blockRangeUtils`, `Monitor`: **73 passing**, the same as on the stock 4.4.17.

I also re-ran the flaky test from relayer#3669 at `master`'s version of that file — i.e. this fix and nothing else — seeding the cache at each height that used to break it:

```
L=5    {"average":1,"blockRange":5}     ✔ Correctly defers destination chain fills
L=11   {"average":1,"blockRange":1}     ✔ Correctly defers destination chain fills
L=118  {"average":1,"blockRange":108}   ✔ Correctly defers destination chain fills
L=119  {"average":1,"blockRange":109}   ✔ Correctly defers destination chain fills
L=120  {"average":1,"blockRange":110}   ✔ Correctly defers destination chain fills
L=125  {"average":1,"blockRange":115}   ✔ Correctly defers destination chain fills
```

The average is a stable `1` at every height instead of `0`, `0.008`, `0.017` or `-0.042`.

So this does fix that flake too — but only once it is released and the bump lands in `relayer`, and relayer#3669 additionally corrects arithmetic in the test itself that is wrong independently of this. They are complementary; I would not hold #3669 for this.

## Version

Bumped to `4.4.18` to match the convention in recent fix PRs. Say the word if you would rather batch the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
