### PR TITLE
improve(svm): Replace type assertions with real narrowing

### DIFF
--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -87,7 +87,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
     }
 
     // Find the index where the slot would be inserted and use that as the end slot (since it is >= the timestamp).
-    const index = sortedIndexBy(this.blocks, { timestamp } as Block, "timestamp");
+    const index = sortedIndexBy<Pick<Block, "timestamp">>(this.blocks, { timestamp }, "timestamp");
     return this.findBlock(this.blocks[index - 1], this.blocks[index], timestamp);
   }
 
@@ -118,7 +118,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
 
   // Grabs the slot for a particular number and caches it.
   private async getBlock(number: number): Promise<SVMBlock> {
-    let index = sortedIndexBy(this.blocks, { number } as Block, "number");
+    let index = sortedIndexBy<Pick<Block, "number">>(this.blocks, { number }, "number");
     if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
 
     // The resolved slot may be rotated backwards if no timestamp exists at the requested slot.
@@ -131,7 +131,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
     };
 
     // Recompute the index after the async call since the state of this.blocks could have changed!
-    index = sortedIndexBy(this.blocks, { number: slot } as Block, "number");
+    index = sortedIndexBy<Pick<Block, "number">>(this.blocks, { number: slot }, "number");
 
     // Rerun this check to avoid duplicate insertion.
     if (this.blocks[index]?.number === slot) return this.blocks[index];

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,7 +40,6 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
-import { define, is, type } from "superstruct";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
@@ -54,7 +53,6 @@ import {
   chainIsSvm,
   chunk,
   getMessageHash,
-  isByteArray,
   isDefined,
   isUnsafeDepositId,
   keccak256,
@@ -218,12 +216,6 @@ export function getDepositIdAtBlock(_contract: unknown, _blockTag: number): Prom
   throw new Error("getDepositIdAtBlock: not implemented");
 }
 
-// A 32-byte array event field, decoded as either Uint8Array or number[] depending on the decoder.
-const Bytes32 = define<Uint8Array | number[]>("Bytes32", (value) => isByteArray(value) && value.length === 32);
-// The subset of decoded FundsDeposited event data needed to identify a deposit. type() (rather than
-// object()) tolerates the remaining event fields.
-const DepositIdEventData = type({ depositId: Bytes32 });
-
 /**
  * Finds deposit events within a 2-day window ending at the specified slot.
  *
@@ -278,10 +270,9 @@ export async function findDeposit(
   const slotsInElapsed = BigInt(Math.round((secondsLookback * 1000) / SLOT_DURATION_MS));
   const startSlot = endSlot - slotsInElapsed;
 
-  // Query for the deposit events with this limited slot range. Filter by deposit id, which is decoded from the
-  // event as a 32-byte array (BigNumber.eq() accepts the big-endian byte representation directly).
-  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find(
-    ({ data }) => is(data, DepositIdEventData) && depositId.eq(data.depositId)
+  // Query for the deposit events with this limited slot range. Filter by deposit id.
+  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find((event) =>
+    depositId.eq((event.data as unknown as { depositId: BigNumber }).depositId)
   );
 
   // If no deposit event is found, return undefined

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,16 +40,10 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
+import { define, is, type } from "superstruct";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
-import {
-  DepositWithBlock,
-  FillStatus,
-  FillWithBlock,
-  RelayData,
-  RelayDataWithMessageHash,
-  SortableEvent,
-} from "../../interfaces";
+import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
 import {
   BigNumber,
   EvmAddress,
@@ -60,6 +54,7 @@ import {
   chainIsSvm,
   chunk,
   getMessageHash,
+  isByteArray,
   isDefined,
   isUnsafeDepositId,
   keccak256,
@@ -223,6 +218,12 @@ export function getDepositIdAtBlock(_contract: unknown, _blockTag: number): Prom
   throw new Error("getDepositIdAtBlock: not implemented");
 }
 
+// A 32-byte array event field, decoded as either Uint8Array or number[] depending on the decoder.
+const Bytes32 = define<Uint8Array | number[]>("Bytes32", (value) => isByteArray(value) && value.length === 32);
+// The subset of decoded FundsDeposited event data needed to identify a deposit. type() (rather than
+// object()) tolerates the remaining event fields.
+const DepositIdEventData = type({ depositId: Bytes32 });
+
 /**
  * Finds deposit events within a 2-day window ending at the specified slot.
  *
@@ -277,9 +278,10 @@ export async function findDeposit(
   const slotsInElapsed = BigInt(Math.round((secondsLookback * 1000) / SLOT_DURATION_MS));
   const startSlot = endSlot - slotsInElapsed;
 
-  // Query for the deposit events with this limited slot range. Filter by deposit id.
-  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find((event) =>
-    depositId.eq((event.data as unknown as { depositId: BigNumber }).depositId)
+  // Query for the deposit events with this limited slot range. Filter by deposit id, which is decoded from the
+  // event as a 32-byte array (BigNumber.eq() accepts the big-endian byte representation directly).
+  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find(
+    ({ data }) => is(data, DepositIdEventData) && depositId.eq(data.depositId)
   );
 
   // If no deposit event is found, return undefined
@@ -483,8 +485,11 @@ export async function findFillEvent(
     return;
   }
 
-  const rawFill = unwrapEventData<SortableEvent>(rawEvent.data, ["depositId", "inputAmount"]);
-  const fill = unpackFillEvent(rawFill, destinationChainId);
+  // SortableEvent fields are sourced from the transaction envelope; only the fill fields come from event data.
+  const blockNumber = Number(rawEvent.slot);
+  const txnRef = rawEvent.signature.toString();
+  const rawFill = unwrapEventData(rawEvent.data, ["depositId", "inputAmount"]);
+  const fill = unpackFillEvent({ ...rawFill, blockNumber, txnRef, txnIndex: 0, logIndex: 0 }, destinationChainId);
   return fill satisfies FillWithBlock;
 }
 
@@ -1016,11 +1021,6 @@ async function resolveFillStatusFromPdaEvents(
     )
   ).flat();
 
-  if (relevantEvents.length === 0) {
-    // No fill or requested slow fill events found for this PDA
-    return FillStatus.Unfilled;
-  }
-
   // Sort events in ascending order of slot number
   relevantEvents.sort((a, b) => Number(a.slot - b.slot));
 
@@ -1028,13 +1028,18 @@ async function resolveFillStatusFromPdaEvents(
   // since it's not possible to submit a slow fill request once a fill has been submitted,
   // we can use the last event in the list to determine the fill status at the requested slot.
   const fillStatusEvent = relevantEvents.pop();
-  switch (fillStatusEvent!.name) {
+  if (!isDefined(fillStatusEvent)) {
+    // No fill or requested slow fill events found for this PDA
+    return FillStatus.Unfilled;
+  }
+
+  switch (fillStatusEvent.name) {
     case SVMEventNames.FilledRelay:
       return FillStatus.Filled;
     case SVMEventNames.RequestedSlowFill:
       return FillStatus.RequestedSlowFill;
     default:
-      throw new Error(`Unexpected event name: ${fillStatusEvent!.name}`);
+      throw new Error(`Unexpected event name: ${fillStatusEvent.name}`);
   }
 }
 

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -98,7 +98,7 @@ export class SvmCpiEventsClient {
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options);
-    return events.filter((event) => event.name === eventName) as EventWithData[];
+    return events.filter((event) => event.name === eventName);
   }
 
   /**
@@ -118,7 +118,7 @@ export class SvmCpiEventsClient {
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options, derivedAddress);
-    return events.filter((event) => event.name === eventName) as EventWithData[];
+    return events.filter((event) => event.name === eventName);
   }
 
   /**
@@ -143,7 +143,7 @@ export class SvmCpiEventsClient {
 
     while (hasMoreSignatures) {
       const signatures: GetSignaturesForAddressApiResponse = await this.rpc
-        .getSignaturesForAddress(addressToQuery!, currentOptions)
+        .getSignaturesForAddress(addressToQuery, currentOptions)
         .send();
       // Signatures are sorted by slot in descending order.
       allSignatures.push(...signatures);

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -144,7 +144,8 @@ function snakeToCamel(s: string): string {
  * Gets the event name from a raw name.
  */
 function isEventName(name: string): name is EventName {
-  return name in SVMEventNames;
+  // Own-property check only; `in` would also match inherited keys like "toString" or "constructor".
+  return Object.hasOwn(SVMEventNames, name);
 }
 
 export function getEventName(rawName: string): EventName {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -25,7 +25,7 @@ import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefined } from "../../utils";
+import { BigNumber, Address as SdkAddress, getMessageHash, isDefined, isUint8Array } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -197,8 +197,8 @@ function unwrapEventDataInner(
     return BigNumber.from(data);
   }
   // Handle Uint8Array and byte arrays
-  if (isByteArray(data)) {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (data instanceof Uint8Array || isUint8Array(data)) {
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as number[]);
     const hex = ethers.utils.hexlify(bytes);
     if (currentKey && uint8ArrayKeysAsBigInt.includes(currentKey)) {
       return BigNumber.from(hex);

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -25,7 +25,7 @@ import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, getMessageHash, isDefined, isUint8Array } from "../../utils";
+import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefined } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -61,8 +61,8 @@ export async function isDevnet(rpc: SVMProvider): Promise<boolean> {
 /**
  * Small utility to convert an Address to a Solana Kit branded type.
  */
-export function toAddress(address: SdkAddress): Address<string> {
-  return address.toBase58() as Address<string>;
+export function toAddress(sdkAddress: SdkAddress): Address<string> {
+  return address(sdkAddress.toBase58());
 }
 
 /**
@@ -143,8 +143,12 @@ function snakeToCamel(s: string): string {
 /**
  * Gets the event name from a raw name.
  */
+function isEventName(name: string): name is EventName {
+  return name in SVMEventNames;
+}
+
 export function getEventName(rawName: string): EventName {
-  if (Object.values(SVMEventNames).some((name) => rawName.includes(name))) return rawName as EventName;
+  if (isEventName(rawName)) return rawName;
   throw new Error(`Unknown event name: ${rawName}`);
 }
 
@@ -192,8 +196,8 @@ function unwrapEventDataInner(
     return BigNumber.from(data);
   }
   // Handle Uint8Array and byte arrays
-  if (data instanceof Uint8Array || isUint8Array(data)) {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as number[]);
+  if (isByteArray(data)) {
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
     const hex = ethers.utils.hexlify(bytes);
     if (currentKey && uint8ArrayKeysAsBigInt.includes(currentKey)) {
       return BigNumber.from(hex);
@@ -209,7 +213,7 @@ function unwrapEventDataInner(
     return ethers.utils.hexlify(bs58.decode(data));
   }
   // Handle objects
-  if (typeof data === "object") {
+  if (isUnwrappedRecord(data)) {
     // Special case: if an object is in the context of the fillType key, then
     // parse out the fillType from the object
     if (currentKey === "fillType") {
@@ -231,10 +235,7 @@ function unwrapEventDataInner(
       return "0x";
     }
     return Object.fromEntries(
-      Object.entries(data as Record<string, unknown>).map(([key, value]) => [
-        key,
-        unwrapEventDataInner(value, uint8ArrayKeysAsBigInt, key),
-      ])
+      Object.entries(data).map(([key, value]) => [key, unwrapEventDataInner(value, uint8ArrayKeysAsBigInt, key)])
     );
   }
   // Return primitives as is
@@ -412,11 +413,11 @@ export const createDefaultTransaction = async (
   signer: TransactionSigner,
   latestBlockhash?: LatestBlockhash
 ): Promise<SolanaTransaction> => {
-  latestBlockhash = isDefined(latestBlockhash) ? latestBlockhash : (await rpcClient.getLatestBlockhash().send()).value;
+  const blockhash = latestBlockhash ?? (await rpcClient.getLatestBlockhash().send()).value;
   return pipe(
     createTransactionMessage({ version: 0 }),
     (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash!, tx)
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(blockhash, tx)
   );
 };
 
@@ -428,13 +429,13 @@ export const createDefaultTransaction = async (
  * @param parser - The parser function to decode the result.
  * @returns The decoded result.
  */
-export const simulateAndDecode = async <P extends (buf: Buffer) => unknown>(
+export const simulateAndDecode = async <T>(
   solanaClient: SVMProvider,
   ix: Instruction,
   signer: KeyPairSigner,
-  parser: P,
+  parser: (buf: Buffer) => T,
   latestBlockhash?: LatestBlockhash
-): Promise<ReturnType<P>> => {
+): Promise<T> => {
   const simulationTx = appendTransactionMessageInstruction(
     ix,
     await createDefaultTransaction(solanaClient, signer, latestBlockhash)
@@ -450,7 +451,7 @@ export const simulateAndDecode = async <P extends (buf: Buffer) => unknown>(
     throw new Error("svm::simulateAndDecode: simulateTransaction failed. No return data.");
   }
 
-  return parser(Buffer.from(simulationResult.value.returnData.data[0], "base64")) as ReturnType<P>;
+  return parser(Buffer.from(simulationResult.value.returnData.data[0], "base64"));
 };
 
 /**

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -3,6 +3,7 @@ import winston from "winston";
 import {
   SVMEventNames,
   unwrapEventData,
+  getEventName,
   getFillDeadline,
   getTimestampForSlot,
   getStatePda,
@@ -128,7 +129,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
 
       const _searchConfig = { ...searchConfig }; // shallow copy
 
-      return _searchConfig as EventSearchConfig;
+      return _searchConfig;
     });
 
     const spokePoolAddress = this.svmEventsClient.getProgramAddress();
@@ -146,7 +147,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
       ...eventsToQuery.map(async (eventName, idx) => {
         const config = eventSearchConfigs[idx];
         const events = await this.svmEventsClient.queryEvents(
-          eventName as SVMEventNames,
+          getEventName(eventName),
           BigInt(config.from),
           BigInt(config.to),
           {

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -16,6 +16,7 @@ import {
   SvmCpiEventsClient,
   SVMEventNames,
   SVMProvider,
+  getEventName,
   getRandomSvmAddress,
   bigToU8a32,
 } from "../../arch/svm";
@@ -25,7 +26,7 @@ import { FillType } from "../../interfaces";
 const randomBytes = (n: number) => ethersUtils.hexlify(ethersUtils.randomBytes(n));
 
 export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
-  private events: Record<EventName, EventWithData[]> = {} as Record<EventName, EventWithData[]>;
+  private events: Partial<Record<EventName, EventWithData[]>> = {};
   private slotHeight: bigint = BigInt(0);
   public chainId: number;
   public minBlockRange = 10;
@@ -42,8 +43,8 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
 
   public setEvents(events: EventWithData[]) {
     for (const event of events) {
-      this.events[event.name as EventName] ??= [];
-      this.events[event.name as EventName].push(event);
+      const eventName = getEventName(event.name);
+      (this.events[eventName] ??= []).push(event);
     }
     const maxSlot = Math.max(...events.map((event) => Number(event.slot)));
     this.setSlotHeight(BigInt(maxSlot) + BigInt(1));
@@ -53,7 +54,7 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     if (name) {
       this.events[name] = [];
     } else {
-      this.events = {} as Record<EventName, EventWithData[]>;
+      this.events = {};
     }
   }
 

--- a/src/clients/mocks/MockSvmSpokePoolClient.ts
+++ b/src/clients/mocks/MockSvmSpokePoolClient.ts
@@ -16,7 +16,7 @@ import { HubPoolClient } from "../HubPoolClient";
 import { EventOverrides } from "./MockEvents";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
 import { MockSvmCpiEventsClient } from "./MockSvmCpiEventsClient";
-import { EventWithData, SvmCpiEventsClient, SVMEventNames, unwrapEventData } from "../../arch/svm";
+import { EventWithData, getEventName, SvmCpiEventsClient, unwrapEventData } from "../../arch/svm";
 
 // This class replaces internal SpokePoolClient functionality, enabling
 // the user to bypass on-chain queries and inject events directly.
@@ -69,7 +69,7 @@ export class MockSvmSpokePoolClient extends SVMSpokePoolClient {
 
     // Get events from the mock event client.
     const events: EventWithData[][] = await Promise.all(
-      eventsToQuery.map((eventName) => this.mockEventsClient.queryEvents(eventName as SVMEventNames, BigInt(from), to))
+      eventsToQuery.map((eventName) => this.mockEventsClient.queryEvents(getEventName(eventName), BigInt(from), to))
     );
 
     const eventsWithBlockNumber = events.map((eventList) =>

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -170,25 +170,11 @@ export function isArrayOf<T>(array: unknown, predicate: (value: unknown) => valu
 }
 
 /**
- * Checks whether a value is a byte array in either of its decoded representations: a Uint8Array, or a
- * non-empty plain array of integers in [0, 255] (as produced for fixed byte-array fields by Anchor borsh
- * decoding). An empty plain array is not considered a byte array, since it is indistinguishable from an
- * empty list.
+ * Checks if a value is a Uint8Array.
  * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
+ * @returns True if the value is a Uint8Array, false otherwise.
  */
-export function isByteArray(value: unknown): value is Uint8Array | number[] {
-  return value instanceof Uint8Array || isUint8Array(value);
-}
-
-/**
- * Checks if a value is a byte array: a plain array of integers in [0, 255], as produced for fixed byte-array
- * fields by Anchor borsh decoding. Note that this deliberately matches number[] and NOT Uint8Array instances;
- * prefer isByteArray(), which matches both representations.
- * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
- */
-export function isUint8Array(value: unknown): value is number[] {
+export function isUint8Array(value: unknown): value is Uint8Array {
   return (
     Array.isArray(value) &&
     value.length > 0 &&

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -170,11 +170,25 @@ export function isArrayOf<T>(array: unknown, predicate: (value: unknown) => valu
 }
 
 /**
- * Checks if a value is a Uint8Array.
+ * Checks whether a value is a byte array in either of its decoded representations: a Uint8Array, or a
+ * non-empty plain array of integers in [0, 255] (as produced for fixed byte-array fields by Anchor borsh
+ * decoding). An empty plain array is not considered a byte array, since it is indistinguishable from an
+ * empty list.
  * @param value The value to check.
- * @returns True if the value is a Uint8Array, false otherwise.
+ * @returns True if the value is a byte array, false otherwise.
  */
-export function isUint8Array(value: unknown): value is Uint8Array {
+export function isByteArray(value: unknown): value is Uint8Array | number[] {
+  return value instanceof Uint8Array || isUint8Array(value);
+}
+
+/**
+ * Checks if a value is a byte array: a plain array of integers in [0, 255], as produced for fixed byte-array
+ * fields by Anchor borsh decoding. Note that this deliberately matches number[] and NOT Uint8Array instances;
+ * prefer isByteArray(), which matches both representations.
+ * @param value The value to check.
+ * @returns True if the value is a byte array, false otherwise.
+ */
+export function isUint8Array(value: unknown): value is number[] {
   return (
     Array.isArray(value) &&
     value.length > 0 &&

--- a/test/Solana.getEventName.unit.test.ts
+++ b/test/Solana.getEventName.unit.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { getEventName, SVMEventNames } from "../src/arch/svm";
+
+/**
+ * Regression test for `getEventName` narrowing.
+ *
+ * The guard behind `getEventName` must test for an *own* property of `SVMEventNames`. An earlier
+ * revision used `name in SVMEventNames`, which also matches keys inherited from `Object.prototype`
+ * ("toString", "constructor", ...). That made `getEventName` return an unknown name instead of
+ * throwing, so a bogus name could reach `SvmCpiEventsClient.queryEvents()` as a real event name and
+ * `MockSvmCpiEventsClient.setEvents()` would blow up dereferencing the inherited value as an array.
+ */
+describe("getEventName", () => {
+  it("accepts every declared event name", () => {
+    for (const name of Object.keys(SVMEventNames)) {
+      expect(getEventName(name)).to.equal(name);
+    }
+  });
+
+  it("rejects keys inherited from Object.prototype", () => {
+    for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty", "isPrototypeOf", "__proto__"]) {
+      expect(() => getEventName(name)).to.throw(`Unknown event name: ${name}`);
+    }
+  });
+
+  it("rejects unknown and partially-matching event names", () => {
+    for (const name of ["", "Bogus", "filledrelay", "FilledRelayX", "XFilledRelay"]) {
+      expect(() => getEventName(name)).to.throw(`Unknown event name: ${name}`);
+    }
+  });
+});


### PR DESCRIPTION
Replace lying casts/guards in the SVM event pipeline with honest predicates. Behaviour changes:
- findFillEvent: populate blockNumber/txnRef from the tx envelope (were undefined at runtime).
- getEventName: exact match; unknown event names now throw at the query boundary.

Groundwork for typed SVM event decoding (codama decoders follow separately).