### PR TITLE
fix(AddressUtils): compare addresses on raw bytes in Address.eq()

### DIFF
--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -216,7 +216,9 @@ export abstract class Address {
     return false;
   }
 
-  // Converts the input address to a 32-byte hex data string.
+  // Converts the address to its native (family-specific) representation, for display and serialisation.
+  // note: This is not an identity: the same account renders differently depending on the family it was typed
+  // for (checksummed hex on EVM, Base58Check on TVM). Use eq()/compare() to test identity.
   toString(): string {
     return this.toNative();
   }

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -2,7 +2,7 @@ import { isAddress } from "viem";
 import { providers, utils } from "ethers";
 import bs58 from "bs58";
 import { TronWeb } from "tronweb";
-import { BigNumber, chainIsEvm, chainIsSvm, chainIsTvm } from "./";
+import { BigNumber, chainIsEvm, chainIsSvm, chainIsTvm, isDefined } from "./";
 
 /**
  * Verify whether an address' bytecode resembles an EIP-7702 delegation.
@@ -232,8 +232,11 @@ export abstract class Address {
   }
 
   // Checks if the other address is equivalent to this address.
+  // note: Equality is defined on the raw bytes, not on the native (family-specific) encoding, so the same account
+  // compares equal regardless of which chain family it was typed for (e.g. EvmAddress vs TvmAddress of the same
+  // 20 bytes). Use `isEVM()`/`isSVM()`/`isTVM()` or compare `toNative()` directly if family matters.
   eq(other?: Address): boolean {
-    return this.toString() === other?.toString();
+    return isDefined(other) && this.compare(other) === 0;
   }
 
   // Compares Addresses by their raw byte representation (big-endian).

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -116,11 +116,29 @@ describe("Address Utils: Address Type", function () {
       const b = generateSvmAddress();
       expect(a.eq(b)).to.be.false;
     });
-    // Cross-type equality is not expected in practice, but verify it behaves correctly.
-    it("Returns false when comparing EVM and SVM addresses", function () {
+    // Equality is defined on the raw bytes, so it is independent of the family an address was typed for.
+    it("Returns false when comparing EVM and SVM addresses with different bytes", function () {
       const evmAddr = EvmAddress.from(randomBytes(20));
       const svmAddr = generateSvmAddress();
       expect(evmAddr.eq(svmAddr)).to.be.false;
+    });
+    it("Returns true when comparing EVM and TVM types of the same address", function () {
+      const raw = randomBytes(20);
+      const evmAddr = toAddressType(raw, CHAIN_IDs.MAINNET);
+      const tvmAddr = toAddressType(raw, CHAIN_IDs.TRON);
+      expect(evmAddr.isEVM()).to.be.true;
+      expect(tvmAddr.isTVM()).to.be.true;
+
+      // The native encodings differ (checksummed hex vs. TRON base58) but the underlying bytes do not.
+      expect(evmAddr.toNative()).to.not.equal(tvmAddr.toNative());
+      expect(evmAddr.eq(tvmAddr)).to.be.true;
+      expect(tvmAddr.eq(evmAddr)).to.be.true;
+    });
+    it("Returns true when comparing 20-byte and zero-padded 32-byte forms of the same address", function () {
+      const raw = randomBytes(20);
+      const a = EvmAddress.from(raw);
+      const b = EvmAddress.from(EVM_ZERO_PAD + raw.slice(2));
+      expect(a.eq(b)).to.be.true;
     });
     it("Returns false for undefined", function () {
       const a = EvmAddress.from(randomBytes(20));

--- a/test/AddressUtils.ts
+++ b/test/AddressUtils.ts
@@ -8,7 +8,8 @@ import {
   toAddressType,
   isValidEvmAddress,
 } from "../src/utils";
-import { CHAIN_IDs } from "../src/constants";
+import { CHAIN_IDs, ZERO_ADDRESS } from "../src/constants";
+import { SVM_DEFAULT_ADDRESS } from "../src/arch/svm";
 import { expect, ethers } from "./utils";
 
 describe("Address Utils: Address Type", function () {
@@ -139,6 +140,18 @@ describe("Address Utils: Address Type", function () {
       const a = EvmAddress.from(raw);
       const b = EvmAddress.from(EVM_ZERO_PAD + raw.slice(2));
       expect(a.eq(b)).to.be.true;
+    });
+    // The zero address is the only same-bytes pair that can span the 20-byte and 32-byte address spaces:
+    // SvmAddress.validate() rejects addresses with the upper 12 bytes zeroed, except the zero address itself.
+    // Across uses both encodings as the "unset" sentinel (SVM re-exports the System Program address as
+    // SVM_DEFAULT_ADDRESS for exactly that purpose), so comparing equal is the intended result here.
+    it("Treats the EVM and SVM zero addresses as equal", function () {
+      const evmZero = EvmAddress.from(ZERO_ADDRESS);
+      const svmZero = SvmAddress.from(bs58.encode(new Uint8Array(32)));
+      expect(svmZero.toNative()).to.equal(SVM_DEFAULT_ADDRESS);
+      expect(evmZero.isZeroAddress() && svmZero.isZeroAddress()).to.be.true;
+      expect(evmZero.eq(svmZero)).to.be.true;
+      expect(svmZero.eq(evmZero)).to.be.true;
     });
     it("Returns false for undefined", function () {
       const a = EvmAddress.from(randomBytes(20));

--- a/test/FillUtils.ts
+++ b/test/FillUtils.ts
@@ -1,6 +1,6 @@
 import { DepositWithBlock, FillType, FillWithBlock } from "../src/interfaces";
 import { bnOne, bnZero, toBN, toAddressType } from "../src/utils";
-import { ZERO_ADDRESS, ZERO_BYTES } from "../src/constants";
+import { CHAIN_IDs, ZERO_ADDRESS, ZERO_BYTES } from "../src/constants";
 import { originChainId, destinationChainId, repaymentChainId } from "./constants";
 import {
   createSpyLogger,
@@ -152,6 +152,19 @@ describe("FillUtils", function () {
             ...fill,
             relayer: toAddressType(blockedAddress.toNative(), repaymentChainId),
           };
+          const result = await verifyFillRepayment(blockedFill, spokeProvider, deposit, hubPoolClient, 0);
+          expect(result).to.be.undefined;
+        }
+      });
+      it("Repayment address is blocked when typed for a TVM chain; fill is unrepayable", async function () {
+        // The blocklist holds EvmAddress entries, but a relayer typed for a TVM chain renders as TRON base58. The
+        // check must match on the underlying bytes rather than the native encoding.
+        for (const blockedAddress of BLOCKED_ADDRESSES) {
+          const tvmRelayer = toAddressType(blockedAddress.toNative(), CHAIN_IDs.TRON);
+          expect(tvmRelayer.isTVM()).to.be.true;
+          expect(tvmRelayer.toNative()).to.not.equal(blockedAddress.toNative());
+
+          const blockedFill = { ...fill, relayer: tvmRelayer };
           const result = await verifyFillRepayment(blockedFill, spokeProvider, deposit, hubPoolClient, 0);
           expect(result).to.be.undefined;
         }


### PR DESCRIPTION
Closes [BOU-72](https://linear.app/uma/issue/BOU-72).

`Address.eq()` compared `this.toString() === other.toString()`, and `toString()` resolves to the family-specific native encoding: `EvmAddress` renders checksummed `0x…` hex while `TvmAddress` renders TRON Base58Check for the same 20 raw bytes. Since `toAddressType()` picks the family from the chainId alone, the same account compares **unequal** depending on which chain it happened to be typed for.

The visible consequence is that `BLOCKED_ADDRESSES` (an `EvmAddress[]`) never matches a relayer, depositor or recipient typed for a TVM chain, so a blocked account can take a repayment, an expired-deposit refund or a slow fill by using a TRON chainId. `fill.relayer` is typed by `repaymentChainId` (`SpokeUtils.ts:108`), `deposit.depositor` by `originChainId` and `deposit.recipient` by `destinationChainId`, so all three checks (`FillUtils.ts:160`, `BundleDataClient.ts:76,160`) are currently no-ops on TRON.

This defines equality on the raw bytes instead, by delegating to `compare()`. Family remains observable via `isEVM()`/`isSVM()`/`isTVM()` and `toNative()`.

## This is live, not theoretical

TRON is a production chain (`728126428`, spoke `TTbCVPfUZmPhrB9sYC8GKgGBQQEdZovkmS`), first TRON-origin deposit 2026-03-30. From the indexer: 690 deposits originating on TRON, 407 to TRON, and **460 fills repaid on TRON in the last 45 days** — every one of which passed a blocklist check that could not have matched.

One relayer, same 45 days, `evm.filled_v3_relay`:

| stored relayer | repayment chain | fills |
|---|---|---|
| `0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67` | mainnet | 86,084 |
| `0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67` | Base / Arbitrum / +18 more | ~140,000 |
| `TAfpoKQJfPiLa9AAkEk8CogM9GBTLBeoqH` | TRON | 457 |

Those are the same 20 bytes. Each row is stored in the form intended for its repayment chain — neither is wrong, which is exactly why the comparison fails. Blocklisting that operator today would stop 20 chains' worth of repayments and let the TRON ones through.

## Behaviour delta

Comparisons that previously returned `false` now return `true` when two instances hold identical bytes but were built as different subclasses. **Nothing that returned `true` becomes `false`**, so no comparison can start failing — only start succeeding.

| case | before | after |
|---|---|---|
| EVM vs TVM, same 20 bytes | false | **true** |
| EVM vs Raw, same bytes | false | **true** |
| TVM vs Raw, same bytes | false | **true** |
| EVM zero vs SVM zero | false | **true** |
| EVM vs SVM, different bytes | false | false |
| EVM vs EVM, same bytes | true | true |
| anything vs `undefined` | false | false |

EVM↔SVM can only collide at the zero address, since `SvmAddress.validate()` rejects top-12-zero except all-zero. Both encodings are the "unset" sentinel in Across — `arch/svm` re-exports the System Program address as `SVM_DEFAULT_ADDRESS` and uses it for an unset `exclusiveRelayer` — so matching is the intended result there. Pinned in a test rather than left implicit.

Note `compare()` is not `undefined`-safe while `eq(other?: Address)` is, hence the `isDefined` guard rather than a bare delegation.

## Downstream: two operator-visible relayer changes

No code in the SDK, relayer, indexer or quote-api relies on the old family-sensitive `false` — family dispatch is consistently done with `isEVM()`/`isSVM()`/`isValidOn()`, and the indexer and quote-api never call `Address.eq()` at all. But the relayer has four latent TRON bugs that this silently fixes, two of which change bot behaviour the moment the SDK is bumped and should go in the release notes:

- **`Relayer.ts:264,843`** — on TRON destinations the relayer never recognised itself as the exclusive relayer, so it skipped its own exclusivity window. It will now fill TRON deposits during its own exclusivity period.
- **`Relayer.ts:831`** — `SLOW_DEPOSITORS` greylisting silently did not apply to TRON-origin deposits. Hex entries will now match them.
- `OFTBridge.ts:173` / `OFTL2Bridge.ts:215` — `isAssociatedSpokePool` was always false on TRON, so `CrossChainTransferClient` reported zero outstanding HubPool↔TRON USDT and `checkStuckRebalances` was blind to in-flight TRON rebalances.
- `BaseBridgeAdapter.ts:80` / `BaseL2BridgeAdapter.ts:93` — `isPoolMonitoringAddress` now short-circuits correctly for TRON, which also avoids a downstream `EvmAddress.from(address.toNative())` that would throw on a `TvmAddress`.

Worth a minor version bump given the behavioural change for consumers.

## Why fix `eq()` rather than the three call sites

`eq()` was a raw-byte comparison when it was written: in #909 `toString()` returned `toHexString()` → `toBytes32()`, and the subclasses overrode only `toAddress()`. #1092 repointed `toString()` at `toNative()` as part of the `toAddress()` → `toNative()` rename, which silently changed `eq()`'s semantics — the comment above `toString()` was left describing the old behaviour, which is corrected here. #1358 then moved `compare()` onto raw bytes without migrating `eq()`. So this restores the original intent and puts identity back on the one primitive that already had it.

The broader reason: the failing shape is "one account, two chain contexts", which recurs beyond the blocklist — chain-agnostic policy lists, operator config (`SLOW_DEPOSITORS` is parsed as `toAddressType(x, hex ? MAINNET : SOLANA)`), a bot's own key spanning every chain, and contracts recorded in L1 events but used on L2. A call site has no way to express "compare these as accounts" other than by picking the right method. The genuinely family-aware question — "can this address be used on chain X" — is `isValidOn()`, which both repos already use correctly and which is untouched here.

## Testing

- `verifyFillRepayment` regression test: a blocked address typed for `CHAIN_IDs.TRON` makes the fill unrepayable. Fails on master, passes here.
- `eq()` cases for EVM↔TVM, 20-byte vs zero-padded 32-byte, and the cross-family zero address.
- Rewrote the `Returns false when comparing EVM and SVM addresses` test, whose stated intent ("cross-type equality is not expected") this change invalidates. It passed either way since the bytes differ.
- 379 passing, `yarn lint-check` clean.

Not run locally: `Solana.*`, `SVMSpokePoolClient.fills` and `relayFeeCalculator.test` need a `solana-test-validator` binary that wasn't available in my environment, and its root hook aborts the whole `yarn test` run. **Those need a CI check before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)