### PR TITLE
fix(svm): Decode SvmSpoke events from a Uint8Array, not a Buffer

### DIFF
--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -10,6 +10,7 @@ import {
   createTransactionMessage,
   getAddressEncoder,
   getBase64EncodedWireTransaction,
+  getBase64Encoder,
   getProgramDerivedAddress,
   getU32Encoder,
   getU64Encoder,
@@ -153,7 +154,10 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
   // The generated decoders only apply to SvmSpoke events; any other program's events would be mis-decoded.
   assert(idl.address === SvmSpokeIdl.address, `decodeEvent: unsupported IDL address ${idl.address}`);
 
-  const rawEventData = Buffer.from(rawEvent, "base64");
+  // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
+  // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
+  // Uint8Array that the generated types promise.
+  const rawEventData = getBase64Encoder().encode(rawEvent);
   const discriminator = rawEventData.subarray(0, 8);
   const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
   assert(
@@ -161,7 +165,8 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
     `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
   );
 
-  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData.subarray(8)) };
+  // Skip the discriminator; the event data follows it.
+  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
 }
 
 /**


### PR DESCRIPTION
Fixes the two `SvmCpiEventsClient (integration)` failures on #1508.

`decodeEvent` passed a `Buffer` to the codama decoders. They populate byte-array fields by slicing their input, and `Buffer.prototype.slice` returns a `Buffer` — so `depositId`, `inputAmount`, `messageHash` etc. came back as `Buffer`s rather than the `Uint8Array` the generated types promise. `Buffer.toString()` utf8-decodes instead of joining bytes, which is what the assertions tripped on:

```
- ^@^@^@ ... ^@	TM-oM-?M-=          // Buffer
+ 0,0,0, ... ,0,9,84,144           // Uint8Array
```

Decode with `@solana/kit`'s base64 encoder (returns a plain `Uint8Array`) and skip the discriminator via the decoder's `offset` argument instead of slicing.

Verified locally against a local validator: `Solana.SvmCpiEventsClient.Integration`, `Solana.EventData` and `Solana.SvmCpiEventsClient.ForgedEvent.unit` all pass, and the full suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)