### PR TITLE
fix(BlockUtils): take the head from a block, not a block number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.18",
+  "version": "4.4.19",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/evm/BlockUtils.ts
+++ b/src/arch/evm/BlockUtils.ts
@@ -61,12 +61,12 @@ export async function averageBlockTime(
   // If the caller was not specific about highBlock, resolve it via the RPC provider. Subtract an offset
   // to account for various RPC provider sync issues that might occur when querting the latest block.
   if (!isDefined(highBlock)) {
-    // Take the head from a block rather than from a block number. A number is just a counter and is not a
-    // promise that the provider can serve it: getBlockNumber() is clamped to a monotonic high-water mark
-    // (BaseProvider._maxInternalBlockNumber, never lowered for the life of the provider), so it keeps
-    // reporting a height the chain has since rolled back past, and a load-balanced pool can answer
-    // eth_blockNumber from a synced node and eth_getBlockByNumber from a lagging one. getBlock("latest") is
-    // not clamped, so the number on the block it returns is a height the provider actually served.
+    // Take the head from a block rather than from a block number. getBlockNumber() is clamped to a
+    // monotonic high-water mark (BaseProvider._maxInternalBlockNumber, never lowered for the life of the
+    // provider): across a pool of backends at different heights it settles on the furthest-ahead one ever
+    // seen and so outruns whichever backend serves the follow-up eth_getBlockByNumber, and it survives the
+    // chain moving backwards underneath it (evm_revert in tests). getBlock("latest") is not clamped, so the
+    // number on the block it returns is a height the backend that answered actually served.
     const latest = await provider.getBlock("latest");
     if (!isDefined(latest?.number)) {
       throw new Error(`BlockFinder: Failed to fetch the latest block on ${getNetworkName(chainId)}`);

--- a/src/arch/evm/BlockUtils.ts
+++ b/src/arch/evm/BlockUtils.ts
@@ -61,11 +61,12 @@ export async function averageBlockTime(
   // If the caller was not specific about highBlock, resolve it via the RPC provider. Subtract an offset
   // to account for various RPC provider sync issues that might occur when querting the latest block.
   if (!isDefined(highBlock)) {
-    // Take the head from a block rather than from a block number. A number is just a counter and is not
-    // a promise that the provider can serve it: ethers memoises the block number as a monotonic
-    // high-water mark, so it keeps reporting a height the chain has since rolled back past, and a
-    // load-balanced pool can answer eth_blockNumber from a synced node and eth_getBlockByNumber from a
-    // lagging one. The number on a block the provider actually returned is a height it can serve.
+    // Take the head from a block rather than from a block number. A number is just a counter and is not a
+    // promise that the provider can serve it: getBlockNumber() is clamped to a monotonic high-water mark
+    // (BaseProvider._maxInternalBlockNumber, never lowered for the life of the provider), so it keeps
+    // reporting a height the chain has since rolled back past, and a load-balanced pool can answer
+    // eth_blockNumber from a synced node and eth_getBlockByNumber from a lagging one. getBlock("latest") is
+    // not clamped, so the number on the block it returns is a height the provider actually served.
     const latest = await provider.getBlock("latest");
     if (!isDefined(latest?.number)) {
       throw new Error(`BlockFinder: Failed to fetch the latest block on ${getNetworkName(chainId)}`);

--- a/src/arch/evm/BlockUtils.ts
+++ b/src/arch/evm/BlockUtils.ts
@@ -61,7 +61,16 @@ export async function averageBlockTime(
   // If the caller was not specific about highBlock, resolve it via the RPC provider. Subtract an offset
   // to account for various RPC provider sync issues that might occur when querting the latest block.
   if (!isDefined(highBlock)) {
-    const latestBlock = await provider.getBlockNumber();
+    // Take the head from a block rather than from a block number. A number is just a counter and is not
+    // a promise that the provider can serve it: ethers memoises the block number as a monotonic
+    // high-water mark, so it keeps reporting a height the chain has since rolled back past, and a
+    // load-balanced pool can answer eth_blockNumber from a synced node and eth_getBlockByNumber from a
+    // lagging one. The number on a block the provider actually returned is a height it can serve.
+    const latest = await provider.getBlock("latest");
+    if (!isDefined(latest?.number)) {
+      throw new Error(`BlockFinder: Failed to fetch the latest block on ${getNetworkName(chainId)}`);
+    }
+    const latestBlock = latest.number;
     highBlock = latestBlock - (highBlockOffset ?? defaultHighBlockOffset);
 
     // The offset presumes a chain with more blocks than the offset itself. Below that it puts the entire

--- a/test/BlockUtils.test.ts
+++ b/test/BlockUtils.test.ts
@@ -13,30 +13,39 @@ const GENESIS_TIMESTAMP = 1_700_000_000;
 type FakeProvider = {
   provider: Provider;
   chainId: number;
-  requestedBlocks: number[];
+  requestedBlocks: number[]; // Numeric block tags requested, i.e. the sample window.
+  headRequests: string[]; // "latest" requests, i.e. head resolution.
 };
 
 /**
  * A provider backed by a synthetic chain of `height + 1` blocks, spaced BLOCK_TIME apart. Supply a chainId
- * to present a second view of a chain already seen by averageBlockTime.
+ * to present a second view of a chain already seen by averageBlockTime. Supply a reportedHeight above
+ * `height` to model a provider whose block number runs ahead of the blocks it will serve.
  */
-function fakeProvider(height: number, chainId = nextChainId++): FakeProvider {
+function fakeProvider(height: number, chainId = nextChainId++, reportedHeight = height): FakeProvider {
   const requestedBlocks: number[] = [];
+  const headRequests: string[] = [];
+
+  const blockAt = (number: number) => ({ number, timestamp: GENESIS_TIMESTAMP + number * BLOCK_TIME });
 
   const provider = {
     getNetwork: () => Promise.resolve({ chainId, name: `chain-${chainId}` }),
-    getBlockNumber: () => Promise.resolve(height),
-    getBlock: (blockTag: number) => {
+    getBlockNumber: () => Promise.resolve(reportedHeight),
+    getBlock: (blockTag: number | string) => {
+      if (typeof blockTag === "string") {
+        headRequests.push(blockTag);
+        return Promise.resolve(blockAt(height));
+      }
       requestedBlocks.push(blockTag);
 
       // Mirror ethers, which does not reject a negative block number but resolves it relative to the head,
       // clamping at genesis.
       const number = blockTag < 0 ? Math.max(height + blockTag, 0) : blockTag;
-      return Promise.resolve(number > height ? null : { number, timestamp: GENESIS_TIMESTAMP + number * BLOCK_TIME });
+      return Promise.resolve(number > height ? null : blockAt(number));
     },
   } as unknown as Provider;
 
-  return { provider, chainId, requestedBlocks };
+  return { provider, chainId, requestedBlocks, headRequests };
 }
 
 describe("BlockUtils: averageBlockTime", () => {
@@ -52,13 +61,30 @@ describe("BlockUtils: averageBlockTime", () => {
   });
 
   it("honours an explicit highBlock and blockRange", async () => {
-    const { provider, requestedBlocks } = fakeProvider(5000);
+    const { provider, requestedBlocks, headRequests } = fakeProvider(5000);
 
     const { average, blockRange } = await averageBlockTime(provider, { highBlock: 1000, blockRange: 50 });
 
     expect(average).to.equal(BLOCK_TIME);
     expect(blockRange).to.equal(50);
     expect(requestedBlocks).to.have.members([950, 1000]);
+    expect(headRequests).to.be.empty; // The caller supplied the head, so there is nothing to resolve.
+  });
+
+  it("takes the head from a block the provider can serve, not from its reported height", async () => {
+    // ethers memoises the block number as a monotonic high-water mark, so once a chain rolls back -- a
+    // reorg, or evm_revert against a test chain -- getBlockNumber() keeps reporting the pre-rollback
+    // height. A load-balanced RPC pool has the same shape: eth_blockNumber answered by a synced node,
+    // eth_getBlockByNumber by a lagging one. Either way the window lands above the served height and the
+    // whole computation fails on a block that cannot be fetched.
+    const { provider, requestedBlocks, headRequests } = fakeProvider(60, nextChainId++, 200);
+
+    const { average, blockRange } = await averageBlockTime(provider);
+
+    expect(average).to.equal(BLOCK_TIME);
+    expect(blockRange).to.equal(50);
+    expect(headRequests).to.have.length(1);
+    expect(requestedBlocks).to.have.members([0, 50]); // Off the served head of 60, not the reported 200.
   });
 
   it("starts the window at genesis and divides by the range actually sampled", async () => {
@@ -120,12 +146,13 @@ describe("BlockUtils: averageBlockTime", () => {
   });
 
   it("memoises per chain", async () => {
-    const { provider, requestedBlocks } = fakeProvider(5000);
+    const { provider, requestedBlocks, headRequests } = fakeProvider(5000);
 
     const first = await averageBlockTime(provider);
     const second = await averageBlockTime(provider);
 
     expect(second).to.deep.equal(first);
     expect(requestedBlocks.length).to.equal(2); // Only the first call reached the provider.
+    expect(headRequests.length).to.equal(1);
   });
 });


### PR DESCRIPTION
Follow-up to #1504. Fixes the flake behind the two `SpokePoolClient: Event Filtering` failures that have now hit at least twice on unrelated branches — [pxrl/svm6](https://github.com/across-protocol/sdk/actions/runs/31409878380) (`block 98`) and `droplet/harden-toaddresstype-tvm` on 2026-07-27 ([run 30277548130](https://github.com/across-protocol/sdk/actions/runs/30277548130), `block -15` there, before #1504 clamped the low end).

## The bug

`averageBlockTime` resolves the head with `provider.getBlockNumber()`, then samples `highBlock = head - 10`. A block number is a counter, not a promise that the provider can serve that height. When it can't, `getBlock` returns null and the whole computation dies:

```
Error: BlockFinder: Failed to fetch block 98 on HardhatNetwork
  at averageBlockTime (src/arch/evm/BlockUtils.ts:82)
  at EVMBlockFinder.getBlockForTimestamp → MockHubPoolClient.getBlockNumbers → queryDepositEvents
```

Two ways the reported head gets ahead of the servable one:

1. **ethers memoises it as a monotonic high-water mark.** `BaseProvider._getInternalBlockNumber` does `if (blockNumber < this._maxInternalBlockNumber) { blockNumber = this._maxInternalBlockNumber; }`, so once a chain rolls back, that provider keeps reporting the pre-rollback height forever.
2. **A load-balanced RPC pool** can answer `eth_blockNumber` from a synced node and the following `eth_getBlockByNumber` from a lagging one. This is the case `defaultHighBlockOffset` exists to absorb — but subtracting 10 doesn't help when the reported head is itself unreachable.

In our test suite it is (1). `test/fixtures/utils.ts` rolls the shared Hardhat chain backwards with `evm_snapshot`/`evm_revert`. `hardhat-ethers` knows ethers goes stale across a revert and handles it by swapping the underlying provider behind `hre.ethers.provider` ([`provider-proxy.ts`](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-ethers/src/internal/provider-proxy.ts), `HARDHAT_NETWORK_REVERT_SNAPSHOT_EVENT`) — but contracts hold `signer.provider`, the concrete wrapper from *before* the revert, which never sees the swap. `MockHubPoolClient`'s `EVMBlockFinder` uses `hubPool.provider`, i.e. that stale wrapper:

```
realHead=20  signer.provider head=120  hre.ethers.provider head=20  getBlock(110)=null
```

Because the result is memoised per chainId for 15 minutes, only the *first* chain-31337 call in a process can trip it. Which test that is depends on file order, block counts and the suite's unseeded `Math.random()`, so it moves with any unrelated change — which is why it reads as an SVM PR breaking an EVM test.

## The change

Take the head from `provider.getBlock("latest")`. The number on a block the provider actually returned is a height it can serve, so `head - 10` and the window below it are reachable by construction. Same number of RPC calls as before; `getBlockNumber()` is simply not a safe source for a height you intend to fetch.

## Tests

New case in `test/BlockUtils.test.ts`, over a synthetic provider whose `getBlockNumber()` reports 200 while it only serves 60. Fails on `master` with `Failed to fetch block 70`, passes here. The two existing `headRequests` assertions also fail on `master` by construction. 9 passing.

Verified against the real failure mode too — a scratch test that captures `signer.provider`, seeds the high-water mark at 120, `evm_revert`s to 20, and calls `averageBlockTime` on the captured provider:

```
without: Error: BlockFinder: Failed to fetch block 110 on HardhatNetwork
with:    realHead=20 reportedHead=120 avg=1 range=10
```

`yarn hardhat test` over the 37 non-Solana, non-arlocal test files: **352 passing** here vs **351** on `master` (the delta is the added case), nothing else moves. Solana files need `solana-test-validator` and `arweaveClient.ts` needs `arlocal`/`sqlite3`, neither of which I have locally; CI covers both. `eslint`, `prettier` and `tsc --noEmit` clean.

## Real-world exposure

Raised in review: a 20-block reorg is not a realistic scenario for most chains. Agreed — reorg depth is the wrong frame, and the fix does not depend on it.

The clamp is a *ratchet*, not a reorg detector. `RetryProvider` is a single ethers instance whose `send` fans out to N `CacheProvider` backends, and `_getQuorum` gives `eth_blockNumber` quorum 1 — so `_maxInternalBlockNumber` is a max over whichever backend happened to answer, taken across the entire life of the process. It settles on the furthest-ahead backend ever seen and never decays. Modelling our own pool shape, no rollback anywhere, chain only ever moving forward:

```
Pool: node A at height 200, node B at height 170. No reorg -- just sync skew.

1. A answers once (routine):        getBlockNumber() = 200
2. Only B serves from here on:
     raw eth_blockNumber (B's truth) = 170
     getBlockNumber()                = 200 <- latched to A's height, forever
     getBlock('latest').number       = 170 <- follows whoever answered
3. highBlock = head - 10, fetched against B:
     getBlockNumber()   : highBlock=190 -> NULL -> throws 'Failed to fetch block'
     getBlock('latest') : highBlock=160 -> OK
4. A itself falls back to 170 (whole pool now consistent at 170):
     getBlockNumber()          = 200 <- still 200, never decays
     getBlock('latest').number = 170 <- self-corrects
```

Step 4 is the property worth removing: one reading from a backend that was ahead — or briefly desynced — poisons the provider for the rest of the process, with no path back short of a restart.

**The offset is denominated in blocks; skew is denominated in seconds.** Against the block times this file already seeds, `defaultHighBlockOffset` buys:

| chain | block time | 10 blocks of tolerance |
|---|---|---|
| Mainnet | 12.5s | 125s |
| Linea, Tron | 3s | 30s |
| Optimism (+ OP stack) | 2s | 20s |
| Ink, MegaETH, Unichain | 1s | 10s |

So on mainnet the reviewer's instinct is right — a backend 125s behind is a broken backend, and this path is effectively never what breaks. The exposure is on the 1–2s chains, where a backend ten seconds behind is unremarkable.

**Severity scales with process lifetime**, since the ratchet needs time to accumulate. Short-lived serverless callers barely see it; long-lived relayer/dataworker processes are where it collects.

**Evidence, stated honestly:** the reproduced case is the CI flake above (`evm_revert`, `realHead=20 reportedHead=120`) — that one is measured and has cost us two runs. For production I have *no* evidence either way: Datadog carries only `app-frontend-v3`, which returns zero hits for `Failed to fetch block` over 30 days, but the relayer and dataworker don't ship logs there, and the frontend is short-lived enough that the ratchet could not accumulate anyway. I'm not claiming that clean search validates anything.

**Blast radius** of the no-`highBlock` path: `estimateBlocksElapsed` → `EVMBlockFinder.getBlockForTimestamp` (core timestamp→block resolution), plus `AcrossConfigStoreClient.ts:410`, where a throw escapes a `catch` that exists to suppress noisy warnings.

## Note

#1513 is unaffected by this and was only ever a victim of the flake — I re-ran its `Test` job on the same commit and it went green, so it does not need to wait for this.

Bumped to `4.4.19` per the convention in recent fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
