### PR TITLE
improve(svm): Type SVM events as a name-discriminated union

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,7 +40,6 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
-import { define, is, type } from "superstruct";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
@@ -54,7 +53,6 @@ import {
   chainIsSvm,
   chunk,
   getMessageHash,
-  isByteArray,
   isDefined,
   isUnsafeDepositId,
   keccak256,
@@ -218,12 +216,6 @@ export function getDepositIdAtBlock(_contract: unknown, _blockTag: number): Prom
   throw new Error("getDepositIdAtBlock: not implemented");
 }
 
-// A 32-byte array event field, decoded as either Uint8Array or number[] depending on the decoder.
-const Bytes32 = define<Uint8Array | number[]>("Bytes32", (value) => isByteArray(value) && value.length === 32);
-// The subset of decoded FundsDeposited event data needed to identify a deposit. type() (rather than
-// object()) tolerates the remaining event fields.
-const DepositIdEventData = type({ depositId: Bytes32 });
-
 /**
  * Finds deposit events within a 2-day window ending at the specified slot.
  *
@@ -280,8 +272,8 @@ export async function findDeposit(
 
   // Query for the deposit events with this limited slot range. Filter by deposit id, which is decoded from the
   // event as a 32-byte array (BigNumber.eq() accepts the big-endian byte representation directly).
-  const depositEvent = (await eventClient.queryEvents("FundsDeposited", startSlot, endSlot))?.find(
-    ({ data }) => is(data, DepositIdEventData) && depositId.eq(data.depositId)
+  const depositEvent = (await eventClient.queryEvents(SVMEventNames.FundsDeposited, startSlot, endSlot))?.find(
+    ({ data }) => depositId.eq(data.depositId)
   );
 
   // If no deposit event is found, return undefined
@@ -1011,7 +1003,7 @@ async function resolveFillStatusFromPdaEvents(
   svmEventsClient: SvmCpiEventsClient
 ): Promise<FillStatus> {
   // Get fill and requested slow fill events from fillStatus PDA
-  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill];
+  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill] as const;
   const relevantEvents = (
     await Promise.all(
       eventsToQuery.map((eventName) =>
@@ -1033,14 +1025,7 @@ async function resolveFillStatusFromPdaEvents(
     return FillStatus.Unfilled;
   }
 
-  switch (fillStatusEvent.name) {
-    case SVMEventNames.FilledRelay:
-      return FillStatus.Filled;
-    case SVMEventNames.RequestedSlowFill:
-      return FillStatus.RequestedSlowFill;
-    default:
-      throw new Error(`Unexpected event name: ${fillStatusEvent.name}`);
-  }
+  return fillStatusEvent.name === SVMEventNames.FilledRelay ? FillStatus.Filled : FillStatus.RequestedSlowFill;
 }
 
 /**

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -11,7 +11,7 @@ import {
   Signature,
 } from "@solana/kit";
 import { bs58, chainIsSvm, getMessageHash, isDefined, toAddressType } from "../../utils";
-import { EventName, EventWithData, SVMProvider } from "./types";
+import { DecodedEvent, EventName, EventWithData, SVMEventNames, SVMProvider } from "./types";
 import { decodeEvent, isDevnet } from "./utils";
 import { Deposit, DepositWithTime, Fill, FillWithTime } from "../../interfaces";
 import { unwrapEventData } from "./";
@@ -91,14 +91,14 @@ export class SvmCpiEventsClient {
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of events matching the eventName.
    */
-  public async queryEvents(
-    eventName: EventName,
+  public async queryEvents<T extends EventName>(
+    eventName: T,
     fromSlot?: bigint,
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
-  ): Promise<EventWithData[]> {
+  ): Promise<EventWithData<T>[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options);
-    return events.filter((event) => event.name === eventName);
+    return events.filter((event): event is EventWithData<T> => event.name === eventName);
   }
 
   /**
@@ -110,15 +110,15 @@ export class SvmCpiEventsClient {
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of events matching the eventName.
    */
-  public async queryDerivedAddressEvents(
-    eventName: string,
+  public async queryDerivedAddressEvents<T extends EventName>(
+    eventName: T,
     derivedAddress: Address,
     fromSlot?: bigint,
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
-  ): Promise<EventWithData[]> {
+  ): Promise<EventWithData<T>[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options, derivedAddress);
-    return events.filter((event) => event.name === eventName);
+    return events.filter((event): event is EventWithData<T> => event.name === eventName);
   }
 
   /**
@@ -205,9 +205,9 @@ export class SvmCpiEventsClient {
    * @param txResult - The transaction result.
    * @returns A promise that resolves to an array of events with their data and name.
    */
-  private processEventFromTx(txResult?: GetTransactionReturnType): { program: Address; data: unknown; name: string }[] {
+  private processEventFromTx(txResult?: GetTransactionReturnType): ({ program: Address } & DecodedEvent)[] {
     if (!isDefined(txResult) || isDefined(txResult.meta?.err)) return [];
-    const events: { program: Address; data: unknown; name: string }[] = [];
+    const events: ({ program: Address } & DecodedEvent)[] = [];
 
     const accountKeys = txResult.transaction.message.accountKeys;
     const messageAccountKeys = [...accountKeys];
@@ -239,8 +239,7 @@ export class SvmCpiEventsClient {
           }
           // Skip the 8-byte Anchor event discriminator and decode the remaining event payload.
           const eventData = Buffer.from(ixData.slice(8)).toString("base64");
-          const { name, data } = decodeEvent(this.idl, eventData);
-          events.push({ program: this.programAddress, name, data });
+          events.push({ program: this.programAddress, ...decodeEvent(this.idl, eventData) });
         }
       }
     }
@@ -275,7 +274,7 @@ export class SvmCpiEventsClient {
     ]);
 
     // Filter for FundsDeposited events only
-    const depositEvents = events?.filter((event) => event?.name === "FundsDeposited");
+    const depositEvents = events?.filter((event) => event?.name === SVMEventNames.FundsDeposited);
     if (!txDetails || !depositEvents?.length) {
       return;
     }
@@ -335,7 +334,7 @@ export class SvmCpiEventsClient {
     ]);
 
     // Filter for FilledRelay events only
-    const fillEvents = events?.filter((event) => event?.name === "FilledRelay");
+    const fillEvents = events?.filter((event) => event?.name === SVMEventNames.FilledRelay);
 
     if (!txDetails || !fillEvents?.length) {
       return;

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -102,23 +102,30 @@ export class SvmCpiEventsClient {
   }
 
   /**
-   * Queries events for the provided derived address at instantiation filtered by event name.
+   * Queries events for the provided derived address, filtered by event name. This is the generic query for
+   * programs without SpokePool-specific handling (e.g. the CCTP TokenMessengerMinter and MessageTransmitter).
+   *
+   * note: The returned events are scoped to *transactions* referencing the derived address; any event emitted
+   * by such a transaction is returned, whether or not the event pertains to the derived address (e.g. a
+   * batched fill emits events for many relays, all of which are returned for each relay's fillStatus PDA).
+   * Callers must associate events with the derived address themselves.
    *
    * @param eventName - The name of the event to filter by.
+   * @param derivedAddress - The derived address whose referencing transactions are queried.
    * @param fromSlot - Optional starting slot.
    * @param toSlot - Optional ending slot.
    * @param options - Options for fetching signatures.
    * @returns A promise that resolves to an array of events matching the eventName.
    */
-  public async queryDerivedAddressEvents<T extends EventName>(
-    eventName: T,
+  public async queryDerivedAddressEvents(
+    eventName: string,
     derivedAddress: Address,
     fromSlot?: bigint,
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
-  ): Promise<EventWithData<T>[]> {
+  ): Promise<RawEventWithData[]> {
     const events = await this.queryAllEvents(fromSlot, toSlot, options, derivedAddress);
-    return events.filter((event): event is EventWithData<T> => event.name === eventName);
+    return events.filter((event) => event.name === eventName);
   }
 
   /**

--- a/src/arch/svm/types.ts
+++ b/src/arch/svm/types.ts
@@ -24,20 +24,22 @@ export type SolanaTransaction = Extract<TransactionMessage, { version: 0 }> &
   TransactionMessageWithBlockhashLifetime &
   TransactionMessageWithFeePayer;
 
-export type EventData =
-  | SvmSpokeClient.BridgedToHubPool
-  | SvmSpokeClient.TokensBridged
-  | SvmSpokeClient.ExecutedRelayerRefundRoot
-  | SvmSpokeClient.RelayedRootBundle
-  | SvmSpokeClient.PausedDeposits
-  | SvmSpokeClient.PausedFills
-  | SvmSpokeClient.SetXDomainAdmin
-  | SvmSpokeClient.FilledRelay
-  | SvmSpokeClient.FundsDeposited
-  | SvmSpokeClient.EmergencyDeletedRootBundle
-  | SvmSpokeClient.RequestedSlowFill
-  | SvmSpokeClient.ClaimedRelayerRefund
-  | SvmSpokeClient.TransferredOwnership;
+// Maps each SvmSpoke event name to the event data type generated from the program.
+export interface EventNameToData {
+  FilledRelay: SvmSpokeClient.FilledRelay;
+  FundsDeposited: SvmSpokeClient.FundsDeposited;
+  RelayedRootBundle: SvmSpokeClient.RelayedRootBundle;
+  ExecutedRelayerRefundRoot: SvmSpokeClient.ExecutedRelayerRefundRoot;
+  BridgedToHubPool: SvmSpokeClient.BridgedToHubPool;
+  PausedDeposits: SvmSpokeClient.PausedDeposits;
+  PausedFills: SvmSpokeClient.PausedFills;
+  SetXDomainAdmin: SvmSpokeClient.SetXDomainAdmin;
+  EmergencyDeletedRootBundle: SvmSpokeClient.EmergencyDeletedRootBundle;
+  RequestedSlowFill: SvmSpokeClient.RequestedSlowFill;
+  ClaimedRelayerRefund: SvmSpokeClient.ClaimedRelayerRefund;
+  TokensBridged: SvmSpokeClient.TokensBridged;
+  TransferredOwnership: SvmSpokeClient.TransferredOwnership;
+}
 
 export enum SVMEventNames {
   FilledRelay = "FilledRelay",
@@ -57,13 +59,21 @@ export enum SVMEventNames {
 
 export type EventName = keyof typeof SVMEventNames;
 
-export type EventWithData = {
+export type EventData = EventNameToData[EventName];
+
+// A decoded SvmSpoke event. The name discriminates the data type: checking `event.name` narrows `event.data`
+// to the corresponding generated event type. The narrow form is defined via Extract so that narrowing
+// predicates over a generic event name remain provably assignable to the base union, and the name is passed
+// through a template literal so that SVMEventNames enum members (which are nominal) resolve to their string
+// literals and may be used interchangeably with them.
+type AnyDecodedEvent = { [N in EventName]: { name: N; data: EventNameToData[N] } }[EventName];
+export type DecodedEvent<T extends EventName = EventName> = Extract<AnyDecodedEvent, { name: `${T}` }>;
+
+export type EventWithData<T extends EventName = EventName> = DecodedEvent<T> & {
   confirmationStatus: string | null;
   blockTime: UnixTimestamp | null;
   signature: Signature;
   slot: bigint;
-  name: string;
-  data: unknown;
   program: Address;
 };
 

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -20,7 +20,6 @@ import {
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
   type Commitment,
-  type Decoder,
   type TransactionSigner,
 } from "@solana/kit";
 import assert from "assert";
@@ -31,7 +30,7 @@ import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefine
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
-  EventData,
+  DecodedEvent,
   EventName,
   SVMEventNames,
   SVMProvider,
@@ -126,21 +125,61 @@ export function parseEventData(eventData: any): any {
 
 // Codama decoders generated from the SvmSpoke program, keyed by event name. Decoding with these (rather than the
 // generic Anchor BorshEventCoder) yields data that actually satisfies the generated event types: base58 Address
-// strings, bigint integers, Uint8Array byte arrays and numeric enums, with camelCase field names.
-const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
-  BridgedToHubPool: SvmSpokeClient.getBridgedToHubPoolDecoder,
-  TokensBridged: SvmSpokeClient.getTokensBridgedDecoder,
-  ExecutedRelayerRefundRoot: SvmSpokeClient.getExecutedRelayerRefundRootDecoder,
-  RelayedRootBundle: SvmSpokeClient.getRelayedRootBundleDecoder,
-  PausedDeposits: SvmSpokeClient.getPausedDepositsDecoder,
-  PausedFills: SvmSpokeClient.getPausedFillsDecoder,
-  SetXDomainAdmin: SvmSpokeClient.getSetXDomainAdminDecoder,
-  FilledRelay: SvmSpokeClient.getFilledRelayDecoder,
-  FundsDeposited: SvmSpokeClient.getFundsDepositedDecoder,
-  EmergencyDeletedRootBundle: SvmSpokeClient.getEmergencyDeletedRootBundleDecoder,
-  RequestedSlowFill: SvmSpokeClient.getRequestedSlowFillDecoder,
-  ClaimedRelayerRefund: SvmSpokeClient.getClaimedRelayerRefundDecoder,
-  TransferredOwnership: SvmSpokeClient.getTransferredOwnershipDecoder,
+// strings, bigint integers, Uint8Array byte arrays and numeric enums, with camelCase field names. Each entry
+// constructs a name/data pair so that the correlation between the two is proven per event type.
+const svmSpokeEventDecoders: { [N in EventName]: (payload: Uint8Array) => DecodedEvent<N> } = {
+  BridgedToHubPool: (payload) => ({
+    name: SVMEventNames.BridgedToHubPool,
+    data: SvmSpokeClient.getBridgedToHubPoolDecoder().decode(payload),
+  }),
+  TokensBridged: (payload) => ({
+    name: SVMEventNames.TokensBridged,
+    data: SvmSpokeClient.getTokensBridgedDecoder().decode(payload),
+  }),
+  ExecutedRelayerRefundRoot: (payload) => ({
+    name: SVMEventNames.ExecutedRelayerRefundRoot,
+    data: SvmSpokeClient.getExecutedRelayerRefundRootDecoder().decode(payload),
+  }),
+  RelayedRootBundle: (payload) => ({
+    name: SVMEventNames.RelayedRootBundle,
+    data: SvmSpokeClient.getRelayedRootBundleDecoder().decode(payload),
+  }),
+  PausedDeposits: (payload) => ({
+    name: SVMEventNames.PausedDeposits,
+    data: SvmSpokeClient.getPausedDepositsDecoder().decode(payload),
+  }),
+  PausedFills: (payload) => ({
+    name: SVMEventNames.PausedFills,
+    data: SvmSpokeClient.getPausedFillsDecoder().decode(payload),
+  }),
+  SetXDomainAdmin: (payload) => ({
+    name: SVMEventNames.SetXDomainAdmin,
+    data: SvmSpokeClient.getSetXDomainAdminDecoder().decode(payload),
+  }),
+  FilledRelay: (payload) => ({
+    name: SVMEventNames.FilledRelay,
+    data: SvmSpokeClient.getFilledRelayDecoder().decode(payload),
+  }),
+  FundsDeposited: (payload) => ({
+    name: SVMEventNames.FundsDeposited,
+    data: SvmSpokeClient.getFundsDepositedDecoder().decode(payload),
+  }),
+  EmergencyDeletedRootBundle: (payload) => ({
+    name: SVMEventNames.EmergencyDeletedRootBundle,
+    data: SvmSpokeClient.getEmergencyDeletedRootBundleDecoder().decode(payload),
+  }),
+  RequestedSlowFill: (payload) => ({
+    name: SVMEventNames.RequestedSlowFill,
+    data: SvmSpokeClient.getRequestedSlowFillDecoder().decode(payload),
+  }),
+  ClaimedRelayerRefund: (payload) => ({
+    name: SVMEventNames.ClaimedRelayerRefund,
+    data: SvmSpokeClient.getClaimedRelayerRefundDecoder().decode(payload),
+  }),
+  TransferredOwnership: (payload) => ({
+    name: SVMEventNames.TransferredOwnership,
+    data: SvmSpokeClient.getTransferredOwnershipDecoder().decode(payload),
+  }),
 };
 
 /**
@@ -150,7 +189,7 @@ const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
  * corresponding decoder generated from the program, so the decoded data matches the generated event types.
  * Events that cannot be identified are rejected.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name: EventName } {
+export function decodeEvent(idl: Idl, rawEvent: string): DecodedEvent {
   // The generated decoders only apply to SvmSpoke events; any other program's events would be mis-decoded.
   assert(idl.address === SvmSpokeIdl.address, `decodeEvent: unsupported IDL address ${idl.address}`);
 
@@ -165,8 +204,8 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: EventData; name
     `decodeEvent: unknown SvmSpoke event ${name ?? ethers.utils.hexlify(discriminator)}`
   );
 
-  // Skip the discriminator; the event data follows it.
-  return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+  // Skip the discriminator; the event data follows it. subarray() of a Uint8Array remains a Uint8Array.
+  return svmSpokeEventDecoders[name](rawEventData.subarray(discriminator.length));
 }
 
 /**

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -11,12 +11,12 @@ import { CHAIN_IDs } from "@across-protocol/constants";
 import { MockSolanaRpcFactory } from "../../providers/mocks";
 import {
   SVM_DEFAULT_ADDRESS,
+  DecodedEvent,
   EventName,
   EventWithData,
   SvmCpiEventsClient,
   SVMEventNames,
   SVMProvider,
-  getEventName,
   getRandomSvmAddress,
   bigToU8a32,
 } from "../../arch/svm";
@@ -43,8 +43,7 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
 
   public setEvents(events: EventWithData[]) {
     for (const event of events) {
-      const eventName = getEventName(event.name);
-      (this.events[eventName] ??= []).push(event);
+      (this.events[event.name] ??= []).push(event);
     }
     const maxSlot = Math.max(...events.map((event) => Number(event.slot)));
     this.setSlotHeight(BigInt(maxSlot) + BigInt(1));
@@ -58,11 +57,16 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     }
   }
 
-  public override queryEvents(eventName: EventName, fromSlot?: bigint, toSlot?: bigint): Promise<EventWithData[]> {
+  public override queryEvents<T extends EventName>(
+    eventName: T,
+    fromSlot?: bigint,
+    toSlot?: bigint
+  ): Promise<EventWithData<T>[]> {
+    const events: EventWithData[] = this.events[eventName] ?? [];
     return Promise.resolve(
-      this.events[eventName]?.filter(
-        (event) => (!fromSlot || event.slot >= fromSlot) && (!toSlot || event.slot <= toSlot)
-      ) ?? []
+      events
+        .filter((event): event is EventWithData<T> => event.name === eventName)
+        .filter((event) => (!fromSlot || event.slot >= fromSlot) && (!toSlot || event.slot <= toSlot))
     );
   }
 
@@ -105,9 +109,8 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     };
 
     return this.generateEvent({
-      event: SVMEventNames.FundsDeposited,
+      decoded: { name: SVMEventNames.FundsDeposited, data: args },
       address: this.getProgramAddress(),
-      args,
       slot,
     });
   }
@@ -147,14 +150,14 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
       exclusiveRelayer: fill.exclusiveRelayer ?? SVM_DEFAULT_ADDRESS,
       exclusivityDeadline: fill.exclusivityDeadline ?? fillDeadline,
       relayer: fill.relayer ?? getRandomSvmAddress(),
+      repaymentChainId: fill.repaymentChainId ?? BigInt(this.chainId),
       messageHash,
       relayExecutionInfo,
     };
 
     return this.generateEvent({
-      event: SVMEventNames.FilledRelay,
+      decoded: { name: SVMEventNames.FilledRelay, data: args },
       address: this.getProgramAddress(),
-      args,
       slot,
     });
   }
@@ -183,20 +186,14 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     };
 
     return this.generateEvent({
-      event: SVMEventNames.RequestedSlowFill,
+      decoded: { name: SVMEventNames.RequestedSlowFill, data: args },
       address: this.getProgramAddress(),
-      args,
       slot,
     });
   }
 
-  protected generateEvent(inputs: {
-    address: Address;
-    event: EventName;
-    args: Record<string, unknown>;
-    slot?: bigint;
-  }) {
-    const { address, event, args } = inputs;
+  protected generateEvent(inputs: { address: Address; decoded: DecodedEvent; slot?: bigint }): EventWithData {
+    const { address, decoded } = inputs;
     let { slot } = inputs;
 
     const randomSlotWithinRange = () =>
@@ -208,20 +205,19 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
     assert(slot >= this.slotHeight, `${slot} < ${this.slotHeight}`);
     this.slotHeight = slot;
 
-    const generatedEvent = {
-      name: event,
+    const generatedEvent: EventWithData = {
+      ...decoded,
       slot,
       signature: signature(
         bs58.encode(
           Uint8Array.from(
             createHash("sha512")
-              .update(`Across-${event}-${slot}-${random(1, 100_000)}`)
+              .update(`Across-${decoded.name}-${slot}-${random(1, 100_000)}`)
               .digest()
           )
         )
       ),
       program: address,
-      data: args,
       confirmationStatus: "finalized",
       blockTime: BigInt(new Date().getTime()) as UnixTimestamp,
     };

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -6,8 +6,16 @@ import {
   TokenMessengerMinterIdl,
 } from "@across-protocol/contracts";
 import { BorshEventCoder, Idl } from "@coral-xyz/anchor";
-import { type ReadonlyUint8Array } from "@solana/kit";
-import { cctpPrograms, decodeEvent, getRandomSvmAddress, parseEventData } from "../src/arch/svm";
+import { signature, type ReadonlyUint8Array } from "@solana/kit";
+import {
+  cctpPrograms,
+  decodeEvent,
+  getRandomSvmAddress,
+  parseEventData,
+  RawDecodedEvent,
+  RawEventWithData,
+  SvmCpiEventsClient,
+} from "../src/arch/svm";
 import { expect } from "./utils";
 
 // Decode through the legacy pipeline (generic Anchor coder + parseEventData) for differential comparison.
@@ -145,5 +153,41 @@ describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
   it("continues to reject unknown SvmSpoke events", () => {
     const bogus = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]).toString("base64");
     expect(() => decodeEvent(SvmSpokeIdl, bogus)).to.throw(/unknown SvmSpoke event/);
+  });
+
+  // Regression: the relayer queries CCTP events via queryDerivedAddressEvents() with plain string event
+  // names (e.g. "DepositForBurn" against the message sent event PDA). Non-SvmSpoke events carry no typed
+  // name, so the method must accept any event name and return raw (untyped) events.
+  it("queries derived-address events for non-SvmSpoke programs by name", async () => {
+    const program = getRandomSvmAddress();
+    const events: RawDecodedEvent[] = [
+      { name: "DepositForBurn", data: { nonce: 1n } },
+      { name: "MintAndWithdraw", data: { amount: 2n } },
+    ];
+
+    // Exercise the real queryDerivedAddressEvents() implementation against a stubbed event source by
+    // shadowing the private queryAllEvents member at runtime. Object.create() returns `any` and
+    // Object.assign() merges the stubbed members without reference to the class's private declarations,
+    // so no type assertions are needed.
+    const stub: SvmCpiEventsClient = Object.create(SvmCpiEventsClient.prototype);
+    Object.assign(stub, {
+      queryAllEvents: (): Promise<RawEventWithData[]> =>
+        Promise.resolve(
+          events.map((decoded, index) => ({
+            ...decoded,
+            slot: BigInt(index),
+            // A valid-form (all-zero-bytes) signature; the filtering logic never inspects it.
+            signature: signature("1".repeat(64)),
+            blockTime: null,
+            confirmationStatus: "confirmed",
+            program,
+          }))
+        ),
+    });
+
+    const matched = await stub.queryDerivedAddressEvents("DepositForBurn", getRandomSvmAddress());
+    expect(matched.length).to.equal(1);
+    expect(matched[0].name).to.equal("DepositForBurn");
+    expect(matched[0].data).to.deep.equal({ nonce: 1n });
   });
 });


### PR DESCRIPTION
Map each SvmSpoke event name to its generated event data type and type
EventWithData as a name-discriminated union, so checking event.name statically
narrows event.data. queryEvents() returns EventWithData<T> for the requested
name, and SVMEventNames members are interchangeable with their string literals.
The decoder table's type annotation is tightened so each entry's name/data
correlation is proven at compile time. queryDerivedAddressEvents() deliberately
stays untyped (eventName: string, raw events): it is the generic query for
non-SvmSpoke programs, and the relayer's CCTP flows call it with plain string
event names a regression test pins that call pattern. findDeposit()'s
depositId cast is replaced by typed access, and mock event construction is
checked against the generated types, which surfaced a missing repaymentChainId
field in mocked FilledRelay events.