### PR TITLE
improve(svm): Decode CCTP events with the generated codama decoders

### DIFF
--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -230,17 +230,45 @@ const messageTransmitterEventDecoders: {
   Unpause: MessageTransmitterClient.getUnpauseDecoder,
 };
 
-// Codama decoders for the CCTP programs consumed through SvmCpiEventsClient, keyed by program (IDL) address.
-// Exported for the table-completeness unit tests.
-export const cctpEventDecoders: Record<string, Record<string, () => Decoder<unknown>> | undefined> = {
-  [TokenMessengerMinterIdl.address]: tokenMessengerMinterEventDecoders,
-  [MessageTransmitterIdl.address]: messageTransmitterEventDecoders,
+// Codama decoders for the CCTP programs consumed through SvmCpiEventsClient, keyed by program (IDL) address,
+// alongside the bundled IDL each decoder set was generated from. Exported for the table-completeness unit tests.
+export const cctpPrograms: Record<
+  string,
+  { idl: Idl; eventDecoders: Record<string, () => Decoder<unknown>> } | undefined
+> = {
+  [TokenMessengerMinterIdl.address]: { idl: TokenMessengerMinterIdl, eventDecoders: tokenMessengerMinterEventDecoders },
+  [MessageTransmitterIdl.address]: { idl: MessageTransmitterIdl, eventDecoders: messageTransmitterEventDecoders },
 };
+
+// A program address is retained across program (IDL) upgrades, so it does not by itself prove that the bundled
+// decoders match a caller-supplied IDL: an event with an unchanged name/discriminator but an updated payload
+// layout would silently decode into shifted fields. Verify the schema itself (events + types), cached per IDL
+// instance since IDLs are module-level constants.
+const bundledIdlMatches = new WeakMap<Idl, boolean>();
+function matchesBundledIdl(idl: Idl, bundled: Idl): boolean {
+  if (idl === bundled) {
+    return true;
+  }
+  let match = bundledIdlMatches.get(idl);
+  if (match === undefined) {
+    const schema = ({ events, types }: Idl) => JSON.stringify({ events, types });
+    match = schema(idl) === schema(bundled);
+    bundledIdlMatches.set(idl, match);
+  }
+  return match;
+}
 
 export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
   // The generated decoders only apply to SvmSpoke events; any other program's events (e.g. the CCTP
   // TokenMessengerMinter and MessageTransmitter programs) are decoded generically below.
   if (idl.address === SvmSpokeIdl.address) {
+    // A supplied SvmSpoke IDL whose schema has drifted from the bundled one must never be decoded with the
+    // bundled decoders (shifted fields), and downstream consumers rely on the generated types, so the generic
+    // path is not a safe fallback either: fail loudly.
+    assert(
+      matchesBundledIdl(idl, SvmSpokeIdl),
+      "decodeEvent: supplied SvmSpoke IDL does not match the bundled SvmSpoke IDL"
+    );
     // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
     // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
     // Uint8Array that the generated types promise.
@@ -257,13 +285,14 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: 
   }
 
   // CCTP programs: decode with the generated codama decoders so that the decoded data matches the generated
-  // event types. Events missing from a decoder table fall through to the generic Anchor path below.
-  const decoders = cctpEventDecoders[idl.address];
-  if (isDefined(decoders)) {
+  // event types. Events missing from a decoder table, or a supplied IDL whose schema has drifted from the
+  // bundled one, fall through to the generic Anchor path below, which decodes per the supplied IDL.
+  const cctpProgram = cctpPrograms[idl.address];
+  if (isDefined(cctpProgram) && matchesBundledIdl(idl, cctpProgram.idl)) {
     const rawEventData = getBase64Encoder().encode(rawEvent);
     const discriminator = rawEventData.subarray(0, 8);
     const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
-    const decoder = isDefined(name) ? decoders[name] : undefined;
+    const decoder = isDefined(name) ? cctpProgram.eventDecoders[name] : undefined;
     if (isDefined(name) && isDefined(decoder)) {
       return { name, data: decoder().decode(rawEventData, discriminator.length) };
     }

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -240,35 +240,10 @@ export const cctpPrograms: Record<
   [MessageTransmitterIdl.address]: { idl: MessageTransmitterIdl, eventDecoders: messageTransmitterEventDecoders },
 };
 
-// A program address is retained across program (IDL) upgrades, so it does not by itself prove that the bundled
-// decoders match a caller-supplied IDL: an event with an unchanged name/discriminator but an updated payload
-// layout would silently decode into shifted fields. Verify the schema itself (events + types), cached per IDL
-// instance since IDLs are module-level constants.
-const bundledIdlMatches = new WeakMap<Idl, boolean>();
-function matchesBundledIdl(idl: Idl, bundled: Idl): boolean {
-  if (idl === bundled) {
-    return true;
-  }
-  let match = bundledIdlMatches.get(idl);
-  if (match === undefined) {
-    const schema = ({ events, types }: Idl) => JSON.stringify({ events, types });
-    match = schema(idl) === schema(bundled);
-    bundledIdlMatches.set(idl, match);
-  }
-  return match;
-}
-
 export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
   // The generated decoders only apply to SvmSpoke events; any other program's events (e.g. the CCTP
   // TokenMessengerMinter and MessageTransmitter programs) are decoded generically below.
   if (idl.address === SvmSpokeIdl.address) {
-    // A supplied SvmSpoke IDL whose schema has drifted from the bundled one must never be decoded with the
-    // bundled decoders (shifted fields), and downstream consumers rely on the generated types, so the generic
-    // path is not a safe fallback either: fail loudly.
-    assert(
-      matchesBundledIdl(idl, SvmSpokeIdl),
-      "decodeEvent: supplied SvmSpoke IDL does not match the bundled SvmSpoke IDL"
-    );
     // Decode to a plain Uint8Array, not a Buffer: the generated decoders slice their input to populate byte-array
     // fields, and slicing a Buffer yields a Buffer, whose toString() and JSON serialisation differ from the
     // Uint8Array that the generated types promise.
@@ -285,10 +260,13 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: 
   }
 
   // CCTP programs: decode with the generated codama decoders so that the decoded data matches the generated
-  // event types. Events missing from a decoder table, or a supplied IDL whose schema has drifted from the
-  // bundled one, fall through to the generic Anchor path below, which decodes per the supplied IDL.
+  // event types. The bundled decoders only apply when the caller supplied the exact bundled IDL instance: a
+  // program address is retained across IDL upgrades, so a different instance (e.g. from a skewed
+  // @across-protocol/contracts version) may carry updated event layouts that the bundled decoders would
+  // silently mis-decode. Any other IDL instance, and any event missing from a decoder table, falls through to
+  // the generic Anchor path below, which decodes per the supplied IDL.
   const cctpProgram = cctpPrograms[idl.address];
-  if (isDefined(cctpProgram) && matchesBundledIdl(idl, cctpProgram.idl)) {
+  if (isDefined(cctpProgram) && idl === cctpProgram.idl) {
     const rawEventData = getBase64Encoder().encode(rawEvent);
     const discriminator = rawEventData.subarray(0, 8);
     const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,4 +1,11 @@
-import { MessageTransmitterClient, SvmSpokeClient, SvmSpokeIdl } from "@across-protocol/contracts";
+import {
+  MessageTransmitterClient,
+  MessageTransmitterIdl,
+  SvmSpokeClient,
+  SvmSpokeIdl,
+  TokenMessengerMinterClient,
+  TokenMessengerMinterIdl,
+} from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
 import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
 import {
@@ -150,6 +157,86 @@ const svmSpokeEventDecoders: Record<EventName, () => Decoder<EventData>> = {
  * corresponding decoder generated from the program, so the decoded data matches the generated event types.
  * Events that cannot be identified are rejected.
  */
+// Per-program maps of CCTP event name to the event data type generated from the program. The decoder tables
+// below are typed against these maps, so a decoder registered under the wrong name is a compile error (up to
+// structural identity), and the completeness of each table against its IDL is pinned by a unit test.
+interface TokenMessengerMinterEvents {
+  OwnershipTransferStarted: TokenMessengerMinterClient.OwnershipTransferStarted;
+  OwnershipTransferred: TokenMessengerMinterClient.OwnershipTransferred;
+  DepositForBurn: TokenMessengerMinterClient.DepositForBurn;
+  MintAndWithdraw: TokenMessengerMinterClient.MintAndWithdraw;
+  RemoteTokenMessengerAdded: TokenMessengerMinterClient.RemoteTokenMessengerAdded;
+  RemoteTokenMessengerRemoved: TokenMessengerMinterClient.RemoteTokenMessengerRemoved;
+  SetTokenController: TokenMessengerMinterClient.SetTokenController;
+  PauserChanged: TokenMessengerMinterClient.PauserChanged;
+  SetBurnLimitPerMessage: TokenMessengerMinterClient.SetBurnLimitPerMessage;
+  LocalTokenAdded: TokenMessengerMinterClient.LocalTokenAdded;
+  LocalTokenRemoved: TokenMessengerMinterClient.LocalTokenRemoved;
+  TokenPairLinked: TokenMessengerMinterClient.TokenPairLinked;
+  TokenPairUnlinked: TokenMessengerMinterClient.TokenPairUnlinked;
+  Pause: TokenMessengerMinterClient.Pause;
+  Unpause: TokenMessengerMinterClient.Unpause;
+  TokenCustodyBurned: TokenMessengerMinterClient.TokenCustodyBurned;
+}
+
+interface MessageTransmitterEvents {
+  OwnershipTransferStarted: MessageTransmitterClient.OwnershipTransferStarted;
+  OwnershipTransferred: MessageTransmitterClient.OwnershipTransferred;
+  PauserChanged: MessageTransmitterClient.PauserChanged;
+  AttesterManagerUpdated: MessageTransmitterClient.AttesterManagerUpdated;
+  MessageReceived: MessageTransmitterClient.MessageReceived;
+  SignatureThresholdUpdated: MessageTransmitterClient.SignatureThresholdUpdated;
+  AttesterEnabled: MessageTransmitterClient.AttesterEnabled;
+  AttesterDisabled: MessageTransmitterClient.AttesterDisabled;
+  MaxMessageBodySizeUpdated: MessageTransmitterClient.MaxMessageBodySizeUpdated;
+  Pause: MessageTransmitterClient.Pause;
+  Unpause: MessageTransmitterClient.Unpause;
+}
+
+const tokenMessengerMinterEventDecoders: {
+  [N in keyof TokenMessengerMinterEvents]: () => Decoder<TokenMessengerMinterEvents[N]>;
+} = {
+  OwnershipTransferStarted: TokenMessengerMinterClient.getOwnershipTransferStartedDecoder,
+  OwnershipTransferred: TokenMessengerMinterClient.getOwnershipTransferredDecoder,
+  DepositForBurn: TokenMessengerMinterClient.getDepositForBurnDecoder,
+  MintAndWithdraw: TokenMessengerMinterClient.getMintAndWithdrawDecoder,
+  RemoteTokenMessengerAdded: TokenMessengerMinterClient.getRemoteTokenMessengerAddedDecoder,
+  RemoteTokenMessengerRemoved: TokenMessengerMinterClient.getRemoteTokenMessengerRemovedDecoder,
+  SetTokenController: TokenMessengerMinterClient.getSetTokenControllerDecoder,
+  PauserChanged: TokenMessengerMinterClient.getPauserChangedDecoder,
+  SetBurnLimitPerMessage: TokenMessengerMinterClient.getSetBurnLimitPerMessageDecoder,
+  LocalTokenAdded: TokenMessengerMinterClient.getLocalTokenAddedDecoder,
+  LocalTokenRemoved: TokenMessengerMinterClient.getLocalTokenRemovedDecoder,
+  TokenPairLinked: TokenMessengerMinterClient.getTokenPairLinkedDecoder,
+  TokenPairUnlinked: TokenMessengerMinterClient.getTokenPairUnlinkedDecoder,
+  Pause: TokenMessengerMinterClient.getPauseDecoder,
+  Unpause: TokenMessengerMinterClient.getUnpauseDecoder,
+  TokenCustodyBurned: TokenMessengerMinterClient.getTokenCustodyBurnedDecoder,
+};
+
+const messageTransmitterEventDecoders: {
+  [N in keyof MessageTransmitterEvents]: () => Decoder<MessageTransmitterEvents[N]>;
+} = {
+  OwnershipTransferStarted: MessageTransmitterClient.getOwnershipTransferStartedDecoder,
+  OwnershipTransferred: MessageTransmitterClient.getOwnershipTransferredDecoder,
+  PauserChanged: MessageTransmitterClient.getPauserChangedDecoder,
+  AttesterManagerUpdated: MessageTransmitterClient.getAttesterManagerUpdatedDecoder,
+  MessageReceived: MessageTransmitterClient.getMessageReceivedDecoder,
+  SignatureThresholdUpdated: MessageTransmitterClient.getSignatureThresholdUpdatedDecoder,
+  AttesterEnabled: MessageTransmitterClient.getAttesterEnabledDecoder,
+  AttesterDisabled: MessageTransmitterClient.getAttesterDisabledDecoder,
+  MaxMessageBodySizeUpdated: MessageTransmitterClient.getMaxMessageBodySizeUpdatedDecoder,
+  Pause: MessageTransmitterClient.getPauseDecoder,
+  Unpause: MessageTransmitterClient.getUnpauseDecoder,
+};
+
+// Codama decoders for the CCTP programs consumed through SvmCpiEventsClient, keyed by program (IDL) address.
+// Exported for the table-completeness unit tests.
+export const cctpEventDecoders: Record<string, Record<string, () => Decoder<unknown>> | undefined> = {
+  [TokenMessengerMinterIdl.address]: tokenMessengerMinterEventDecoders,
+  [MessageTransmitterIdl.address]: messageTransmitterEventDecoders,
+};
+
 export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
   // The generated decoders only apply to SvmSpoke events; any other program's events (e.g. the CCTP
   // TokenMessengerMinter and MessageTransmitter programs) are decoded generically below.
@@ -167,6 +254,19 @@ export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: 
 
     // Skip the discriminator; the event data follows it.
     return { name, data: svmSpokeEventDecoders[name]().decode(rawEventData, discriminator.length) };
+  }
+
+  // CCTP programs: decode with the generated codama decoders so that the decoded data matches the generated
+  // event types. Events missing from a decoder table fall through to the generic Anchor path below.
+  const decoders = cctpEventDecoders[idl.address];
+  if (isDefined(decoders)) {
+    const rawEventData = getBase64Encoder().encode(rawEvent);
+    const discriminator = rawEventData.subarray(0, 8);
+    const name = (idl.events ?? []).find((event) => Buffer.from(event.discriminator).equals(discriminator))?.name;
+    const decoder = isDefined(name) ? decoders[name] : undefined;
+    if (isDefined(name) && isDefined(decoder)) {
+      return { name, data: decoder().decode(rawEventData, discriminator.length) };
+    }
   }
 
   const event = new BorshEventCoder(idl).decode(rawEvent);

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@across-protocol/contracts";
 import { BorshEventCoder, Idl } from "@coral-xyz/anchor";
 import { type ReadonlyUint8Array } from "@solana/kit";
-import { cctpEventDecoders, decodeEvent, getRandomSvmAddress, parseEventData } from "../src/arch/svm";
+import { cctpPrograms, decodeEvent, getRandomSvmAddress, parseEventData } from "../src/arch/svm";
 import { expect } from "./utils";
 
 // Decode through the legacy pipeline (generic Anchor coder + parseEventData) for differential comparison.
@@ -28,12 +28,50 @@ describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
   it("registers a decoder for every CCTP IDL event", () => {
     const cctpIdls: Idl[] = [TokenMessengerMinterIdl, MessageTransmitterIdl];
     for (const idl of cctpIdls) {
-      const decoders = cctpEventDecoders[idl.address];
-      expect(decoders, idl.address).to.not.equal(undefined);
-      const tableNames = Object.keys(decoders ?? {}).sort();
+      const program = cctpPrograms[idl.address];
+      expect(program, idl.address).to.not.equal(undefined);
+      const tableNames = Object.keys(program?.eventDecoders ?? {}).sort();
       const idlNames = (idl.events ?? []).map((event) => event.name).sort();
       expect(tableNames).to.deep.equal(idlNames);
     }
+  });
+
+  // A program address is retained across IDL upgrades, so the bundled decoders must only apply when the
+  // supplied IDL's schema actually matches the bundled one. A drifted CCTP IDL (here: DepositForBurn gains a
+  // trailing field) must decode per the *supplied* IDL via the generic path - the bundled decoder would
+  // silently drop the new field.
+  it("decodes per the supplied IDL when a CCTP schema has drifted from the bundled one", () => {
+    const drifted: Idl = JSON.parse(JSON.stringify(TokenMessengerMinterIdl));
+    const depositForBurn = (drifted.types ?? []).find((type) => type.name === "DepositForBurn");
+    expect(depositForBurn).to.not.equal(undefined);
+    if (depositForBurn?.type.kind === "struct" && Array.isArray(depositForBurn.type.fields)) {
+      depositForBurn.type.fields.push({ name: "new_field", type: "u64" });
+    }
+
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 1n,
+      burnToken: getRandomSvmAddress(),
+      amount: 9n,
+      depositor: getRandomSvmAddress(),
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 1,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+    const newField = Buffer.alloc(8);
+    newField.writeBigUInt64LE(777n);
+    const rawEvent = encodeEvent(drifted, "DepositForBurn", Buffer.concat([Buffer.from(payload), newField]));
+
+    const decoded = decodeEvent(drifted, rawEvent);
+    expect(decoded.name).to.equal("DepositForBurn");
+    expect(decoded.data).to.deep.include({ newField: 777n });
+  });
+
+  it("rejects a supplied SvmSpoke IDL whose schema has drifted from the bundled one", () => {
+    const drifted: Idl = JSON.parse(JSON.stringify(SvmSpokeIdl));
+    (drifted.events ?? []).pop();
+    const bogus = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]).toString("base64");
+    expect(() => decodeEvent(drifted, bogus)).to.throw(/does not match the bundled SvmSpoke IDL/);
   });
 
   // The codama decoders must produce the same consumer-visible data as the legacy Anchor + parseEventData

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -36,11 +36,11 @@ describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
     }
   });
 
-  // A program address is retained across IDL upgrades, so the bundled decoders must only apply when the
-  // supplied IDL's schema actually matches the bundled one. A drifted CCTP IDL (here: DepositForBurn gains a
-  // trailing field) must decode per the *supplied* IDL via the generic path - the bundled decoder would
-  // silently drop the new field.
-  it("decodes per the supplied IDL when a CCTP schema has drifted from the bundled one", () => {
+  // A program address is retained across IDL upgrades, so the bundled decoders only apply when the caller
+  // supplied the exact bundled IDL instance. A drifted CCTP IDL (here: DepositForBurn gains a trailing field)
+  // must decode per the *supplied* IDL via the generic path - the bundled decoder would silently drop the new
+  // field.
+  it("decodes per the supplied IDL when a CCTP IDL differs from the bundled one", () => {
     const drifted: Idl = JSON.parse(JSON.stringify(TokenMessengerMinterIdl));
     const depositForBurn = (drifted.types ?? []).find((type) => type.name === "DepositForBurn");
     expect(depositForBurn).to.not.equal(undefined);
@@ -65,13 +65,6 @@ describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
     const decoded = decodeEvent(drifted, rawEvent);
     expect(decoded.name).to.equal("DepositForBurn");
     expect(decoded.data).to.deep.include({ newField: 777n });
-  });
-
-  it("rejects a supplied SvmSpoke IDL whose schema has drifted from the bundled one", () => {
-    const drifted: Idl = JSON.parse(JSON.stringify(SvmSpokeIdl));
-    (drifted.events ?? []).pop();
-    const bogus = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]).toString("base64");
-    expect(() => decodeEvent(drifted, bogus)).to.throw(/does not match the bundled SvmSpoke IDL/);
   });
 
   // The codama decoders must produce the same consumer-visible data as the legacy Anchor + parseEventData

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -1,0 +1,118 @@
+import {
+  MessageTransmitterClient,
+  MessageTransmitterIdl,
+  SvmSpokeIdl,
+  TokenMessengerMinterClient,
+  TokenMessengerMinterIdl,
+} from "@across-protocol/contracts";
+import { BorshEventCoder, Idl } from "@coral-xyz/anchor";
+import { type ReadonlyUint8Array } from "@solana/kit";
+import { cctpEventDecoders, decodeEvent, getRandomSvmAddress, parseEventData } from "../src/arch/svm";
+import { expect } from "./utils";
+
+// Decode through the legacy pipeline (generic Anchor coder + parseEventData) for differential comparison.
+function legacyDecode(idl: Idl, rawEvent: string): { name: string; data: unknown } | null {
+  const event = new BorshEventCoder(idl).decode(rawEvent);
+  return event === null ? null : { name: event.name, data: parseEventData(event.data) };
+}
+
+function encodeEvent(idl: Idl, name: string, payload: ReadonlyUint8Array): string {
+  const idlEvent = (idl.events ?? []).find((event) => event.name === name);
+  if (!idlEvent) throw new Error(`${name} event not found in IDL ${idl.address}`);
+  return Buffer.concat([Buffer.from(idlEvent.discriminator), Buffer.from(payload)]).toString("base64");
+}
+
+describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
+  // Every event defined by the CCTP IDLs must have a registered codama decoder, so that new events added by a
+  // contracts bump cannot silently decode with divergent (legacy Anchor) shapes.
+  it("registers a decoder for every CCTP IDL event", () => {
+    const cctpIdls: Idl[] = [TokenMessengerMinterIdl, MessageTransmitterIdl];
+    for (const idl of cctpIdls) {
+      const decoders = cctpEventDecoders[idl.address];
+      expect(decoders, idl.address).to.not.equal(undefined);
+      const tableNames = Object.keys(decoders ?? {}).sort();
+      const idlNames = (idl.events ?? []).map((event) => event.name).sort();
+      expect(tableNames).to.deep.equal(idlNames);
+    }
+  });
+
+  // The codama decoders must produce the same consumer-visible data as the legacy Anchor + parseEventData
+  // pipeline that downstream consumers (the relayer's CCTP flows) were built against.
+  it("decodes DepositForBurn identically to the legacy pipeline", () => {
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 42n,
+      burnToken: getRandomSvmAddress(),
+      amount: 123_456n,
+      depositor: getRandomSvmAddress(),
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 3,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+    const rawEvent = encodeEvent(TokenMessengerMinterIdl, "DepositForBurn", payload);
+    expect(decodeEvent(TokenMessengerMinterIdl, rawEvent)).to.deep.equal(
+      legacyDecode(TokenMessengerMinterIdl, rawEvent)
+    );
+  });
+
+  it("decodes MintAndWithdraw identically to the legacy pipeline", () => {
+    const payload = TokenMessengerMinterClient.getMintAndWithdrawEncoder().encode({
+      mintRecipient: getRandomSvmAddress(),
+      amount: 555n,
+      mintToken: getRandomSvmAddress(),
+    });
+    const rawEvent = encodeEvent(TokenMessengerMinterIdl, "MintAndWithdraw", payload);
+    expect(decodeEvent(TokenMessengerMinterIdl, rawEvent)).to.deep.equal(
+      legacyDecode(TokenMessengerMinterIdl, rawEvent)
+    );
+  });
+
+  it("decodes MessageReceived identically to the legacy pipeline", () => {
+    const payload = MessageTransmitterClient.getMessageReceivedEncoder().encode({
+      caller: getRandomSvmAddress(),
+      sourceDomain: 0,
+      nonce: 7n,
+      sender: getRandomSvmAddress(),
+      messageBody: Uint8Array.from({ length: 64 }, (_, index) => index),
+    });
+    const rawEvent = encodeEvent(MessageTransmitterIdl, "MessageReceived", payload);
+    expect(decodeEvent(MessageTransmitterIdl, rawEvent)).to.deep.equal(legacyDecode(MessageTransmitterIdl, rawEvent));
+  });
+
+  // Regression: SvmCpiEventsClient is IDL-parameterised and used downstream with non-SvmSpoke programs
+  // (e.g. the CCTP TokenMessengerMinter). decodeEvent must decode those generically rather than rejecting
+  // them or mis-decoding them with SvmSpoke layouts.
+  it("decodes non-SvmSpoke events with the generic Anchor coder", () => {
+    const depositor = getRandomSvmAddress();
+    const payload = TokenMessengerMinterClient.getDepositForBurnEncoder().encode({
+      nonce: 1n,
+      burnToken: getRandomSvmAddress(),
+      amount: 1_000n,
+      depositor,
+      mintRecipient: getRandomSvmAddress(),
+      destinationDomain: 7,
+      destinationTokenMessenger: getRandomSvmAddress(),
+      destinationCaller: getRandomSvmAddress(),
+    });
+
+    const idlEvent = (TokenMessengerMinterIdl.events ?? []).find((event) => event.name === "DepositForBurn");
+    expect(idlEvent).to.not.equal(undefined);
+    const rawEvent = Buffer.concat([Buffer.from(idlEvent!.discriminator), Buffer.from(payload)]).toString("base64");
+
+    const decoded = decodeEvent(TokenMessengerMinterIdl, rawEvent);
+    expect(decoded.name).to.equal("DepositForBurn");
+
+    // The shape the relayer consumes: base58 address strings and bigint amounts.
+    expect(decoded.data).to.deep.include({ depositor, destinationDomain: 7, amount: 1_000n });
+  });
+
+  it("rejects unknown non-SvmSpoke events rather than mis-decoding them", () => {
+    const bogus = Buffer.from([9, 9, 9, 9, 9, 9, 9, 9, 1]).toString("base64");
+    expect(() => decodeEvent(TokenMessengerMinterIdl, bogus)).to.throw(/malformed event for IDL/);
+  });
+
+  it("continues to reject unknown SvmSpoke events", () => {
+    const bogus = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9]).toString("base64");
+    expect(() => decodeEvent(SvmSpokeIdl, bogus)).to.throw(/unknown SvmSpoke event/);
+  });
+});


### PR DESCRIPTION
SvmCpiEventsClient is used downstream against the CCTP TokenMessengerMinter and MessageTransmitter programs, whose events were decoded via the generic Anchor coder into shapes no type describes. Add per-program decoder tables built from the codama clients generated in the contracts package, dispatched by IDL address, so CCTP event data now matches the generated event types. Each table is typed against a name-to-type map, its completeness against the IDL is pinned by a unit test, and decoder output is verified identical to the legacy Anchor+parseEventData pipeline for the events the relayer consumes (DepositForBurn, MintAndWithdraw, MessageReceived). Events without a registered decoder fall back to the generic Anchor path unchanged, and non-SvmSpoke decoding is now regression-tested end to end.