### PR TITLE
improve(svm): Decode SvmSpoke and CCTP events with the generated codama decoders

### DIFF
--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -87,7 +87,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
     }
 
     // Find the index where the slot would be inserted and use that as the end slot (since it is >= the timestamp).
-    const index = sortedIndexBy(this.blocks, { timestamp } as Block, "timestamp");
+    const index = sortedIndexBy<Pick<Block, "timestamp">>(this.blocks, { timestamp }, "timestamp");
     return this.findBlock(this.blocks[index - 1], this.blocks[index], timestamp);
   }
 
@@ -118,7 +118,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
 
   // Grabs the slot for a particular number and caches it.
   private async getBlock(number: number): Promise<SVMBlock> {
-    let index = sortedIndexBy(this.blocks, { number } as Block, "number");
+    let index = sortedIndexBy<Pick<Block, "number">>(this.blocks, { number }, "number");
     if (this.blocks[index]?.number === number) return this.blocks[index]; // Return early if block already exists.
 
     // The resolved slot may be rotated backwards if no timestamp exists at the requested slot.
@@ -131,7 +131,7 @@ export class SVMBlockFinder extends BlockFinder<SVMBlock> {
     };
 
     // Recompute the index after the async call since the state of this.blocks could have changed!
-    index = sortedIndexBy(this.blocks, { number: slot } as Block, "number");
+    index = sortedIndexBy<Pick<Block, "number">>(this.blocks, { number: slot }, "number");
 
     // Rerun this check to avoid duplicate insertion.
     if (this.blocks[index]?.number === slot) return this.blocks[index];

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,7 +40,6 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
-import { define, is, type } from "superstruct";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
@@ -54,7 +53,6 @@ import {
   chainIsSvm,
   chunk,
   getMessageHash,
-  isByteArray,
   isDefined,
   isUnsafeDepositId,
   keccak256,
@@ -218,12 +216,6 @@ export function getDepositIdAtBlock(_contract: unknown, _blockTag: number): Prom
   throw new Error("getDepositIdAtBlock: not implemented");
 }
 
-// A 32-byte array event field, decoded as either Uint8Array or number[] depending on the decoder.
-const Bytes32 = define<Uint8Array | number[]>("Bytes32", (value) => isByteArray(value) && value.length === 32);
-// The subset of decoded FundsDeposited event data needed to identify a deposit. type() (rather than
-// object()) tolerates the remaining event fields.
-const DepositIdEventData = type({ depositId: Bytes32 });
-
 /**
  * Finds deposit events within a 2-day window ending at the specified slot.
  *
@@ -278,10 +270,9 @@ export async function findDeposit(
   const slotsInElapsed = BigInt(Math.round((secondsLookback * 1000) / SLOT_DURATION_MS));
   const startSlot = endSlot - slotsInElapsed;
 
-  // Query for the deposit events with this limited slot range. Filter by deposit id, which is decoded from the
-  // event as a 32-byte array (BigNumber.eq() accepts the big-endian byte representation directly).
-  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find(
-    ({ data }) => is(data, DepositIdEventData) && depositId.eq(data.depositId)
+  // Query for the deposit events with this limited slot range. Filter by deposit id.
+  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find((event) =>
+    depositId.eq((event.data as unknown as { depositId: BigNumber }).depositId)
   );
 
   // If no deposit event is found, return undefined

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,16 +40,10 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
+import { define, is, type } from "superstruct";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
-import {
-  DepositWithBlock,
-  FillStatus,
-  FillWithBlock,
-  RelayData,
-  RelayDataWithMessageHash,
-  SortableEvent,
-} from "../../interfaces";
+import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
 import {
   BigNumber,
   EvmAddress,
@@ -60,6 +54,7 @@ import {
   chainIsSvm,
   chunk,
   getMessageHash,
+  isByteArray,
   isDefined,
   isUnsafeDepositId,
   keccak256,
@@ -223,6 +218,12 @@ export function getDepositIdAtBlock(_contract: unknown, _blockTag: number): Prom
   throw new Error("getDepositIdAtBlock: not implemented");
 }
 
+// A 32-byte array event field, decoded as either Uint8Array or number[] depending on the decoder.
+const Bytes32 = define<Uint8Array | number[]>("Bytes32", (value) => isByteArray(value) && value.length === 32);
+// The subset of decoded FundsDeposited event data needed to identify a deposit. type() (rather than
+// object()) tolerates the remaining event fields.
+const DepositIdEventData = type({ depositId: Bytes32 });
+
 /**
  * Finds deposit events within a 2-day window ending at the specified slot.
  *
@@ -277,9 +278,10 @@ export async function findDeposit(
   const slotsInElapsed = BigInt(Math.round((secondsLookback * 1000) / SLOT_DURATION_MS));
   const startSlot = endSlot - slotsInElapsed;
 
-  // Query for the deposit events with this limited slot range. Filter by deposit id.
-  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find((event) =>
-    depositId.eq((event.data as unknown as { depositId: BigNumber }).depositId)
+  // Query for the deposit events with this limited slot range. Filter by deposit id, which is decoded from the
+  // event as a 32-byte array (BigNumber.eq() accepts the big-endian byte representation directly).
+  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find(
+    ({ data }) => is(data, DepositIdEventData) && depositId.eq(data.depositId)
   );
 
   // If no deposit event is found, return undefined
@@ -483,8 +485,11 @@ export async function findFillEvent(
     return;
   }
 
-  const rawFill = unwrapEventData<SortableEvent>(rawEvent.data, ["depositId", "inputAmount"]);
-  const fill = unpackFillEvent(rawFill, destinationChainId);
+  // SortableEvent fields are sourced from the transaction envelope; only the fill fields come from event data.
+  const blockNumber = Number(rawEvent.slot);
+  const txnRef = rawEvent.signature.toString();
+  const rawFill = unwrapEventData(rawEvent.data, ["depositId", "inputAmount"]);
+  const fill = unpackFillEvent({ ...rawFill, blockNumber, txnRef, txnIndex: 0, logIndex: 0 }, destinationChainId);
   return fill satisfies FillWithBlock;
 }
 
@@ -1016,11 +1021,6 @@ async function resolveFillStatusFromPdaEvents(
     )
   ).flat();
 
-  if (relevantEvents.length === 0) {
-    // No fill or requested slow fill events found for this PDA
-    return FillStatus.Unfilled;
-  }
-
   // Sort events in ascending order of slot number
   relevantEvents.sort((a, b) => Number(a.slot - b.slot));
 
@@ -1028,13 +1028,18 @@ async function resolveFillStatusFromPdaEvents(
   // since it's not possible to submit a slow fill request once a fill has been submitted,
   // we can use the last event in the list to determine the fill status at the requested slot.
   const fillStatusEvent = relevantEvents.pop();
-  switch (fillStatusEvent!.name) {
+  if (!isDefined(fillStatusEvent)) {
+    // No fill or requested slow fill events found for this PDA
+    return FillStatus.Unfilled;
+  }
+
+  switch (fillStatusEvent.name) {
     case SVMEventNames.FilledRelay:
       return FillStatus.Filled;
     case SVMEventNames.RequestedSlowFill:
       return FillStatus.RequestedSlowFill;
     default:
-      throw new Error(`Unexpected event name: ${fillStatusEvent!.name}`);
+      throw new Error(`Unexpected event name: ${fillStatusEvent.name}`);
   }
 }
 

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -98,7 +98,7 @@ export class SvmCpiEventsClient {
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options);
-    return events.filter((event) => event.name === eventName) as EventWithData[];
+    return events.filter((event) => event.name === eventName);
   }
 
   /**
@@ -118,7 +118,7 @@ export class SvmCpiEventsClient {
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options, derivedAddress);
-    return events.filter((event) => event.name === eventName) as EventWithData[];
+    return events.filter((event) => event.name === eventName);
   }
 
   /**
@@ -143,7 +143,7 @@ export class SvmCpiEventsClient {
 
     while (hasMoreSignatures) {
       const signatures: GetSignaturesForAddressApiResponse = await this.rpc
-        .getSignaturesForAddress(addressToQuery!, currentOptions)
+        .getSignaturesForAddress(addressToQuery, currentOptions)
         .send();
       // Signatures are sorted by slot in descending order.
       allSignatures.push(...signatures);

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -144,7 +144,8 @@ function snakeToCamel(s: string): string {
  * Gets the event name from a raw name.
  */
 function isEventName(name: string): name is EventName {
-  return name in SVMEventNames;
+  // Own-property check only; `in` would also match inherited keys like "toString" or "constructor".
+  return Object.hasOwn(SVMEventNames, name);
 }
 
 export function getEventName(rawName: string): EventName {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,4 +1,11 @@
-import { MessageTransmitterClient, SvmSpokeClient, SvmSpokeIdl } from "@across-protocol/contracts";
+import {
+  MessageTransmitterClient,
+  MessageTransmitterIdl,
+  SvmSpokeClient,
+  SvmSpokeIdl,
+  TokenMessengerMinterClient,
+  TokenMessengerMinterIdl,
+} from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
 import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
 import {
@@ -150,6 +157,89 @@ const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
  * corresponding decoder generated from the program, so the decoded data matches the generated event types.
  * Events that cannot be identified are rejected.
  */
+// Per-program maps of CCTP event name to the event data type generated from the program. The decoder tables
+// below are typed against these maps, so a decoder registered under the wrong name is a compile error (up to
+// structural identity), and the completeness of each table against its IDL is pinned by a unit test.
+interface TokenMessengerMinterEvents {
+  OwnershipTransferStarted: TokenMessengerMinterClient.OwnershipTransferStarted;
+  OwnershipTransferred: TokenMessengerMinterClient.OwnershipTransferred;
+  DepositForBurn: TokenMessengerMinterClient.DepositForBurn;
+  MintAndWithdraw: TokenMessengerMinterClient.MintAndWithdraw;
+  RemoteTokenMessengerAdded: TokenMessengerMinterClient.RemoteTokenMessengerAdded;
+  RemoteTokenMessengerRemoved: TokenMessengerMinterClient.RemoteTokenMessengerRemoved;
+  SetTokenController: TokenMessengerMinterClient.SetTokenController;
+  PauserChanged: TokenMessengerMinterClient.PauserChanged;
+  SetBurnLimitPerMessage: TokenMessengerMinterClient.SetBurnLimitPerMessage;
+  LocalTokenAdded: TokenMessengerMinterClient.LocalTokenAdded;
+  LocalTokenRemoved: TokenMessengerMinterClient.LocalTokenRemoved;
+  TokenPairLinked: TokenMessengerMinterClient.TokenPairLinked;
+  TokenPairUnlinked: TokenMessengerMinterClient.TokenPairUnlinked;
+  Pause: TokenMessengerMinterClient.Pause;
+  Unpause: TokenMessengerMinterClient.Unpause;
+  TokenCustodyBurned: TokenMessengerMinterClient.TokenCustodyBurned;
+}
+
+interface MessageTransmitterEvents {
+  OwnershipTransferStarted: MessageTransmitterClient.OwnershipTransferStarted;
+  OwnershipTransferred: MessageTransmitterClient.OwnershipTransferred;
+  PauserChanged: MessageTransmitterClient.PauserChanged;
+  AttesterManagerUpdated: MessageTransmitterClient.AttesterManagerUpdated;
+  MessageReceived: MessageTransmitterClient.MessageReceived;
+  SignatureThresholdUpdated: MessageTransmitterClient.SignatureThresholdUpdated;
+  AttesterEnabled: MessageTransmitterClient.AttesterEnabled;
+  AttesterDisabled: MessageTransmitterClient.AttesterDisabled;
+  MaxMessageBodySizeUpdated: MessageTransmitterClient.MaxMessageBodySizeUpdated;
+  Pause: MessageTransmitterClient.Pause;
+  Unpause: MessageTransmitterClient.Unpause;
+}
+
+const tokenMessengerMinterEventDecoders: {
+  [N in keyof TokenMessengerMinterEvents]: () => Decoder<TokenMessengerMinterEvents[N]>;
+} = {
+  OwnershipTransferStarted: TokenMessengerMinterClient.getOwnershipTransferStartedDecoder,
+  OwnershipTransferred: TokenMessengerMinterClient.getOwnershipTransferredDecoder,
+  DepositForBurn: TokenMessengerMinterClient.getDepositForBurnDecoder,
+  MintAndWithdraw: TokenMessengerMinterClient.getMintAndWithdrawDecoder,
+  RemoteTokenMessengerAdded: TokenMessengerMinterClient.getRemoteTokenMessengerAddedDecoder,
+  RemoteTokenMessengerRemoved: TokenMessengerMinterClient.getRemoteTokenMessengerRemovedDecoder,
+  SetTokenController: TokenMessengerMinterClient.getSetTokenControllerDecoder,
+  PauserChanged: TokenMessengerMinterClient.getPauserChangedDecoder,
+  SetBurnLimitPerMessage: TokenMessengerMinterClient.getSetBurnLimitPerMessageDecoder,
+  LocalTokenAdded: TokenMessengerMinterClient.getLocalTokenAddedDecoder,
+  LocalTokenRemoved: TokenMessengerMinterClient.getLocalTokenRemovedDecoder,
+  TokenPairLinked: TokenMessengerMinterClient.getTokenPairLinkedDecoder,
+  TokenPairUnlinked: TokenMessengerMinterClient.getTokenPairUnlinkedDecoder,
+  Pause: TokenMessengerMinterClient.getPauseDecoder,
+  Unpause: TokenMessengerMinterClient.getUnpauseDecoder,
+  TokenCustodyBurned: TokenMessengerMinterClient.getTokenCustodyBurnedDecoder,
+};
+
+const messageTransmitterEventDecoders: {
+  [N in keyof MessageTransmitterEvents]: () => Decoder<MessageTransmitterEvents[N]>;
+} = {
+  OwnershipTransferStarted: MessageTransmitterClient.getOwnershipTransferStartedDecoder,
+  OwnershipTransferred: MessageTransmitterClient.getOwnershipTransferredDecoder,
+  PauserChanged: MessageTransmitterClient.getPauserChangedDecoder,
+  AttesterManagerUpdated: MessageTransmitterClient.getAttesterManagerUpdatedDecoder,
+  MessageReceived: MessageTransmitterClient.getMessageReceivedDecoder,
+  SignatureThresholdUpdated: MessageTransmitterClient.getSignatureThresholdUpdatedDecoder,
+  AttesterEnabled: MessageTransmitterClient.getAttesterEnabledDecoder,
+  AttesterDisabled: MessageTransmitterClient.getAttesterDisabledDecoder,
+  MaxMessageBodySizeUpdated: MessageTransmitterClient.getMaxMessageBodySizeUpdatedDecoder,
+  Pause: MessageTransmitterClient.getPauseDecoder,
+  Unpause: MessageTransmitterClient.getUnpauseDecoder,
+};
+
+// Codama decoders for the CCTP programs consumed through SvmCpiEventsClient, keyed by program (IDL) address,
+// alongside the bundled IDL each decoder set was generated from. Exported for the table-completeness unit tests.
+export const cctpPrograms: Record<
+  string,
+  { idl: Idl; eventDecoders: Record<string, () => Decoder<unknown>> } | undefined
+> = {
+  [TokenMessengerMinterIdl.address]: { idl: TokenMessengerMinterIdl, eventDecoders: tokenMessengerMinterEventDecoders },
+  [MessageTransmitterIdl.address]: { idl: MessageTransmitterIdl, eventDecoders: messageTransmitterEventDecoders },
+};
+
 export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
   // The generated decoders only apply to SvmSpoke events; any other program's events (e.g. the CCTP
   // TokenMessengerMinter and MessageTransmitter programs) are decoded generically below.
@@ -167,6 +257,23 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: 
 
     // Skip the discriminator; the event data follows it.
     return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+  }
+
+  // CCTP programs: decode with the generated codama decoders so that the decoded data matches the generated
+  // event types. The bundled decoders only apply when the caller supplied the exact bundled IDL instance: a
+  // program address is retained across IDL upgrades, so a different instance (e.g. from a skewed
+  // @across-protocol/contracts version) may carry updated event layouts that the bundled decoders would
+  // silently mis-decode. Any other IDL instance, and any event missing from a decoder table, falls through to
+  // the generic Anchor path below, which decodes per the supplied IDL.
+  const cctpProgram = cctpPrograms[idl.address];
+  if (isDefined(cctpProgram) && idl === cctpProgram.idl) {
+    const rawEventData = getBase64Encoder().encode(rawEvent);
+    const discriminator = rawEventData.subarray(0, 8);
+    const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
+    const decoder = isDefined(name) ? cctpProgram.eventDecoders[name] : undefined;
+    if (isDefined(name) && isDefined(decoder)) {
+      return { name, data: decoder().decode(rawEventData, discriminator.length) };
+    }
   }
 
   const event = new BorshEventCoder(idl).decode(rawEvent);

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,6 +1,6 @@
 import { MessageTransmitterClient, SvmSpokeClient, SvmSpokeIdl } from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
-import { BN, Idl } from "@coral-xyz/anchor";
+import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
 import {
   Address,
   Instruction,
@@ -150,23 +150,31 @@ const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
  * corresponding decoder generated from the program, so the decoded data matches the generated event types.
  * Events that cannot be identified are rejected.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name: EventName } {
-  // The generated decoders only apply to SvmSpoke events; any other program's events would be mis-decoded.
-  assert(idl.address === SvmSpokeIdl.address, `decodeEvent: unsupported IDL address ${idl.address}`);
+export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
+  // The generated decoders only apply to SvmSpoke events; any other program's events (e.g. the CCTP
+  // TokenMessengerMinter and MessageTransmitter programs) are decoded generically below.
+  if (idl.address === SvmSpokeIdl.address) {
+    // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
+    // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
+    // Uint8Array that the generated types promise.
+    const rawEventData = getBase64Encoder().encode(rawEvent);
+    const discriminator = rawEventData.subarray(0, 8);
+    const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
+    assert(
+      isDefined(name) && isEventName(name),
+      `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
+    );
 
-  // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
-  // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
-  // Uint8Array that the generated types promise.
-  const rawEventData = getBase64Encoder().encode(rawEvent);
-  const discriminator = rawEventData.subarray(0, 8);
-  const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
-  assert(
-    isDefined(name) && isEventName(name),
-    `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
-  );
+    // Skip the discriminator; the event data follows it.
+    return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+  }
 
-  // Skip the discriminator; the event data follows it.
-  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+  const event = new BorshEventCoder(idl).decode(rawEvent);
+  if (!event) throw new Error(`decodeEvent: malformed event for IDL ${idl.address}: ${rawEvent}`);
+  return {
+    name: event.name,
+    data: parseEventData(event.data),
+  };
 }
 
 /**

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -134,20 +134,59 @@ export function parseEventData(eventData: any): any {
 // Codama decoders generated from the SvmSpoke program, keyed by event name. Decoding with these (rather than the
 // generic Anchor BorshEventCoder) yields data that actually satisfies the generated event types: base58 Address
 // strings, bigint integers, Uint8Array byte arrays and numeric enums, with camelCase field names.
-const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
-  BridgedToHubPool: SvmSpokeClient.getBridgedToHubPoolDecoder,
-  TokensBridged: SvmSpokeClient.getTokensBridgedDecoder,
-  ExecutedRelayerRefundRoot: SvmSpokeClient.getExecutedRelayerRefundRootDecoder,
-  RelayedRootBundle: SvmSpokeClient.getRelayedRootBundleDecoder,
-  PausedDeposits: SvmSpokeClient.getPausedDepositsDecoder,
-  PausedFills: SvmSpokeClient.getPausedFillsDecoder,
-  SetXDomainAdmin: SvmSpokeClient.getSetXDomainAdminDecoder,
-  FilledRelay: SvmSpokeClient.getFilledRelayDecoder,
-  FundsDeposited: SvmSpokeClient.getFundsDepositedDecoder,
-  EmergencyDeletedRootBundle: SvmSpokeClient.getEmergencyDeletedRootBundleDecoder,
-  RequestedSlowFill: SvmSpokeClient.getRequestedSlowFillDecoder,
-  ClaimedRelayerRefund: SvmSpokeClient.getClaimedRelayerRefundDecoder,
-  TransferredOwnership: SvmSpokeClient.getTransferredOwnershipDecoder,
+const svmSpokeEventDecoders: Record<EventName, (payload: Uint8Array) => { name: string; data: EventData }> = {
+  BridgedToHubPool: (payload) => ({
+    name: SVMEventNames.BridgedToHubPool,
+    data: SvmSpokeClient.getBridgedToHubPoolDecoder().decode(payload),
+  }),
+  TokensBridged: (payload) => ({
+    name: SVMEventNames.TokensBridged,
+    data: SvmSpokeClient.getTokensBridgedDecoder().decode(payload),
+  }),
+  ExecutedRelayerRefundRoot: (payload) => ({
+    name: SVMEventNames.ExecutedRelayerRefundRoot,
+    data: SvmSpokeClient.getExecutedRelayerRefundRootDecoder().decode(payload),
+  }),
+  RelayedRootBundle: (payload) => ({
+    name: SVMEventNames.RelayedRootBundle,
+    data: SvmSpokeClient.getRelayedRootBundleDecoder().decode(payload),
+  }),
+  PausedDeposits: (payload) => ({
+    name: SVMEventNames.PausedDeposits,
+    data: SvmSpokeClient.getPausedDepositsDecoder().decode(payload),
+  }),
+  PausedFills: (payload) => ({
+    name: SVMEventNames.PausedFills,
+    data: SvmSpokeClient.getPausedFillsDecoder().decode(payload),
+  }),
+  SetXDomainAdmin: (payload) => ({
+    name: SVMEventNames.SetXDomainAdmin,
+    data: SvmSpokeClient.getSetXDomainAdminDecoder().decode(payload),
+  }),
+  FilledRelay: (payload) => ({
+    name: SVMEventNames.FilledRelay,
+    data: SvmSpokeClient.getFilledRelayDecoder().decode(payload),
+  }),
+  FundsDeposited: (payload) => ({
+    name: SVMEventNames.FundsDeposited,
+    data: SvmSpokeClient.getFundsDepositedDecoder().decode(payload),
+  }),
+  EmergencyDeletedRootBundle: (payload) => ({
+    name: SVMEventNames.EmergencyDeletedRootBundle,
+    data: SvmSpokeClient.getEmergencyDeletedRootBundleDecoder().decode(payload),
+  }),
+  RequestedSlowFill: (payload) => ({
+    name: SVMEventNames.RequestedSlowFill,
+    data: SvmSpokeClient.getRequestedSlowFillDecoder().decode(payload),
+  }),
+  ClaimedRelayerRefund: (payload) => ({
+    name: SVMEventNames.ClaimedRelayerRefund,
+    data: SvmSpokeClient.getClaimedRelayerRefundDecoder().decode(payload),
+  }),
+  TransferredOwnership: (payload) => ({
+    name: SVMEventNames.TransferredOwnership,
+    data: SvmSpokeClient.getTransferredOwnershipDecoder().decode(payload),
+  }),
 };
 
 /**
@@ -255,8 +294,8 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: 
       `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
     );
 
-    // Skip the discriminator; the event data follows it.
-    return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+    // Skip the discriminator; the event data follows it. subarray() of a Uint8Array remains a Uint8Array.
+    return svmSpokeEventDecoders[name](rawEventData.subarray(discriminator.length));
   }
 
   // CCTP programs: decode with the generated codama decoders so that the decoded data matches the generated

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -10,6 +10,7 @@ import {
   createTransactionMessage,
   getAddressEncoder,
   getBase64EncodedWireTransaction,
+  getBase64Encoder,
   getProgramDerivedAddress,
   getU32Encoder,
   getU64Encoder,
@@ -153,7 +154,10 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
   // The generated decoders only apply to SvmSpoke events; any other program's events would be mis-decoded.
   assert(idl.address === SvmSpokeIdl.address, `decodeEvent: unsupported IDL address ${idl.address}`);
 
-  const rawEventData = Buffer.from(rawEvent, "base64");
+  // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
+  // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
+  // Uint8Array that the generated types promise.
+  const rawEventData = getBase64Encoder().encode(rawEvent);
   const discriminator = rawEventData.subarray(0, 8);
   const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
   assert(
@@ -161,7 +165,8 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
     `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
   );
 
-  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData.subarray(8)) };
+  // Skip the discriminator; the event data follows it.
+  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
 }
 
 /**

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -25,7 +25,7 @@ import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefined } from "../../utils";
+import { BigNumber, Address as SdkAddress, getMessageHash, isDefined, isUint8Array } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -197,8 +197,8 @@ function unwrapEventDataInner(
     return BigNumber.from(data);
   }
   // Handle Uint8Array and byte arrays
-  if (isByteArray(data)) {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (data instanceof Uint8Array || isUint8Array(data)) {
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as number[]);
     const hex = ethers.utils.hexlify(bytes);
     if (currentKey && uint8ArrayKeysAsBigInt.includes(currentKey)) {
       return BigNumber.from(hex);

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -25,7 +25,7 @@ import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, getMessageHash, isDefined, isUint8Array } from "../../utils";
+import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefined } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -61,8 +61,8 @@ export async function isDevnet(rpc: SVMProvider): Promise<boolean> {
 /**
  * Small utility to convert an Address to a Solana Kit branded type.
  */
-export function toAddress(address: SdkAddress): Address<string> {
-  return address.toBase58() as Address<string>;
+export function toAddress(sdkAddress: SdkAddress): Address<string> {
+  return address(sdkAddress.toBase58());
 }
 
 /**
@@ -143,8 +143,12 @@ function snakeToCamel(s: string): string {
 /**
  * Gets the event name from a raw name.
  */
+function isEventName(name: string): name is EventName {
+  return name in SVMEventNames;
+}
+
 export function getEventName(rawName: string): EventName {
-  if (Object.values(SVMEventNames).some((name) => rawName.includes(name))) return rawName as EventName;
+  if (isEventName(rawName)) return rawName;
   throw new Error(`Unknown event name: ${rawName}`);
 }
 
@@ -192,8 +196,8 @@ function unwrapEventDataInner(
     return BigNumber.from(data);
   }
   // Handle Uint8Array and byte arrays
-  if (data instanceof Uint8Array || isUint8Array(data)) {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data as number[]);
+  if (isByteArray(data)) {
+    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
     const hex = ethers.utils.hexlify(bytes);
     if (currentKey && uint8ArrayKeysAsBigInt.includes(currentKey)) {
       return BigNumber.from(hex);
@@ -209,7 +213,7 @@ function unwrapEventDataInner(
     return ethers.utils.hexlify(bs58.decode(data));
   }
   // Handle objects
-  if (typeof data === "object") {
+  if (isUnwrappedRecord(data)) {
     // Special case: if an object is in the context of the fillType key, then
     // parse out the fillType from the object
     if (currentKey === "fillType") {
@@ -231,10 +235,7 @@ function unwrapEventDataInner(
       return "0x";
     }
     return Object.fromEntries(
-      Object.entries(data as Record<string, unknown>).map(([key, value]) => [
-        key,
-        unwrapEventDataInner(value, uint8ArrayKeysAsBigInt, key),
-      ])
+      Object.entries(data).map(([key, value]) => [key, unwrapEventDataInner(value, uint8ArrayKeysAsBigInt, key)])
     );
   }
   // Return primitives as is
@@ -412,11 +413,11 @@ export const createDefaultTransaction = async (
   signer: TransactionSigner,
   latestBlockhash?: LatestBlockhash
 ): Promise<SolanaTransaction> => {
-  latestBlockhash = isDefined(latestBlockhash) ? latestBlockhash : (await rpcClient.getLatestBlockhash().send()).value;
+  const blockhash = latestBlockhash ?? (await rpcClient.getLatestBlockhash().send()).value;
   return pipe(
     createTransactionMessage({ version: 0 }),
     (tx) => setTransactionMessageFeePayerSigner(signer, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash!, tx)
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(blockhash, tx)
   );
 };
 
@@ -428,13 +429,13 @@ export const createDefaultTransaction = async (
  * @param parser - The parser function to decode the result.
  * @returns The decoded result.
  */
-export const simulateAndDecode = async <P extends (buf: Buffer) => unknown>(
+export const simulateAndDecode = async <T>(
   solanaClient: SVMProvider,
   ix: Instruction,
   signer: KeyPairSigner,
-  parser: P,
+  parser: (buf: Buffer) => T,
   latestBlockhash?: LatestBlockhash
-): Promise<ReturnType<P>> => {
+): Promise<T> => {
   const simulationTx = appendTransactionMessageInstruction(
     ix,
     await createDefaultTransaction(solanaClient, signer, latestBlockhash)
@@ -450,7 +451,7 @@ export const simulateAndDecode = async <P extends (buf: Buffer) => unknown>(
     throw new Error("svm::simulateAndDecode: simulateTransaction failed. No return data.");
   }
 
-  return parser(Buffer.from(simulationResult.value.returnData.data[0], "base64")) as ReturnType<P>;
+  return parser(Buffer.from(simulationResult.value.returnData.data[0], "base64"));
 };
 
 /**

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,6 +1,6 @@
-import { MessageTransmitterClient, SvmSpokeClient } from "@across-protocol/contracts";
+import { MessageTransmitterClient, SvmSpokeClient, SvmSpokeIdl } from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
-import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
+import { BN, Idl } from "@coral-xyz/anchor";
 import {
   Address,
   Instruction,
@@ -19,6 +19,7 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
   type Commitment,
+  type Decoder,
   type TransactionSigner,
 } from "@solana/kit";
 import assert from "assert";
@@ -29,6 +30,7 @@ import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefine
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
+  EventData,
   EventName,
   SVMEventNames,
   SVMProvider,
@@ -121,16 +123,45 @@ export function parseEventData(eventData: any): any {
   return eventData;
 }
 
+// Codama decoders generated from the SvmSpoke program, keyed by event name. Decoding with these (rather than the
+// generic Anchor BorshEventCoder) yields data that actually satisfies the generated event types: base58 Address
+// strings, bigint integers, Uint8Array byte arrays and numeric enums, with camelCase field names.
+const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
+  BridgedToHubPool: SvmSpokeClient.getBridgedToHubPoolDecoder,
+  TokensBridged: SvmSpokeClient.getTokensBridgedDecoder,
+  ExecutedRelayerRefundRoot: SvmSpokeClient.getExecutedRelayerRefundRootDecoder,
+  RelayedRootBundle: SvmSpokeClient.getRelayedRootBundleDecoder,
+  PausedDeposits: SvmSpokeClient.getPausedDepositsDecoder,
+  PausedFills: SvmSpokeClient.getPausedFillsDecoder,
+  SetXDomainAdmin: SvmSpokeClient.getSetXDomainAdminDecoder,
+  FilledRelay: SvmSpokeClient.getFilledRelayDecoder,
+  FundsDeposited: SvmSpokeClient.getFundsDepositedDecoder,
+  EmergencyDeletedRootBundle: SvmSpokeClient.getEmergencyDeletedRootBundleDecoder,
+  RequestedSlowFill: SvmSpokeClient.getRequestedSlowFillDecoder,
+  ClaimedRelayerRefund: SvmSpokeClient.getClaimedRelayerRefundDecoder,
+  TransferredOwnership: SvmSpokeClient.getTransferredOwnershipDecoder,
+};
+
 /**
- * Decodes a raw event according to a supplied IDL.
+ * Decodes a raw SvmSpoke event.
+ *
+ * The event name is resolved from the IDL's event discriminator table and the payload is decoded with the
+ * corresponding decoder generated from the program, so the decoded data matches the generated event types.
+ * Events that cannot be identified are rejected.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
-  const event = new BorshEventCoder(idl).decode(rawEvent);
-  if (!event) throw new Error(`Malformed rawEvent for IDL ${idl.address}: ${rawEvent}`);
-  return {
-    name: event.name,
-    data: parseEventData(event.data),
-  };
+export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name: EventName } {
+  // The generated decoders only apply to SvmSpoke events; any other program's events would be mis-decoded.
+  assert(idl.address === SvmSpokeIdl.address, `decodeEvent: unsupported IDL address ${idl.address}`);
+
+  const rawEventData = Buffer.from(rawEvent, "base64");
+  const discriminator = rawEventData.subarray(0, 8);
+  const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
+  assert(
+    isDefined(name) && isEventName(name),
+    `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
+  );
+
+  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData.subarray(8)) };
 }
 
 /**

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -3,6 +3,7 @@ import winston from "winston";
 import {
   SVMEventNames,
   unwrapEventData,
+  getEventName,
   getFillDeadline,
   getTimestampForSlot,
   getStatePda,
@@ -128,7 +129,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
 
       const _searchConfig = { ...searchConfig }; // shallow copy
 
-      return _searchConfig as EventSearchConfig;
+      return _searchConfig;
     });
 
     const spokePoolAddress = this.svmEventsClient.getProgramAddress();
@@ -146,7 +147,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
       ...eventsToQuery.map(async (eventName, idx) => {
         const config = eventSearchConfigs[idx];
         const events = await this.svmEventsClient.queryEvents(
-          eventName as SVMEventNames,
+          getEventName(eventName),
           BigInt(config.from),
           BigInt(config.to),
           {

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -16,6 +16,7 @@ import {
   SvmCpiEventsClient,
   SVMEventNames,
   SVMProvider,
+  getEventName,
   getRandomSvmAddress,
   bigToU8a32,
 } from "../../arch/svm";
@@ -25,7 +26,7 @@ import { FillType } from "../../interfaces";
 const randomBytes = (n: number) => ethersUtils.hexlify(ethersUtils.randomBytes(n));
 
 export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
-  private events: Record<EventName, EventWithData[]> = {} as Record<EventName, EventWithData[]>;
+  private events: Partial<Record<EventName, EventWithData[]>> = {};
   private slotHeight: bigint = BigInt(0);
   public chainId: number;
   public minBlockRange = 10;
@@ -42,8 +43,8 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
 
   public setEvents(events: EventWithData[]) {
     for (const event of events) {
-      this.events[event.name as EventName] ??= [];
-      this.events[event.name as EventName].push(event);
+      const eventName = getEventName(event.name);
+      (this.events[eventName] ??= []).push(event);
     }
     const maxSlot = Math.max(...events.map((event) => Number(event.slot)));
     this.setSlotHeight(BigInt(maxSlot) + BigInt(1));
@@ -53,7 +54,7 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     if (name) {
       this.events[name] = [];
     } else {
-      this.events = {} as Record<EventName, EventWithData[]>;
+      this.events = {};
     }
   }
 

--- a/src/clients/mocks/MockSvmSpokePoolClient.ts
+++ b/src/clients/mocks/MockSvmSpokePoolClient.ts
@@ -16,7 +16,7 @@ import { HubPoolClient } from "../HubPoolClient";
 import { EventOverrides } from "./MockEvents";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
 import { MockSvmCpiEventsClient } from "./MockSvmCpiEventsClient";
-import { EventWithData, SvmCpiEventsClient, SVMEventNames, unwrapEventData } from "../../arch/svm";
+import { EventWithData, getEventName, SvmCpiEventsClient, unwrapEventData } from "../../arch/svm";
 
 // This class replaces internal SpokePoolClient functionality, enabling
 // the user to bypass on-chain queries and inject events directly.
@@ -69,7 +69,7 @@ export class MockSvmSpokePoolClient extends SVMSpokePoolClient {
 
     // Get events from the mock event client.
     const events: EventWithData[][] = await Promise.all(
-      eventsToQuery.map((eventName) => this.mockEventsClient.queryEvents(eventName as SVMEventNames, BigInt(from), to))
+      eventsToQuery.map((eventName) => this.mockEventsClient.queryEvents(getEventName(eventName), BigInt(from), to))
     );
 
     const eventsWithBlockNumber = events.map((eventList) =>

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -170,25 +170,11 @@ export function isArrayOf<T>(array: unknown, predicate: (value: unknown) => valu
 }
 
 /**
- * Checks whether a value is a byte array in either of its decoded representations: a Uint8Array, or a
- * non-empty plain array of integers in [0, 255] (as produced for fixed byte-array fields by Anchor borsh
- * decoding). An empty plain array is not considered a byte array, since it is indistinguishable from an
- * empty list.
+ * Checks if a value is a Uint8Array.
  * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
+ * @returns True if the value is a Uint8Array, false otherwise.
  */
-export function isByteArray(value: unknown): value is Uint8Array | number[] {
-  return value instanceof Uint8Array || isUint8Array(value);
-}
-
-/**
- * Checks if a value is a byte array: a plain array of integers in [0, 255], as produced for fixed byte-array
- * fields by Anchor borsh decoding. Note that this deliberately matches number[] and NOT Uint8Array instances;
- * prefer isByteArray(), which matches both representations.
- * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
- */
-export function isUint8Array(value: unknown): value is number[] {
+export function isUint8Array(value: unknown): value is Uint8Array {
   return (
     Array.isArray(value) &&
     value.length > 0 &&

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -170,11 +170,25 @@ export function isArrayOf<T>(array: unknown, predicate: (value: unknown) => valu
 }
 
 /**
- * Checks if a value is a Uint8Array.
+ * Checks whether a value is a byte array in either of its decoded representations: a Uint8Array, or a
+ * non-empty plain array of integers in [0, 255] (as produced for fixed byte-array fields by Anchor borsh
+ * decoding). An empty plain array is not considered a byte array, since it is indistinguishable from an
+ * empty list.
  * @param value The value to check.
- * @returns True if the value is a Uint8Array, false otherwise.
+ * @returns True if the value is a byte array, false otherwise.
  */
-export function isUint8Array(value: unknown): value is Uint8Array {
+export function isByteArray(value: unknown): value is Uint8Array | number[] {
+  return value instanceof Uint8Array || isUint8Array(value);
+}
+
+/**
+ * Checks if a value is a byte array: a plain array of integers in [0, 255], as produced for fixed byte-array
+ * fields by Anchor borsh decoding. Note that this deliberately matches number[] and NOT Uint8Array instances;
+ * prefer isByteArray(), which matches both representations.
+ * @param value The value to check.
+ * @returns True if the value is a byte array, false otherwise.
+ */
+export function isUint8Array(value: unknown): value is number[] {
   return (
     Array.isArray(value) &&
     value.length > 0 &&

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -1,0 +1,149 @@
+import {
+  MessageTransmitterClient,
+  MessageTransmitterIdl,
+  SvmSpokeIdl,
+  TokenMessengerMinterClient,
+  TokenMessengerMinterIdl,
+} from "@across-protocol/contracts";
+import { BorshEventCoder, Idl } from "@coral-xyz/anchor";
+import { type ReadonlyUint8Array } from "@solana/kit";
+import { cctpPrograms, decodeEvent, getRandomSvmAddress, parseEventData } from "../src/arch/svm";
+import { expect } from "./utils";
+
+// Decode through the legacy pipeline (generic Anchor coder + parseEventData) for differential comparison.
+function legacyDecode(idl: Idl, rawEvent: string): { name: string; data: unknown } | null {
+  const event = new BorshEventCoder(idl).decode(rawEvent);
+  return event === null ? null : { name: event.name, data: parseEventData(event.data) };
+}
+
+function encodeEvent(idl: Idl, name: string, payload: ReadonlyUint8Array): string {
+  const idlEvent = (idl.events ?? []).find((event) => event.name === name);
+  if (!idlEvent) throw new Error(`${name} event not found in IDL ${idl.address}`);
+  return Buffer.concat([Buffer.from(idlEvent.discriminator), Buffer.from(payload)]).toString("base64");
+}
+
+describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
+  // Every event defined by the CCTP IDLs must have a registered codama decoder, so that new events added by a
+  // contracts bump cannot silently decode with divergent (legacy Anchor) shapes.
+  it("registers a decoder for every CCTP IDL event", () => {
+    const cctpIdls: Idl[] = [TokenMessengerMinterIdl, MessageTransmitterIdl];
+    for (const idl of cctpIdls) {
+      const program = cctpPrograms[idl.address];
+      expect(program, idl.address).to.not.equal(undefined);
+      const tableNames = Object.keys(program?.eventDecoders ?? {}).sort();
+      const idlNames = (idl.events ?? []).map((event) => event.name).sort();
+      expect(tableNames).to.deep.equal(idlNames);
+    }
+  });
+
+  // A program address is retained across IDL upgrades, so the bundled decoders only apply when the caller
+  // supplied the exact bundled IDL instance. A drifted CCTP IDL (here: DepositForBurn gains a trailing field)
+  // must decode per the *supplied* IDL via the generic path - the bundled decoder would silently drop the new
+  // field.
+  it("decodes per the supplied IDL when a CCTP IDL differs from the bundled one", () => {
+    const drifted: Idl = JSON.parse(JSON.stringify(TokenMessengerMinterIdl));
+    const depositForBurn = (drifted.types ?? []).find((type) => type.name === "DepositForBurn");
+    expect(depositForBurn).to.not.equal(undefined);
+    if (depositForBurn?.type.kind === "struct" && Array.isArray(depositForBurn.type.fields)) {
+      depositForBurn.type.fields.push({ name: "new_field", type: "u64" });
+    }
+
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 1n,
+      burnToken: getRandomSvmAddress(),
+      amount: 9n,
+      depositor: getRandomSvmAddress(),
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 1,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+    const newField = Buffer.alloc(8);
+    newField.writeBigUInt64LE(777n);
+    const rawEvent = encodeEvent(drifted, "DepositForBurn", Buffer.concat([Buffer.from(payload), newField]));
+
+    const decoded = decodeEvent(drifted, rawEvent);
+    expect(decoded.name).to.equal("DepositForBurn");
+    expect(decoded.data).to.deep.include({ newField: 777n });
+  });
+
+  // The codama decoders must produce the same consumer-visible data as the legacy Anchor + parseEventData
+  // pipeline that downstream consumers (the relayer's CCTP flows) were built against.
+  it("decodes DepositForBurn identically to the legacy pipeline", () => {
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 42n,
+      burnToken: getRandomSvmAddress(),
+      amount: 123_456n,
+      depositor: getRandomSvmAddress(),
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 3,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+    const rawEvent = encodeEvent(TokenMessengerMinterIdl, "DepositForBurn", payload);
+    expect(decodeEvent(TokenMessengerMinterIdl, rawEvent)).to.deep.equal(
+      legacyDecode(TokenMessengerMinterIdl, rawEvent)
+    );
+  });
+
+  it("decodes MintAndWithdraw identically to the legacy pipeline", () => {
+    const payload = TokenMessengerMinterClient.getMintAndWithdrawEncoder().encode({
+      mintRecipient: getRandomSvmAddress(),
+      amount: 555n,
+      mintToken: getRandomSvmAddress(),
+    });
+    const rawEvent = encodeEvent(TokenMessengerMinterIdl, "MintAndWithdraw", payload);
+    expect(decodeEvent(TokenMessengerMinterIdl, rawEvent)).to.deep.equal(
+      legacyDecode(TokenMessengerMinterIdl, rawEvent)
+    );
+  });
+
+  it("decodes MessageReceived identically to the legacy pipeline", () => {
+    const payload = MessageTransmitterClient.getMessageReceivedEncoder().encode({
+      caller: getRandomSvmAddress(),
+      sourceDomain: 0,
+      nonce: 7n,
+      sender: getRandomSvmAddress(),
+      messageBody: Uint8Array.from({ length: 64 }, (_, index) => index),
+    });
+    const rawEvent = encodeEvent(MessageTransmitterIdl, "MessageReceived", payload);
+    expect(decodeEvent(MessageTransmitterIdl, rawEvent)).to.deep.equal(legacyDecode(MessageTransmitterIdl, rawEvent));
+  });
+
+  // Regression: SvmCpiEventsClient is IDL-parameterised and used downstream with non-SvmSpoke programs
+  // (e.g. the CCTP TokenMessengerMinter). decodeEvent must decode those generically rather than rejecting
+  // them or mis-decoding them with SvmSpoke layouts.
+  it("decodes non-SvmSpoke events with the generic Anchor coder", () => {
+    const depositor = getRandomSvmAddress();
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 1n,
+      burnToken: getRandomSvmAddress(),
+      amount: 1_000n,
+      depositor,
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 7,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+
+    const idlEvent = (TokenMessengerMinterIdl.events ?? []).find((event) => event.name === "DepositForBurn");
+    expect(idlEvent).to.not.equal(undefined);
+    const rawEvent = Buffer.concat([Buffer.from(idlEvent!.discriminator), Buffer.from(payload)]).toString("base64");
+
+    const decoded = decodeEvent(TokenMessengerMinterIdl, rawEvent);
+    expect(decoded.name).to.equal("DepositForBurn");
+
+    // The shape the relayer consumes: base58 address strings and bigint amounts.
+    expect(decoded.data).to.deep.include({ depositor, destinationDomain: 7, amount: 1_000n });
+  });
+
+  it("rejects unknown non-SvmSpoke events rather than mis-decoding them", () => {
+    const bogus = Buffer.from([9, 9, 9, 9, 9, 9, 9, 9, 1]).toString("base64");
+    expect(() => decodeEvent(TokenMessengerMinterIdl, bogus)).to.throw(/malformed event for IDL/);
+  });
+
+  it("continues to reject unknown SvmSpoke events", () => {
+    const bogus = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]).toString("base64");
+    expect(() => decodeEvent(SvmSpokeIdl, bogus)).to.throw(/unknown SvmSpoke event/);
+  });
+});

--- a/test/Solana.getEventName.unit.test.ts
+++ b/test/Solana.getEventName.unit.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+import { getEventName, SVMEventNames } from "../src/arch/svm";
+
+/**
+ * Regression test for `getEventName` narrowing.
+ *
+ * The guard behind `getEventName` must test for an *own* property of `SVMEventNames`. An earlier
+ * revision used `name in SVMEventNames`, which also matches keys inherited from `Object.prototype`
+ * ("toString", "constructor", ...). That made `getEventName` return an unknown name instead of
+ * throwing, so a bogus name could reach `SvmCpiEventsClient.queryEvents()` as a real event name and
+ * `MockSvmCpiEventsClient.setEvents()` would blow up dereferencing the inherited value as an array.
+ */
+describe("getEventName", () => {
+  it("accepts every declared event name", () => {
+    for (const name of Object.keys(SVMEventNames)) {
+      expect(getEventName(name)).to.equal(name);
+    }
+  });
+
+  it("rejects keys inherited from Object.prototype", () => {
+    for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty", "isPrototypeOf", "__proto__"]) {
+      expect(() => getEventName(name)).to.throw(`Unknown event name: ${name}`);
+    }
+  });
+
+  it("rejects unknown and partially-matching event names", () => {
+    for (const name of ["", "Bogus", "filledrelay", "FilledRelayX", "XFilledRelay"]) {
+      expect(() => getEventName(name)).to.throw(`Unknown event name: ${name}`);
+    }
+  });
+});


### PR DESCRIPTION
Resolve each event by its IDL discriminator and decode it with the 
codama decoder generated from the owning program, so decoded data now 
actually satisfies the generated event types (base58 Address strings,
bigints, Uint8Array byte arrays, numeric enums) instead of the
undescribed number[] and variant-object shapes produced by Anchor's 
BorshEventCoder. SvmSpoke events must resolve to a known SVMEventNames
member, so an unrecognised event fails loudly rather than yielding data
in an unexpected shape. CCTP (TokenMessengerMinter/MessageTransmitter)
events decode through per-program tables whose completeness against their
IDLs is pinned by unit tests; the bundled decoders apply only when the
caller supplied the exact bundled IDL instance (a program address
survives IDL upgrades), and any other IDL falls through to the generic
Anchor path, decoding per the supplied IDL. Each table entry constructs
its name/data pair, so the follow-on typed-event PR only tightens the
table's type annotation. Equivalence with the legacy pipeline is proven
by differential tests and by scripts/validate-svm-event-decoding.ts
against recent mainnet transactions.