### PR TITLE
feat(addressAggregator): export AbstractAdapter and adapter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.18",
+  "version": "4.4.19",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/addressAggregator/index.ts
+++ b/src/addressAggregator/index.ts
@@ -4,6 +4,11 @@ import * as adapters from "./adapters";
 
 export * as adapters from "./adapters";
 
+// Exported from here rather than the adapters barrel: AddressAggregator.sources() enumerates that
+// barrel's keys, so re-exporting the base class there would advertise it as a selectable source.
+export { AbstractAdapter } from "./adapters/abstract";
+export type { AdapterOptions, AddressListAdapter } from "./types";
+
 export class AddressAggregator {
   constructor(
     readonly adapters: AddressListAdapter[],


### PR DESCRIPTION
Follow-up to a review comment from Paul on across-protocol/relayer#3700.

## Problem

`AbstractAdapter` carries all the reusable machinery for a remote address list — caller-supplied name/path/timeout/retries/`throwOnError`/logger, a fetch with `1.5^n` backoff, and `error()` handling — and `risklabs`/`bybit` are each roughly 20-line subclasses over it.

None of it is reachable by consumers. `adapters/index.ts` exports only `bybit`, `fs`, `processEnv` and `risklabs`, and the package `exports` map surfaces just `src/index.ts`, so neither `AbstractAdapter` nor `AdapterOptions` can be imported. A downstream repo that wants an HTTP-backed list can implement the `AddressListAdapter` interface, but has to hand-roll the fetch/retry/error handling.

That is exactly what happened in the relayer: `src/common/addressFilter/http.ts` was a near-verbatim reimplementation of this base class — same options, same backoff, same warn shape — carrying a comment noting it as "a candidate for upstreaming". It is being deleted in relayer#3700, and this export is what lets the next such adapter subclass instead of copying.

## Change

```ts
export { AbstractAdapter } from "./adapters/abstract";
export type { AdapterOptions, AddressListAdapter } from "./types";
```

`AdapterOptions` is included deliberately: `AbstractAdapter`'s constructor takes `Omit<AdapterOptions, "name" | "path">` and the existing subclasses accept `opts?: AdapterOptions`, so exporting the class alone would not be enough to write one.

### Why not the adapters barrel

`AddressAggregator.sources()` returns `Object.keys(adapters)`, so `export * as abstract from "./abstract"` there would list the abstract base class as a selectable source in the `supportedSources` debug log. Exporting from the module index keeps that enumeration honest and leaves all existing runtime behaviour untouched. A comment records the reasoning.

Happy to move it into the barrel and filter `sources()` instead if you would rather adapter things live together — it just trades a purely additive change for a behavioural one.

## Verification

- `yarn lint-check` clean; build (cjs/esm/types) succeeds.
- The emitted `dist/types/src/addressAggregator/index.d.ts` carries both exports, confirming they reach the public surface.
- Compiled a scratch subclass against `tsconfig.build.json` — `super(...)`, the protected `fetch`/`error` helpers, and passing the instance to `AddressAggregator` all typecheck. Removed before commit.
- Confirmed no regression to the enumeration, against the built output:

```
sources():   ["bybit","fs","processEnv","risklabs"]   # unchanged
adapters:    ["bybit","fs","processEnv","risklabs"]   # unchanged
AbstractAdapter exported: function
```

I did not run the full `yarn test` suite locally — leaving that to CI, as the change is additive exports with no runtime behaviour change.

Patch bump to 4.4.19, matching the convention in recent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)