### PR TITLE
feat(tvm): Submit a TransferContract when there is no calldata

### DIFF
--- a/src/arch/tvm/TransactionUtils.ts
+++ b/src/arch/tvm/TransactionUtils.ts
@@ -26,8 +26,10 @@ export interface TronSimulationResult {
  * `triggerSmartContract` → `sign` → `sendRawTransaction` pipeline.
  *
  * TRON models a native TRX transfer as its own transaction type (`TransferContract`), distinct from
- * the `TriggerSmartContract` used for calls. A populated transaction carrying no calldata is
- * therefore dispatched to TronWeb's `sendTransaction` instead; see {@link transferNative}.
+ * the `TriggerSmartContract` used for calls. A populated transaction with no `data` field is
+ * therefore dispatched to TronWeb's `sendTransaction` instead; see {@link transferNative}. Note that
+ * this turns on `data` being absent, not empty: an explicit `"0x"` remains a contract call, since
+ * that is how TronWeb encodes a `receive`/`fallback` invocation.
  *
  * @param tronWeb An authenticated TronWeb instance (with private key set).
  * @param populatedTx The populated transaction containing `to`, and `data` for a contract call.
@@ -51,9 +53,13 @@ export async function submitTransaction(
     throw new Error("submitTransaction: TronWeb instance must have a default address configured");
   }
 
-  // No calldata means this is a value transfer, which triggerSmartContract cannot express: it
+  // No calldata at all means this is a value transfer, which triggerSmartContract cannot express: it
   // requires a deployed contract at the target address, so it can never fund an EOA.
-  if (!isDefined(data) || data === "0x") {
+  //
+  // Empty-but-present calldata ("0x") is deliberately *not* treated as a transfer. That is TronWeb's
+  // own encoding for a `receive`/`fallback` selector, which it submits as a TriggerSmartContract; a
+  // TransferContract would move the TRX without running the recipient's code.
+  if (!isDefined(data)) {
     return transferNative(tronWeb, tronAddress, callValue);
   }
 

--- a/src/arch/tvm/TransactionUtils.ts
+++ b/src/arch/tvm/TransactionUtils.ts
@@ -1,6 +1,6 @@
 import { TronWeb } from "tronweb";
 import { PopulatedTransaction } from "ethers";
-import { TvmAddress } from "../../utils";
+import { isDefined, TvmAddress } from "../../utils";
 
 export interface TronTransactionResult {
   txid: string;
@@ -25,8 +25,12 @@ export interface TronSimulationResult {
  * converts the target address to TRON Base58 format, and uses TronWeb's
  * `triggerSmartContract` → `sign` → `sendRawTransaction` pipeline.
  *
+ * TRON models a native TRX transfer as its own transaction type (`TransferContract`), distinct from
+ * the `TriggerSmartContract` used for calls. A populated transaction carrying no calldata is
+ * therefore dispatched to TronWeb's `sendTransaction` instead; see {@link transferNative}.
+ *
  * @param tronWeb An authenticated TronWeb instance (with private key set).
- * @param populatedTx The populated transaction containing `to` and `data`.
+ * @param populatedTx The populated transaction containing `to`, and `data` for a contract call.
  * @param feeLimit The maximum TRX to burn for energy consumption, in SUN (1 TRX = 1,000,000 SUN).
  * @returns The transaction ID and result status.
  */
@@ -37,14 +41,20 @@ export async function submitTransaction(
   callValue: number = 0
 ): Promise<TronTransactionResult> {
   const { to, data } = populatedTx;
-  if (!to || !data) {
-    throw new Error("submitTransaction: populatedTx must have both 'to' and 'data' fields");
+  if (!to) {
+    throw new Error("submitTransaction: populatedTx must have a 'to' field");
   }
 
   const tronAddress = TvmAddress.from(to).toNative();
   const ownerAddress = tronWeb.defaultAddress?.base58;
   if (!ownerAddress) {
     throw new Error("submitTransaction: TronWeb instance must have a default address configured");
+  }
+
+  // No calldata means this is a value transfer, which triggerSmartContract cannot express: it
+  // requires a deployed contract at the target address, so it can never fund an EOA.
+  if (!isDefined(data) || data === "0x") {
+    return transferNative(tronWeb, tronAddress, callValue);
   }
 
   // Use triggerSmartContract with the `input` option to pass pre-encoded calldata.
@@ -69,6 +79,30 @@ export async function submitTransaction(
 
   return {
     txid: broadcast.txid ?? signedTx.txID,
+    result: broadcast.result ?? false,
+  };
+}
+
+/**
+ * Transfer native TRX to an account via a `TransferContract` transaction.
+ *
+ * TronWeb's `sendTransaction` builds, signs and broadcasts in one call, using the instance's default
+ * private key. No fee limit applies, since transfers consume bandwidth rather than energy.
+ *
+ * @param tronWeb An authenticated TronWeb instance (with private key set).
+ * @param recipient Base58 recipient address.
+ * @param amount Transfer amount in SUN (1 TRX = 1,000,000 SUN).
+ * @returns The transaction ID and result status.
+ */
+async function transferNative(tronWeb: TronWeb, recipient: string, amount: number): Promise<TronTransactionResult> {
+  if (amount <= 0) {
+    throw new Error("submitTransaction: a transaction with no calldata must transfer a non-zero value");
+  }
+
+  const broadcast = await tronWeb.trx.sendTransaction(recipient, amount);
+
+  return {
+    txid: broadcast.txid ?? broadcast.transaction.txID,
     result: broadcast.result ?? false,
   };
 }

--- a/test/Tvm.TransactionUtils.test.ts
+++ b/test/Tvm.TransactionUtils.test.ts
@@ -72,14 +72,32 @@ describe("TVM TransactionUtils", function () {
       expect(result).to.deep.equal({ txid: TXID, result: true });
     });
 
-    it("Treats empty calldata as a transfer", async function () {
+    // "0x" is TronWeb's encoding for a `receive`/`fallback` selector, so empty-but-present calldata
+    // is a contract call, not a transfer: a TransferContract would move the TRX without running the
+    // recipient's code. Only an absent `data` field selects the transfer path.
+    it("Treats explicit empty calldata as a fallback contract call", async function () {
       const { tronWeb, transfers, contractCalls } = fakeTronWeb();
 
       const populatedTx = { to: RECIPIENT, data: "0x" } as PopulatedTransaction;
       await submitTransaction(tronWeb, populatedTx, FEE_LIMIT, 1);
 
-      expect(transfers).to.deep.equal([{ to: RECIPIENT_BASE58, amount: 1 }]);
-      expect(contractCalls).to.deep.equal([]);
+      expect(transfers).to.deep.equal([]);
+      expect(contractCalls.length).to.equal(1);
+      const [contractCall] = contractCalls;
+      expect(contractCall.to).to.equal(RECIPIENT_BASE58);
+      expect(contractCall.options).to.deep.equal({ feeLimit: FEE_LIMIT, input: "", callValue: 1 });
+    });
+
+    it("Submits a zero-value fallback call rather than rejecting it", async function () {
+      const { tronWeb, transfers, contractCalls } = fakeTronWeb();
+
+      const populatedTx = { to: RECIPIENT, data: "0x" } as PopulatedTransaction;
+      const result = await submitTransaction(tronWeb, populatedTx, FEE_LIMIT, 0);
+
+      expect(transfers).to.deep.equal([]);
+      expect(contractCalls.length).to.equal(1);
+      expect(contractCalls[0].options).to.deep.equal({ feeLimit: FEE_LIMIT, input: "", callValue: 0 });
+      expect(result).to.deep.equal({ txid: TXID, result: true });
     });
 
     it("Submits calldata as a contract call", async function () {

--- a/test/Tvm.TransactionUtils.test.ts
+++ b/test/Tvm.TransactionUtils.test.ts
@@ -1,0 +1,127 @@
+import { PopulatedTransaction } from "ethers";
+import { TronWeb } from "tronweb";
+import { submitTransaction } from "../src/arch/tvm";
+import { assertPromiseError, expect } from "./utils";
+
+// EVM-format addresses and their Base58 equivalents. TRON encodes an address as the 20-byte EVM
+// address prefixed with 0x41, base58check-encoded.
+const RECIPIENT = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
+const RECIPIENT_BASE58 = "TYZ5ekizCPH4QdsnMfqQUFXBLtsuTuUKjJ";
+const OWNER_BASE58 = "TQ42TumxqaP1gHs216UA9u36soVdza4T5Y";
+
+const TXID = "3b699036b64d765dea6a9103c33793d343381bab361b3e96051e56de2d174247";
+const FEE_LIMIT = 100_000_000;
+const CALLDATA = "0xdeadbeef";
+
+type Transfer = { to: string; amount: number };
+type ContractCall = { to: string; selector: string; options: Record<string, unknown>; owner: string };
+
+type FakeTronWeb = {
+  tronWeb: TronWeb;
+  transfers: Transfer[];
+  contractCalls: ContractCall[];
+};
+
+/**
+ * A TronWeb instance that records what was submitted instead of broadcasting it. `broadcast` is the
+ * response returned by both submission paths, permitting a failed or txid-less broadcast.
+ */
+function fakeTronWeb(broadcast: { result?: boolean; txid?: string } = { result: true, txid: TXID }): FakeTronWeb {
+  const transfers: Transfer[] = [];
+  const contractCalls: ContractCall[] = [];
+
+  const tronWeb = {
+    defaultAddress: { base58: OWNER_BASE58 },
+    transactionBuilder: {
+      triggerSmartContract: (
+        to: string,
+        selector: string,
+        options: Record<string, unknown>,
+        _: unknown[],
+        owner: string
+      ) => {
+        contractCalls.push({ to, selector, options, owner });
+        return Promise.resolve({ result: { result: true }, transaction: { txID: TXID } });
+      },
+    },
+    trx: {
+      sendTransaction: (to: string, amount: number) => {
+        transfers.push({ to, amount });
+        return Promise.resolve({ ...broadcast, transaction: { txID: TXID } });
+      },
+      sign: (txn: unknown) => Promise.resolve(txn),
+      sendRawTransaction: () => Promise.resolve({ ...broadcast, transaction: { txID: TXID } }),
+    },
+  } as unknown as TronWeb;
+
+  return { tronWeb, transfers, contractCalls };
+}
+
+describe("TVM TransactionUtils", function () {
+  describe("submitTransaction", function () {
+    it("Transfers TRX when the transaction has no calldata", async function () {
+      const { tronWeb, transfers, contractCalls } = fakeTronWeb();
+      const callValue = 1_500_000; // 1.5 TRX in SUN.
+
+      const result = await submitTransaction(tronWeb, { to: RECIPIENT } as PopulatedTransaction, FEE_LIMIT, callValue);
+
+      // A transfer is a TransferContract, not a TriggerSmartContract, and pays bandwidth rather
+      // than energy - so no fee limit is involved.
+      expect(transfers).to.deep.equal([{ to: RECIPIENT_BASE58, amount: callValue }]);
+      expect(contractCalls).to.deep.equal([]);
+      expect(result).to.deep.equal({ txid: TXID, result: true });
+    });
+
+    it("Treats empty calldata as a transfer", async function () {
+      const { tronWeb, transfers, contractCalls } = fakeTronWeb();
+
+      const populatedTx = { to: RECIPIENT, data: "0x" } as PopulatedTransaction;
+      await submitTransaction(tronWeb, populatedTx, FEE_LIMIT, 1);
+
+      expect(transfers).to.deep.equal([{ to: RECIPIENT_BASE58, amount: 1 }]);
+      expect(contractCalls).to.deep.equal([]);
+    });
+
+    it("Submits calldata as a contract call", async function () {
+      const { tronWeb, transfers, contractCalls } = fakeTronWeb();
+
+      const populatedTx = { to: RECIPIENT, data: CALLDATA } as PopulatedTransaction;
+      const result = await submitTransaction(tronWeb, populatedTx, FEE_LIMIT, 0);
+
+      expect(transfers).to.deep.equal([]);
+      expect(contractCalls.length).to.equal(1);
+      const [contractCall] = contractCalls;
+      expect(contractCall.to).to.equal(RECIPIENT_BASE58);
+      expect(contractCall.owner).to.equal(OWNER_BASE58);
+      // The full calldata is supplied via `input`, so the function selector is empty.
+      expect(contractCall.selector).to.equal("");
+      expect(contractCall.options).to.deep.equal({ feeLimit: FEE_LIMIT, input: CALLDATA.slice(2), callValue: 0 });
+      expect(result).to.deep.equal({ txid: TXID, result: true });
+    });
+
+    it("Rejects a transaction with neither calldata nor value", async function () {
+      const { tronWeb, transfers } = fakeTronWeb();
+
+      const populatedTx = { to: RECIPIENT } as PopulatedTransaction;
+      await assertPromiseError(submitTransaction(tronWeb, populatedTx, FEE_LIMIT), "must transfer a non-zero value");
+      expect(transfers).to.deep.equal([]);
+    });
+
+    it("Rejects a transaction with no recipient", async function () {
+      const { tronWeb } = fakeTronWeb();
+
+      const populatedTx = { data: CALLDATA } as PopulatedTransaction;
+      await assertPromiseError(submitTransaction(tronWeb, populatedTx, FEE_LIMIT), "must have a 'to' field");
+    });
+
+    it("Reports a failed transfer broadcast", async function () {
+      const { tronWeb } = fakeTronWeb({ result: false });
+
+      const populatedTx = { to: RECIPIENT } as PopulatedTransaction;
+      const result = await submitTransaction(tronWeb, populatedTx, FEE_LIMIT, 1);
+
+      // The local txID is the fallback when the node rejects the broadcast and returns no txid.
+      expect(result).to.deep.equal({ txid: TXID, result: false });
+    });
+  });
+});


### PR DESCRIPTION
Upstreams the TVM half of across-protocol/relayer#3665, per Slack discussion — the goal is for `TransactionClient` not to need a branch on TRON's transaction types.

## Problem

`arch.tvm.submitTransaction` only ever builds a `TriggerSmartContract`, and hard-throws when calldata is absent:

```ts
if (!to || !data) { throw new Error("...must have both 'to' and 'data' fields"); }
```

TRON models a native TRX transfer as a distinct transaction type (`TransferContract`), so a bare value transfer — what the refiller emits to top up a signer that has run low — cannot be submitted at all.

## Change

The deciding condition was already being inspected, so the throw becomes a branch: no calldata → `TransferContract`, via TronWeb's `sendTransaction` (build + sign + broadcast in one call). `feeLimit` is not passed on that path: transfers pay bandwidth, not energy. No signature change.

A missing `to` still throws. So does no-calldata-and-no-value, rather than silently sending 0 TRX.

## Verification

Against Tron mainnet (`api.trongrid.io`), recipient an EOA:

- `transactionBuilder.sendTrx` → `raw_data.contract[0].type === "TransferContract"`, valid txID.
- `triggerSmartContract` → `No contract or not a valid smart contract`.

So the old path could not have funded an EOA even with the throw removed — the dispatch is required, not cosmetic. New unit tests cover both branches plus the rejections; `yarn build`, `yarn test` and `yarn lint-check` pass.

## Relayer side

relayer `master` needs no code change: it already passes `data: args[0]`, which is `undefined` for the refiller's value-only raw transaction, and the fee limit it computes is ignored on the transfer path. This should replace relayer#3665 with a version bump.

Two items from that PR are relayer-local and deliberately not here:

- `src/refiller/README.md` says GCKMS signers are unsupported on this path. They aren't — `getGckmsSigner` returns an `ethers.Wallet`, which is exactly what `getTronWebFromEvmSigner` asserts on.
- Retries rebuild a fresh transfer with a new txID. TVM has no nonce, so a broadcast that lands but times out on the response can double-send. Pre-existing for contract calls; the failure mode is now "lose TRX" rather than "duplicate a call".

🤖 Generated with [Claude Code](https://claude.com/claude-code)