### PR TITLE
improve(svm): Compute relay data hashes from relay events

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -972,29 +972,48 @@ export async function getAssociatedTokenAddress(
   return associatedToken;
 }
 
+// getRelayDataHash() is the SVM-specific implementation backing the chain-dispatching getRelayDataHash() in
+// src/utils/SpokeUtils.ts.
 export function getRelayDataHash(relayData: RelayData & { messageHash: string }, destinationChainId: number): string {
   assert(relayData.messageHash.startsWith("0x"), "Message hash must be a hex string");
+  const messageHash = Uint8Array.from(Buffer.from(relayData.messageHash.slice(2), "hex"));
+  return hashRelayData(toSvmRelayData(relayData), messageHash, destinationChainId);
+}
 
+// The relay data hash never covers the message itself: the SvmSpoke hashes relay data with the message replaced
+// by messageHash, so that the hash can be reconstructed from events, which carry only messageHash. The message
+// is therefore not accepted as an input here. The RelayData encoder requires one, so encode an empty placeholder
+// and splice messageHash into its position (the message is the final RelayData field), matching the SvmSpoke:
+// https://github.com/across-protocol/contracts/blob/3310f8dc716407a5f97ef5fd2eae63df83251f2f/programs/svm-spoke/src/utils/merkle_proof_utils.rs#L5
+function hashRelayData(
+  relayData: Omit<SvmSpokeClient.RelayDataArgs, "message">,
+  messageHash: Uint8Array,
+  destinationChainId: number
+): string {
   const uint64Encoder = getU64Encoder();
+  const encodedRelayData = SvmSpokeClient.getRelayDataEncoder().encode({ ...relayData, message: new Uint8Array(0) });
 
-  const svmRelayData = toSvmRelayData(relayData);
-  const relayDataEncoder = SvmSpokeClient.getRelayDataEncoder();
-  const encodedRelayData = relayDataEncoder.encode(svmRelayData);
-  const encodedMessage = Buffer.from(relayData.message.slice(2), "hex");
-  const encodedMessageHash = Uint8Array.from(Buffer.from(relayData.messageHash.slice(2), "hex"));
-
-  // Reformat the encoded relay data the same way it is done in the SvmSpoke:
-  // https://github.com/across-protocol/contracts/blob/3310f8dc716407a5f97ef5fd2eae63df83251f2f/programs/svm-spoke/src/utils/merkle_proof_utils.rs#L5
-  // We want to use messageHash always so we can construct the relayDataHash just from the Fill.
-  // If we don't have a message, we can just pass an empty message here.
-  const messageOffset = encodedRelayData.length - 4 - encodedMessage.length;
+  const messageOffset = encodedRelayData.length - 4; // Strip the empty message (its 4-byte u32 length prefix).
   const contentToHash = Buffer.concat([
     encodedRelayData.slice(0, messageOffset),
-    encodedMessageHash,
+    messageHash,
     Uint8Array.from(uint64Encoder.encode(BigInt(destinationChainId))),
   ]);
 
   return keccak256(contentToHash);
+}
+
+// Relay data as embedded in SVM relay events (FilledRelay, RequestedSlowFill): the native RelayData with the
+// message replaced by its hash. Events never carry the message itself; messageHash is the commitment, and the
+// message must be reconciled against the corresponding deposit. Both relay event types satisfy this shape.
+export type SvmRelayEventData = Omit<SvmSpokeClient.RelayData, "message"> & { messageHash: ReadonlyUint8Array };
+
+/**
+ * Computes the relay data hash for the relay data embedded in a FilledRelay or RequestedSlowFill event. This is
+ * the same hash the relay's fillStatus PDA is derived from, so it identifies which relay an event belongs to.
+ */
+export function getRelayDataHashFromEvent(event: SvmRelayEventData, destinationChainId: number): string {
+  return hashRelayData(event, Uint8Array.from(event.messageHash), destinationChainId);
 }
 
 async function resolveFillStatusFromPdaEvents(

--- a/test/Solana.RelayDataHash.unit.test.ts
+++ b/test/Solana.RelayDataHash.unit.test.ts
@@ -1,0 +1,94 @@
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { SvmSpokeClient } from "@across-protocol/contracts";
+import { arrayify, hexZeroPad } from "ethers/lib/utils";
+import {
+  getRandomSvmAddress,
+  getRelayDataHash,
+  getRelayDataHashFromEvent,
+  SvmRelayEventData,
+  toAddress,
+} from "../src/arch/svm";
+import { RelayData } from "../src/interfaces";
+import { BigNumber, randomAddress, toAddressType } from "../src/utils";
+import { expect } from "./utils";
+
+describe("SVM relay data hash", () => {
+  const originChainId = CHAIN_IDs.MAINNET;
+  const destinationChainId = CHAIN_IDs.SOLANA;
+
+  const relayData = (depositId: number): RelayData & { messageHash: string } => ({
+    originChainId,
+    depositor: toAddressType(randomAddress(), originChainId),
+    recipient: toAddressType(getRandomSvmAddress(), destinationChainId),
+    inputToken: toAddressType(randomAddress(), originChainId),
+    outputToken: toAddressType(getRandomSvmAddress(), destinationChainId),
+    inputAmount: BigNumber.from(1_000),
+    outputAmount: BigNumber.from(900),
+    depositId: BigNumber.from(depositId),
+    fillDeadline: 1_893_456_000,
+    exclusivityDeadline: 0,
+    exclusiveRelayer: toAddressType(getRandomSvmAddress(), destinationChainId),
+    message: "0x1234",
+    messageHash: `0x${"ab".repeat(32)}`,
+  });
+
+  const bytes32 = (value: BigNumber | string): Uint8Array =>
+    arrayify(hexZeroPad(typeof value === "string" ? value : value.toHexString(), 32));
+
+  // The relay data as it would be embedded in a FilledRelay or RequestedSlowFill event.
+  const relayEventData = (relay: RelayData & { messageHash: string }): SvmRelayEventData => ({
+    depositor: toAddress(relay.depositor),
+    recipient: toAddress(relay.recipient),
+    exclusiveRelayer: toAddress(relay.exclusiveRelayer),
+    inputToken: toAddress(relay.inputToken),
+    outputToken: toAddress(relay.outputToken),
+    inputAmount: bytes32(relay.inputAmount),
+    outputAmount: relay.outputAmount.toBigInt(),
+    originChainId: BigInt(relay.originChainId),
+    depositId: bytes32(relay.depositId),
+    fillDeadline: relay.fillDeadline,
+    exclusivityDeadline: relay.exclusivityDeadline,
+    messageHash: bytes32(relay.messageHash),
+  });
+
+  it("computes the same relay data hash from relay data and from event data", () => {
+    const relay = relayData(1);
+    const expected = getRelayDataHash(relay, destinationChainId);
+    expect(getRelayDataHashFromEvent(relayEventData(relay), destinationChainId)).to.equal(expected);
+  });
+
+  it("accepts FilledRelay events (structural superset of the embedded relay data)", () => {
+    const relay = relayData(2);
+    const relayer = getRandomSvmAddress();
+    const fillEvent: SvmSpokeClient.FilledRelay = {
+      ...relayEventData(relay),
+      relayer,
+      repaymentChainId: BigInt(destinationChainId),
+      relayExecutionInfo: {
+        updatedRecipient: toAddress(relay.recipient),
+        updatedMessageHash: bytes32(relay.messageHash),
+        updatedOutputAmount: relay.outputAmount.toBigInt(),
+        fillType: SvmSpokeClient.FillType.FastFill,
+      },
+    };
+    expect(getRelayDataHashFromEvent(fillEvent, destinationChainId)).to.equal(
+      getRelayDataHash(relay, destinationChainId)
+    );
+  });
+
+  it("distinguishes relays by their event data", () => {
+    const relay = relayData(3);
+    const other = relayEventData({ ...relay, depositId: BigNumber.from(4) });
+    expect(getRelayDataHashFromEvent(other, destinationChainId)).to.not.equal(
+      getRelayDataHash(relay, destinationChainId)
+    );
+  });
+
+  it("hashes the messageHash commitment, not the message", () => {
+    const relay = relayData(5);
+    const differentMessage = { ...relay, message: "0x123456" };
+    expect(getRelayDataHash(differentMessage, destinationChainId)).to.equal(
+      getRelayDataHash(relay, destinationChainId)
+    );
+  });
+});


### PR DESCRIPTION
Split getRelayDataHash() into a canonical-input wrapper over a core that does not accept the message: the SvmSpoke hashes relay data with the message replaced by messageHash, precisely so the hash is reconstructible from FilledRelay/RequestedSlowFill events, which carry only the hash. Add getRelayDataHashFromEvent() to do that reconstruction from typed event data, and pin the cross-domain invariant in tests: the hash computed from canonical relay data equals the hash computed from the event a fill of that relay emits. This is the identity that event-to-relay association will be built on.