### PR TITLE
improve(svm): Convert typed events directly to SDK domain types

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -40,7 +40,7 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
-import { arrayify } from "ethers/lib/utils";
+import { arrayify, hexlify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import { DepositWithBlock, FillStatus, FillWithBlock, RelayData, RelayDataWithMessageHash } from "../../interfaces";
 import {
@@ -57,8 +57,7 @@ import {
   isUnsafeDepositId,
   keccak256,
   mapAsync,
-  unpackDepositEvent,
-  unpackFillEvent,
+  toAddressType,
 } from "../../utils";
 import {
   createDefaultTransaction,
@@ -70,7 +69,6 @@ import {
   isDepositForBurnEvent,
   simulateAndDecode,
   toAddress,
-  unwrapEventData,
   getRootBundlePda,
   getAcrossPlusMessageDecoder,
   getAccountMeta,
@@ -80,7 +78,15 @@ import {
 } from "./";
 import { SvmCpiEventsClient } from "./eventsClient";
 import { SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, SVM_SLOT_SKIPPED, isSolanaError } from "./provider";
-import { AttestedCCTPMessage, SVMEventNames, SVMProvider, LatestBlockhash, SolanaTransaction } from "./types";
+import {
+  AttestedCCTPMessage,
+  EventNameToData,
+  EventWithData,
+  SVMEventNames,
+  SVMProvider,
+  LatestBlockhash,
+  SolanaTransaction,
+} from "./types";
 import {
   getEmergencyDeleteRootBundleRootBundleId,
   getNearestSlotTime,
@@ -281,20 +287,16 @@ export async function findDeposit(
     return undefined;
   }
 
-  const txnIndex = 0;
-  const logIndex = 0;
-  const blockNumber = Number(depositEvent.slot);
-  const txnRef = depositEvent.signature.toString();
-
-  const rawData = unwrapEventData(depositEvent.data, ["depositId", "outputAmount"]);
-  const { originChainId, ...deposit } = unpackDepositEvent(
-    { ...rawData, blockNumber, txnRef, txnIndex, logIndex },
-    CHAIN_IDs.SOLANA
+  const { originChainId: _originChainId, ...deposit } = depositFromEvent(
+    depositEvent.data,
+    CHAIN_IDs.SOLANA,
+    depositEvent
   );
 
-  return {
-    ...deposit,
-  } satisfies Omit<DepositWithBlock, "originChainId" | "quoteBlockNumber" | "fromLiteChain" | "toLiteChain">;
+  return deposit satisfies Omit<
+    DepositWithBlock,
+    "originChainId" | "quoteBlockNumber" | "fromLiteChain" | "toLiteChain"
+  >;
 }
 
 /**
@@ -478,16 +480,11 @@ export async function findFillEvent(
   );
 
   const [rawEvent] = fillEvents;
-  if (!isDefined(rawEvent)) {
+  if (!isDefined(rawEvent) || rawEvent.name !== "FilledRelay") {
     return;
   }
 
-  // SortableEvent fields are sourced from the transaction envelope; only the fill fields come from event data.
-  const blockNumber = Number(rawEvent.slot);
-  const txnRef = rawEvent.signature.toString();
-  const rawFill = unwrapEventData(rawEvent.data, ["depositId", "inputAmount"]);
-  const fill = unpackFillEvent({ ...rawFill, blockNumber, txnRef, txnIndex: 0, logIndex: 0 }, destinationChainId);
-  return fill satisfies FillWithBlock;
+  return fillFromEvent(rawEvent.data, destinationChainId, rawEvent);
 }
 
 /**
@@ -1019,6 +1016,83 @@ export type SvmRelayEventData = Omit<SvmSpokeClient.RelayData, "message"> & { me
  */
 export function getRelayDataHashFromEvent(event: SvmRelayEventData, destinationChainId: number): string {
   return hashRelayData(event, Uint8Array.from(event.messageHash), destinationChainId);
+}
+
+// The transaction envelope fields that locate an event on chain (SortableEvent provenance).
+type EventEnvelope = Pick<EventWithData, "slot" | "signature">;
+
+/**
+ * Converts typed FundsDeposited event data into an SDK Deposit. The deposit's origin chain is not part of the
+ * event and must be supplied by the caller (it is implied by the SpokePool the event was read from).
+ */
+export function depositFromEvent(
+  data: EventNameToData["FundsDeposited"],
+  originChainId: number,
+  { slot, signature }: EventEnvelope
+): Omit<DepositWithBlock, "quoteBlockNumber" | "fromLiteChain" | "toLiteChain"> {
+  const destinationChainId = Number(data.destinationChainId);
+  const message = hexlify(data.message);
+  return {
+    originChainId,
+    destinationChainId,
+    depositId: BigNumber.from(data.depositId),
+    depositor: toAddressType(data.depositor, originChainId),
+    recipient: toAddressType(data.recipient, destinationChainId),
+    inputToken: toAddressType(data.inputToken, originChainId),
+    outputToken: toAddressType(data.outputToken, destinationChainId),
+    inputAmount: BigNumber.from(data.inputAmount),
+    outputAmount: BigNumber.from(data.outputAmount),
+    quoteTimestamp: data.quoteTimestamp,
+    fillDeadline: data.fillDeadline,
+    exclusivityDeadline: data.exclusivityDeadline,
+    exclusiveRelayer: toAddressType(data.exclusiveRelayer, destinationChainId),
+    message,
+    messageHash: getMessageHash(message),
+    blockNumber: Number(slot),
+    txnRef: signature,
+    txnIndex: 0,
+    logIndex: 0,
+  };
+}
+
+/**
+ * Converts typed FilledRelay event data into an SDK Fill. The fill's destination chain is not part of the
+ * event and must be supplied by the caller (it is implied by the SpokePool the event was read from).
+ */
+export function fillFromEvent(
+  data: EventNameToData["FilledRelay"],
+  destinationChainId: number,
+  { slot, signature }: EventEnvelope
+): FillWithBlock {
+  const originChainId = Number(data.originChainId);
+  const repaymentChainId = Number(data.repaymentChainId);
+  return {
+    originChainId,
+    destinationChainId,
+    depositId: BigNumber.from(data.depositId),
+    depositor: toAddressType(data.depositor, originChainId),
+    recipient: toAddressType(data.recipient, destinationChainId),
+    inputToken: toAddressType(data.inputToken, originChainId),
+    outputToken: toAddressType(data.outputToken, destinationChainId),
+    inputAmount: BigNumber.from(data.inputAmount),
+    outputAmount: BigNumber.from(data.outputAmount),
+    fillDeadline: data.fillDeadline,
+    exclusivityDeadline: data.exclusivityDeadline,
+    exclusiveRelayer: toAddressType(data.exclusiveRelayer, destinationChainId),
+    relayer: toAddressType(data.relayer, repaymentChainId),
+    repaymentChainId,
+    messageHash: hexlify(data.messageHash),
+    relayExecutionInfo: {
+      updatedRecipient: toAddressType(data.relayExecutionInfo.updatedRecipient, destinationChainId),
+      updatedMessageHash: hexlify(data.relayExecutionInfo.updatedMessageHash),
+      updatedOutputAmount: BigNumber.from(data.relayExecutionInfo.updatedOutputAmount),
+      fillType: data.relayExecutionInfo.fillType,
+    },
+    blockNumber: Number(slot),
+    txnRef: signature,
+    txnIndex: 0,
+    logIndex: 0,
+  };
 }
 
 async function resolveFillStatusFromPdaEvents(

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -10,11 +10,11 @@ import {
   GetTransactionApi,
   Signature,
 } from "@solana/kit";
-import { bs58, chainIsSvm, getMessageHash, isDefined, toAddressType } from "../../utils";
+import { bs58, chainIsSvm, getMessageHash, isDefined } from "../../utils";
 import { DecodedEvent, EventName, EventWithData, SVMEventNames, SVMProvider } from "./types";
 import { decodeEvent, getFillStatusPda, isDevnet } from "./utils";
-import { Deposit, DepositWithTime, Fill, FillWithTime, RelayDataWithMessageHash } from "../../interfaces";
-import { getRelayDataHash, getRelayDataHashFromEvent, unwrapEventData } from "./";
+import { DepositWithTime, FillWithTime, RelayDataWithMessageHash } from "../../interfaces";
+import { depositFromEvent, fillFromEvent, getRelayDataHash, getRelayDataHashFromEvent } from "./";
 import assert from "assert";
 
 /**
@@ -291,37 +291,18 @@ export class SvmCpiEventsClient {
     ]);
 
     // Filter for FundsDeposited events only
-    const depositEvents = events?.filter((event) => event?.name === SVMEventNames.FundsDeposited);
+    const depositEvents = events?.filter(
+      (event): event is { program: Address } & DecodedEvent<"FundsDeposited"> =>
+        event.name === SVMEventNames.FundsDeposited
+    );
     if (!txDetails || !depositEvents?.length) {
       return;
     }
 
-    return depositEvents.map((event) => {
-      const data = unwrapEventData<
-        Deposit & {
-          depositor: string;
-          recipient: string;
-          exclusiveRelayer: string;
-          inputToken: string;
-          outputToken: string;
-        }
-      >(event.data, ["depositId", "outputAmount"]);
-      return {
-        ...data,
-        depositor: toAddressType(data.depositor, data.originChainId),
-        recipient: toAddressType(data.recipient, data.destinationChainId),
-        exclusiveRelayer: toAddressType(data.exclusiveRelayer, data.destinationChainId),
-        inputToken: toAddressType(data.inputToken, data.originChainId),
-        outputToken: toAddressType(data.outputToken, data.destinationChainId),
-        depositTimestamp: Number(txDetails.blockTime),
-        originChainId,
-        messageHash: getMessageHash(data.message),
-        blockNumber: Number(txDetails.slot),
-        txnIndex: 0,
-        txnRef: txSignature,
-        logIndex: 0,
-      } satisfies DepositEventFromSignature;
-    });
+    return depositEvents.map((event) => ({
+      ...depositFromEvent(event.data, originChainId, { slot: txDetails.slot, signature: txSignature }),
+      depositTimestamp: Number(txDetails.blockTime),
+    }));
   }
 
   /**
@@ -351,37 +332,18 @@ export class SvmCpiEventsClient {
     ]);
 
     // Filter for FilledRelay events only
-    const fillEvents = events?.filter((event) => event?.name === SVMEventNames.FilledRelay);
+    const fillEvents = events?.filter(
+      (event): event is { program: Address } & DecodedEvent<"FilledRelay"> => event.name === SVMEventNames.FilledRelay
+    );
 
     if (!txDetails || !fillEvents?.length) {
       return;
     }
 
-    return fillEvents.map((event) => {
-      const data = unwrapEventData<
-        Fill & {
-          depositor: string;
-          recipient: string;
-          exclusiveRelayer: string;
-          inputToken: string;
-          outputToken: string;
-        }
-      >(event.data, ["depositId", "inputAmount"]);
-      return {
-        ...data,
-        depositor: toAddressType(data.depositor, data.originChainId),
-        recipient: toAddressType(data.recipient, data.destinationChainId),
-        exclusiveRelayer: toAddressType(data.exclusiveRelayer, data.destinationChainId),
-        inputToken: toAddressType(data.inputToken, data.originChainId),
-        outputToken: toAddressType(data.outputToken, data.destinationChainId),
-        fillTimestamp: Number(txDetails.blockTime),
-        blockNumber: Number(txDetails.slot),
-        txnRef: txSignature,
-        txnIndex: 0,
-        logIndex: 0,
-        destinationChainId,
-      } satisfies FillEventFromSignature;
-    });
+    return fillEvents.map((event) => ({
+      ...fillFromEvent(event.data, destinationChainId, { slot: txDetails.slot, signature: txSignature }),
+      fillTimestamp: Number(txDetails.blockTime),
+    }));
   }
 
   public getProgramAddress(): Address {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,6 +1,6 @@
 import { MessageTransmitterClient, SvmSpokeClient, SvmSpokeIdl } from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
-import { BN, Idl } from "@coral-xyz/anchor";
+import { Idl } from "@coral-xyz/anchor";
 import {
   Address,
   Instruction,
@@ -25,8 +25,8 @@ import {
 import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
-import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, getMessageHash, isByteArray, isDefined } from "../../utils";
+import { RelayData, RelayDataWithMessageHash } from "../../interfaces";
+import { BigNumber, Address as SdkAddress, getMessageHash, isDefined } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -88,39 +88,6 @@ export async function getNearestSlotTime(
   assert(isDefined(timestamp), `Unable to resolve block time for SVM slot ${slot}`);
 
   return { slot, timestamp };
-}
-
-/**
- * Parses event data from a transaction.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function parseEventData(eventData: any): any {
-  if (!eventData) return eventData;
-
-  if (Array.isArray(eventData)) {
-    return eventData.map(parseEventData);
-  }
-
-  if (Buffer.isBuffer(eventData)) {
-    return new Uint8Array(eventData);
-  }
-
-  if (typeof eventData === "object") {
-    const stringTag = Object.prototype.toString.call(eventData);
-    if (stringTag.includes("PublicKey")) {
-      return address(eventData.toString());
-    }
-    if (BN.isBN(eventData)) {
-      return BigInt(eventData.toString());
-    }
-
-    // Convert each key from snake_case to camelCase and process the value recursively.
-    return Object.fromEntries(
-      Object.entries(eventData).map(([key, value]) => [snakeToCamel(key), parseEventData(value)])
-    );
-  }
-
-  return eventData;
 }
 
 // Codama decoders generated from the SvmSpoke program, keyed by event name. Decoding with these (rather than the
@@ -209,13 +176,6 @@ export function decodeEvent(idl: Idl, rawEvent: string): DecodedEvent {
 }
 
 /**
- * Converts a snake_case string to camelCase.
- */
-function snakeToCamel(s: string): string {
-  return s.replace(/(_\w)/g, (match) => match[1].toUpperCase());
-}
-
-/**
  * Gets the event name from a raw name.
  */
 function isEventName(name: string): name is EventName {
@@ -270,10 +230,9 @@ function unwrapEventDataInner(
     }
     return BigNumber.from(data);
   }
-  // Handle Uint8Array and byte arrays
-  if (isByteArray(data)) {
-    const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
-    const hex = ethers.utils.hexlify(bytes);
+  // Handle byte arrays
+  if (data instanceof Uint8Array) {
+    const hex = ethers.utils.hexlify(data);
     if (currentKey && uint8ArrayKeysAsBigInt.includes(currentKey)) {
       return BigNumber.from(hex);
     }
@@ -289,22 +248,6 @@ function unwrapEventDataInner(
   }
   // Handle objects
   if (isUnwrappedRecord(data)) {
-    // Special case: if an object is in the context of the fillType key, then
-    // parse out the fillType from the object
-    if (currentKey === "fillType") {
-      const fillType = Object.keys(data)[0];
-      switch (fillType) {
-        case "FastFill":
-          return FillType.FastFill;
-        case "ReplacedSlowFill":
-          return FillType.ReplacedSlowFill;
-        case "SlowFill":
-          return FillType.SlowFill;
-        default:
-          throw new Error(`Unknown fill type: ${fillType}`);
-      }
-    }
-
     // Special case: if an object is empty, return 0x
     if (Object.keys(data).length === 0) {
       return "0x";

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -168,30 +168,3 @@ export function includesAsync<T>(
 export function isArrayOf<T>(array: unknown, predicate: (value: unknown) => value is T): array is T[] {
   return Array.isArray(array) && array.every(predicate);
 }
-
-/**
- * Checks whether a value is a byte array in either of its decoded representations: a Uint8Array, or a
- * non-empty plain array of integers in [0, 255] (as produced for fixed byte-array fields by Anchor borsh
- * decoding). An empty plain array is not considered a byte array, since it is indistinguishable from an
- * empty list.
- * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
- */
-export function isByteArray(value: unknown): value is Uint8Array | number[] {
-  return value instanceof Uint8Array || isUint8Array(value);
-}
-
-/**
- * Checks if a value is a byte array: a plain array of integers in [0, 255], as produced for fixed byte-array
- * fields by Anchor borsh decoding. Note that this deliberately matches number[] and NOT Uint8Array instances;
- * prefer isByteArray(), which matches both representations.
- * @param value The value to check.
- * @returns True if the value is a byte array, false otherwise.
- */
-export function isUint8Array(value: unknown): value is number[] {
-  return (
-    Array.isArray(value) &&
-    value.length > 0 &&
-    value.every((item) => typeof item === "number" && Number.isInteger(item) && item >= 0 && item < 256)
-  );
-}


### PR DESCRIPTION
Add depositFromEvent()/fillFromEvent() to convert typed
FundsDeposited/FilledRelay event data directly to SDK Deposit/Fill
types, replacing the unwrapEventData claim-and-convert chains in
findDeposit, findFillEvent and getDeposit/FillEventsFromSignature. This
fixes three bugs the generic claims hid: the signature helpers converted
addresses with chain IDs read from fields that do not exist on the event
(originChainId on FundsDeposited, destinationChainId on FilledRelay),
yielding RawAddress instead of the native address types, and the fill
helper never converted relayer/updatedRecipient at all. Retire the
legacy unwrap remnants (the number[] byte-array heuristic, the fillType
variant-object branch, isUint8Array); parseEventData stays, since the
generic Anchor path (non-bundled IDLs) still decodes through it. The
differential validation script (committed in the decode PR) keeps the
retired unwrap semantics frozen verbatim as its legacy reference.