### PR TITLE
improve(svm): Associate fillStatus PDA events with their relay

### DIFF
--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -112,27 +112,36 @@ export class SvmCpiEventsClient {
    * other relays (e.g. from batched fills). Each event is therefore associated back to the relay by its relay
    * data hash, the same hash the fillStatus PDA is derived from; events belonging to other relays are dropped.
    * Signatures are paginated to exhaustion within the slot bounds, so transactions spamming the PDA can add
-   * latency but cannot displace the relay's own events.
+   * latency but cannot displace the relay's own events. A caller-supplied fillStatus PDA is likewise only a
+   * transaction locator: association is by relay data hash, so a stale or incorrect PDA can only yield missing
+   * events, never another relay's.
    *
    * @param relayData - Relay data identifying the relay to query events for.
    * @param destinationChainId - Destination chain ID of the relay (must be an SVM chain).
    * @param eventNames - The names of the events to filter by (FilledRelay and/or RequestedSlowFill).
-   * @param opts - Optional slot bounds and a precomputed fillStatus PDA.
+   * @param opts - Optional slot bounds, a precomputed fillStatus PDA and the commitment level (default:
+   * confirmed), which applies to both the signature listing and the transaction reads.
    * @returns A promise that resolves to an array of events pertaining to the relay.
    */
   public async queryEventsForRelay(
     relayData: RelayDataWithMessageHash,
     destinationChainId: number,
     eventNames: RelayEventName[],
-    opts: { fromSlot?: bigint; toSlot?: bigint; fillStatusPda?: Address } = {}
+    opts: {
+      fromSlot?: bigint;
+      toSlot?: bigint;
+      fillStatusPda?: Address;
+      commitment?: Exclude<Commitment, "processed">;
+    } = {}
   ): Promise<EventWithData<RelayEventName>[]> {
     assert(chainIsSvm(destinationChainId), `Destination chain ${destinationChainId} is not an SVM chain`);
+    const { commitment = "confirmed" } = opts;
     const fillStatusPda =
       opts.fillStatusPda ?? (await getFillStatusPda(this.programAddress, relayData, destinationChainId));
     const messageHash = relayData.messageHash ?? getMessageHash(relayData.message);
     const relayDataHash = getRelayDataHash({ ...relayData, messageHash }, destinationChainId);
 
-    const events = await this.queryAllEvents(opts.fromSlot, opts.toSlot, undefined, fillStatusPda);
+    const events = await this.queryAllEvents(opts.fromSlot, opts.toSlot, { limit: 1000, commitment }, fillStatusPda);
     return events
       .filter((event): event is EventWithData<RelayEventName> => eventNames.some((name) => name === event.name))
       .filter((event) => getRelayDataHashFromEvent(event.data, destinationChainId) === relayDataHash);
@@ -213,7 +222,8 @@ export class SvmCpiEventsClient {
       return true;
     });
 
-    // Fetch events for all signatures in parallel.
+    // Fetch events for all signatures in parallel. Dispatch is unbounded, but request concurrency is bounded
+    // by the provider's rate-limiting queue (RateLimitedSolanaRpcFactory), mirroring the EVM provider layer.
     const eventsWithSlots = await Promise.all(
       filteredSignatures.map(async (signatureTransaction) => {
         const events = await this.readEventsFromSignature(signatureTransaction.signature, options.commitment);

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -12,9 +12,9 @@ import {
 } from "@solana/kit";
 import { bs58, chainIsSvm, getMessageHash, isDefined, toAddressType } from "../../utils";
 import { DecodedEvent, EventName, EventWithData, SVMEventNames, SVMProvider } from "./types";
-import { decodeEvent, isDevnet } from "./utils";
-import { Deposit, DepositWithTime, Fill, FillWithTime } from "../../interfaces";
-import { unwrapEventData } from "./";
+import { decodeEvent, getFillStatusPda, isDevnet } from "./utils";
+import { Deposit, DepositWithTime, Fill, FillWithTime, RelayDataWithMessageHash } from "../../interfaces";
+import { getRelayDataHash, getRelayDataHashFromEvent, unwrapEventData } from "./";
 import assert from "assert";
 
 /**
@@ -46,6 +46,9 @@ type GetSignaturesForAddressApiResponse = readonly GetSignaturesForAddressTransa
 
 export type DepositEventFromSignature = Omit<DepositWithTime, "fromLiteChain" | "toLiteChain">;
 export type FillEventFromSignature = FillWithTime;
+
+// The events that embed the relay data of the relay they pertain to (see queryEventsForRelay()).
+export type RelayEventName = Extract<EventName, "FilledRelay" | "RequestedSlowFill">;
 
 export class SvmCpiEventsClient {
   private rpc: SVMProvider;
@@ -102,7 +105,47 @@ export class SvmCpiEventsClient {
   }
 
   /**
+   * Queries FilledRelay and/or RequestedSlowFill events pertaining to a specific relay.
+   *
+   * Events are located via the relay's fillStatus PDA, but Solana only indexes transactions by account, so the
+   * underlying query yields all program events from any transaction touching that PDA - including events for
+   * other relays (e.g. from batched fills). Each event is therefore associated back to the relay by its relay
+   * data hash, the same hash the fillStatus PDA is derived from; events belonging to other relays are dropped.
+   * Signatures are paginated to exhaustion within the slot bounds, so transactions spamming the PDA can add
+   * latency but cannot displace the relay's own events.
+   *
+   * @param relayData - Relay data identifying the relay to query events for.
+   * @param destinationChainId - Destination chain ID of the relay (must be an SVM chain).
+   * @param eventNames - The names of the events to filter by (FilledRelay and/or RequestedSlowFill).
+   * @param opts - Optional slot bounds and a precomputed fillStatus PDA.
+   * @returns A promise that resolves to an array of events pertaining to the relay.
+   */
+  public async queryEventsForRelay(
+    relayData: RelayDataWithMessageHash,
+    destinationChainId: number,
+    eventNames: RelayEventName[],
+    opts: { fromSlot?: bigint; toSlot?: bigint; fillStatusPda?: Address } = {}
+  ): Promise<EventWithData<RelayEventName>[]> {
+    assert(chainIsSvm(destinationChainId), `Destination chain ${destinationChainId} is not an SVM chain`);
+    const fillStatusPda =
+      opts.fillStatusPda ?? (await getFillStatusPda(this.programAddress, relayData, destinationChainId));
+    const messageHash = relayData.messageHash ?? getMessageHash(relayData.message);
+    const relayDataHash = getRelayDataHash({ ...relayData, messageHash }, destinationChainId);
+
+    const events = await this.queryAllEvents(opts.fromSlot, opts.toSlot, undefined, fillStatusPda);
+    return events
+      .filter((event): event is EventWithData<RelayEventName> => eventNames.some((name) => name === event.name))
+      .filter((event) => getRelayDataHashFromEvent(event.data, destinationChainId) === relayDataHash);
+  }
+
+  /**
    * Queries events for the provided derived address at instantiation filtered by event name.
+   *
+   * @deprecated The returned events are scoped to *transactions* referencing the derived address; any event
+   * emitted by such a transaction is returned, whether or not the event pertains to the derived address (e.g.
+   * a batched fill emits events for many relays, all of which are returned for each relay's fillStatus PDA).
+   * Callers must associate events with the derived address themselves. Prefer queryEventsForRelay(), which
+   * does this association by relay data hash.
    *
    * @param eventName - The name of the event to filter by.
    * @param fromSlot - Optional starting slot.

--- a/test/Solana.SvmCpiEventsClient.RelayAssociation.unit.test.ts
+++ b/test/Solana.SvmCpiEventsClient.RelayAssociation.unit.test.ts
@@ -134,4 +134,24 @@ describe("SvmCpiEventsClient (relay event association)", () => {
 
     expect(events.length).to.equal(0);
   });
+
+  it("applies the requested commitment to the underlying query", async () => {
+    const expected = relayData(5);
+    let observed: string | undefined;
+    const stub: SvmCpiEventsClient = Object.create(SvmCpiEventsClient.prototype);
+    Object.assign(stub, {
+      programAddress: program,
+      queryAllEvents: (_from?: bigint, _to?: bigint, options?: { commitment?: string }): Promise<EventWithData[]> => {
+        observed = options?.commitment;
+        return Promise.resolve([]);
+      },
+    });
+
+    await stub.queryEventsForRelay(expected, destinationChainId, ["FilledRelay"], { commitment: "finalized" });
+    expect(observed).to.equal("finalized");
+
+    // Defaults to confirmed when unspecified.
+    await stub.queryEventsForRelay(expected, destinationChainId, ["FilledRelay"]);
+    expect(observed).to.equal("confirmed");
+  });
 });

--- a/test/Solana.SvmCpiEventsClient.RelayAssociation.unit.test.ts
+++ b/test/Solana.SvmCpiEventsClient.RelayAssociation.unit.test.ts
@@ -1,0 +1,137 @@
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { address, signature } from "@solana/kit";
+import { SvmSpokeClient } from "@across-protocol/contracts";
+import { arrayify, hexZeroPad } from "ethers/lib/utils";
+import {
+  DecodedEvent,
+  EventWithData,
+  getRandomSvmAddress,
+  RelayEventName,
+  SvmCpiEventsClient,
+  toAddress,
+} from "../src/arch/svm";
+import { RelayDataWithMessageHash } from "../src/interfaces";
+import { BigNumber, randomAddress, toAddressType } from "../src/utils";
+import { expect } from "./utils";
+
+describe("SvmCpiEventsClient (relay event association)", () => {
+  const program = address("DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru");
+  const originChainId = CHAIN_IDs.MAINNET;
+  const destinationChainId = CHAIN_IDs.SOLANA;
+
+  const relayData = (depositId: number): RelayDataWithMessageHash => ({
+    originChainId,
+    depositor: toAddressType(randomAddress(), originChainId),
+    recipient: toAddressType(getRandomSvmAddress(), destinationChainId),
+    inputToken: toAddressType(randomAddress(), originChainId),
+    outputToken: toAddressType(getRandomSvmAddress(), destinationChainId),
+    inputAmount: BigNumber.from(1_000),
+    outputAmount: BigNumber.from(900),
+    depositId: BigNumber.from(depositId),
+    fillDeadline: 1_893_456_000,
+    exclusivityDeadline: 0,
+    exclusiveRelayer: toAddressType(getRandomSvmAddress(), destinationChainId),
+    message: "0x",
+    messageHash: `0x${"ab".repeat(32)}`,
+  });
+
+  const bytes32 = (value: BigNumber | string): Uint8Array =>
+    arrayify(hexZeroPad(typeof value === "string" ? value : value.toHexString(), 32));
+
+  const fillEvent = (relay: RelayDataWithMessageHash): SvmSpokeClient.FilledRelay => ({
+    depositor: toAddress(relay.depositor),
+    recipient: toAddress(relay.recipient),
+    exclusiveRelayer: toAddress(relay.exclusiveRelayer),
+    inputToken: toAddress(relay.inputToken),
+    outputToken: toAddress(relay.outputToken),
+    inputAmount: bytes32(relay.inputAmount),
+    outputAmount: relay.outputAmount.toBigInt(),
+    originChainId: BigInt(relay.originChainId),
+    depositId: bytes32(relay.depositId),
+    fillDeadline: relay.fillDeadline,
+    exclusivityDeadline: relay.exclusivityDeadline,
+    messageHash: bytes32(relay.messageHash ?? "0x"),
+    relayer: getRandomSvmAddress(),
+    repaymentChainId: BigInt(destinationChainId),
+    relayExecutionInfo: {
+      updatedRecipient: toAddress(relay.recipient),
+      updatedMessageHash: bytes32(relay.messageHash ?? "0x"),
+      updatedOutputAmount: relay.outputAmount.toBigInt(),
+      fillType: SvmSpokeClient.FillType.FastFill,
+    },
+  });
+
+  const requestSlowFillEvent = (relay: RelayDataWithMessageHash): SvmSpokeClient.RequestedSlowFill => {
+    const {
+      relayer: _relayer,
+      repaymentChainId: _repaymentChainId,
+      relayExecutionInfo: _info,
+      ...event
+    } = fillEvent(relay);
+    return event;
+  };
+
+  // Exercise the real queryEventsForRelay() implementation against a stubbed event source by shadowing the
+  // private queryAllEvents member at runtime. Object.create() returns `any` and Object.assign() merges the
+  // stubbed members without reference to the class's private declarations, so no type assertions are needed.
+  const client = (events: DecodedEvent<RelayEventName>[]): SvmCpiEventsClient => {
+    const stub: SvmCpiEventsClient = Object.create(SvmCpiEventsClient.prototype);
+    return Object.assign(stub, {
+      programAddress: program,
+      queryAllEvents: (): Promise<EventWithData[]> =>
+        Promise.resolve(
+          events.map((decoded, index) => ({
+            ...decoded,
+            slot: BigInt(index),
+            // A valid-form (all-zero-bytes) signature; the association logic never inspects it.
+            signature: signature("1".repeat(64)),
+            blockTime: null,
+            confirmationStatus: "confirmed",
+            program,
+          }))
+        ),
+    });
+  };
+
+  it("returns only events belonging to the queried relay", async () => {
+    const expected = relayData(1);
+    const other = { ...expected, depositId: BigNumber.from(2) };
+    const eventsClient = client([
+      { name: "FilledRelay", data: fillEvent(other) },
+      { name: "FilledRelay", data: fillEvent(expected) },
+    ]);
+
+    const events = await eventsClient.queryEventsForRelay(expected, destinationChainId, ["FilledRelay"]);
+
+    expect(events.length).to.equal(1);
+    expect(events[0].slot).to.equal(BigInt(1));
+  });
+
+  it("filters by event name", async () => {
+    const expected = relayData(3);
+    const eventsClient = client([
+      { name: "RequestedSlowFill", data: requestSlowFillEvent(expected) },
+      { name: "FilledRelay", data: fillEvent(expected) },
+    ]);
+
+    const fills = await eventsClient.queryEventsForRelay(expected, destinationChainId, ["FilledRelay"]);
+    const all = await eventsClient.queryEventsForRelay(expected, destinationChainId, [
+      "FilledRelay",
+      "RequestedSlowFill",
+    ]);
+
+    expect(fills.length).to.equal(1);
+    expect(fills[0].name).to.equal("FilledRelay");
+    expect(all.length).to.equal(2);
+  });
+
+  it("associates by messageHash", async () => {
+    const expected = relayData(4);
+    const otherMessage = { ...expected, messageHash: `0x${"cd".repeat(32)}` };
+    const eventsClient = client([{ name: "FilledRelay", data: fillEvent(otherMessage) }]);
+
+    const events = await eventsClient.queryEventsForRelay(expected, destinationChainId, ["FilledRelay"]);
+
+    expect(events.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Add SvmCpiEventsClient.queryEventsForRelay(), which queries a relay's
fillStatus PDA and associates each returned event back to the relay by
its relay data hash - the same hash the PDA is derived from. Solana only
indexes transactions by account, so PDA queries return all program
events from any transaction touching the PDA, including events for other
relays (e.g. from batched fills); consuming them without association is
the source of the fill status misattribution bug. Signatures are
paginated to exhaustion within the slot bounds, so spamming transactions
at a PDA adds latency but cannot displace the relay's own events.
queryDerivedAddressEvents() remains the generic derived-address query
for non-SvmSpoke programs; its documentation now points SvmSpoke
relay-event callers at queryEventsForRelay(). The SpokePool callers
migrate together with the fill-status fix.