### PR TITLE
fix(coingecko): send Pro API key as header, not query string

### DIFF
--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -530,6 +530,8 @@ export class Coingecko {
 
   private async _callPro<T>(path: string): Promise<T> {
     const url = `${this.proHost}/${path}`;
-    return await fetchWithTimeout<T>(url, { x_cg_pro_api_key: this.apiKey });
+    // Send the Pro API key as a request header rather than a query-string parameter so it is never
+    // interpolated into the request URL (and therefore never leaked into thrown/logged error messages).
+    return await fetchWithTimeout<T>(url, {}, { "x-cg-pro-api-key": this.apiKey ?? "" });
   }
 }


### PR DESCRIPTION
## Motivation

`Coingecko._callPro` passed the Pro API key as the **second** positional argument to `fetchWithTimeout(url, params, headers, ...)` — i.e. as `params`. `applyQueryParams` therefore appended `x_cg_pro_api_key=<KEY>` to the request URL. On a 2xx response whose body fails to parse as JSON, `baseFetch` throws `Error(`Expected JSON response from ${fullUrl} ...`)` with the key-bearing URL, which is then logged (e.g. `getContractPrices`'s catch block) and can propagate to callers that log uncaught errors.

## Change

Pass the credential as an `x-cg-pro-api-key` **header** (CoinGecko's documented header form) instead of a query parameter, mirroring `_callBasic` which already passes headers positionally. The key is no longer interpolated into any URL, so it can't appear in thrown/logged error messages.

Note: this is the code fix only — any key already exposed in existing logs should be rotated separately.