### PR TITLE
fix(svm): correct address/chain-id resolution in SVM event decoding

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -509,7 +509,8 @@ export async function fillRelayInstruction(
   repaymentAddress: EvmAddress | SvmAddress,
   repaymentChainId: number,
   // Owning token program of the output mint. Defaults to the classic SPL token program; pass the
-  // Token-2022 program id when filling a Token-2022 output mint so the relayer ATA derives correctly.
+  // Token-2022 program id when filling a Token-2022 output mint so that both the relayer ATA and
+  // the instruction's tokenProgram account resolve to that program.
   outputTokenProgram?: Address<string>
 ): Promise<Instruction> {
   const program = toAddress(spokePool);
@@ -541,6 +542,10 @@ export async function fillRelayInstruction(
     relayerTokenAccount: relayerTokenAccount,
     recipientTokenAccount: recipientTokenAccount,
     fillStatus: fillStatusPda,
+    // Must match the program the relayer ATA was derived against above. The instruction builder
+    // otherwise defaults this account to the classic SPL token program, which would pair a
+    // Token-2022 ATA with the wrong token program and fail on-chain.
+    tokenProgram: outputTokenProgram,
     eventAuthority,
     program,
     relayHash: relayDataHash,

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -483,8 +483,14 @@ export async function findFillEvent(
     return;
   }
 
+  // Merge the transaction/slot metadata carried on EventWithData before unpacking, mirroring findDeposit.
+  // unpackFillEvent does not derive these from the raw event, so without this they come back undefined.
+  const blockNumber = Number(rawEvent.slot);
+  const txnRef = rawEvent.signature.toString();
+  const txnIndex = 0;
+  const logIndex = 0;
   const rawFill = unwrapEventData<SortableEvent>(rawEvent.data, ["depositId", "inputAmount"]);
-  const fill = unpackFillEvent(rawFill, destinationChainId);
+  const fill = unpackFillEvent({ ...rawFill, blockNumber, txnRef, txnIndex, logIndex }, destinationChainId);
   return fill satisfies FillWithBlock;
 }
 
@@ -501,7 +507,10 @@ export async function fillRelayInstruction(
   signer: TransactionSigner<string>,
   recipientTokenAccount: Address<string>,
   repaymentAddress: EvmAddress | SvmAddress,
-  repaymentChainId: number
+  repaymentChainId: number,
+  // Owning token program of the output mint. Defaults to the classic SPL token program; pass the
+  // Token-2022 program id when filling a Token-2022 output mint so the relayer ATA derives correctly.
+  outputTokenProgram?: Address<string>
 ): Promise<Instruction> {
   const program = toAddress(spokePool);
   assert(
@@ -519,8 +528,8 @@ export async function fillRelayInstruction(
     getStatePda(program),
     getFillStatusPda(program, relayData, relayData.destinationChainId),
     getEventAuthority(program),
-    getFillRelayDelegatePda(relayDataHash, BigInt(repaymentChainId), signer.address, program),
-    getAssociatedTokenAddress(relayer, relayData.outputToken),
+    getFillRelayDelegatePda(relayDataHash, BigInt(repaymentChainId), toAddress(repaymentAddress), program),
+    getAssociatedTokenAddress(relayer, relayData.outputToken, outputTokenProgram),
   ]);
 
   const svmRelayData = toSvmRelayData(relayData);

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -13,7 +13,7 @@ import {
 import { bs58, chainIsSvm, getMessageHash, isDefined, toAddressType } from "../../utils";
 import { EventName, EventWithData, SVMProvider } from "./types";
 import { decodeEvent, isDevnet } from "./utils";
-import { Deposit, DepositWithTime, Fill, FillWithTime } from "../../interfaces";
+import { Deposit, DepositWithTime, Fill, FillWithTime, RelayExecutionEventInfo } from "../../interfaces";
 import { unwrapEventData } from "./";
 import assert from "assert";
 
@@ -290,12 +290,14 @@ export class SvmCpiEventsClient {
           outputToken: string;
         }
       >(event.data, ["depositId", "outputAmount"]);
+      // A FundsDeposited event carries destinationChainId but not originChainId (origin is implicitly this
+      // SVM chain), so depositor/inputToken must be resolved against the originChainId function argument.
       return {
         ...data,
-        depositor: toAddressType(data.depositor, data.originChainId),
+        depositor: toAddressType(data.depositor, originChainId),
         recipient: toAddressType(data.recipient, data.destinationChainId),
         exclusiveRelayer: toAddressType(data.exclusiveRelayer, data.destinationChainId),
-        inputToken: toAddressType(data.inputToken, data.originChainId),
+        inputToken: toAddressType(data.inputToken, originChainId),
         outputToken: toAddressType(data.outputToken, data.destinationChainId),
         depositTimestamp: Number(txDetails.blockTime),
         originChainId,
@@ -349,15 +351,26 @@ export class SvmCpiEventsClient {
           exclusiveRelayer: string;
           inputToken: string;
           outputToken: string;
+          relayer: string;
+          relayExecutionInfo: Omit<RelayExecutionEventInfo, "updatedRecipient"> & { updatedRecipient: string };
         }
       >(event.data, ["depositId", "inputAmount"]);
+      // A FilledRelay event carries originChainId but not destinationChainId (destination is implicitly this
+      // SVM chain), so recipient/exclusiveRelayer/outputToken must be resolved against the
+      // destinationChainId function argument. relayer and relayExecutionInfo.updatedRecipient were not
+      // converted at all, leaving them as raw hex strings mistyped as Address.
       return {
         ...data,
         depositor: toAddressType(data.depositor, data.originChainId),
-        recipient: toAddressType(data.recipient, data.destinationChainId),
-        exclusiveRelayer: toAddressType(data.exclusiveRelayer, data.destinationChainId),
+        recipient: toAddressType(data.recipient, destinationChainId),
+        exclusiveRelayer: toAddressType(data.exclusiveRelayer, destinationChainId),
         inputToken: toAddressType(data.inputToken, data.originChainId),
-        outputToken: toAddressType(data.outputToken, data.destinationChainId),
+        outputToken: toAddressType(data.outputToken, destinationChainId),
+        relayer: toAddressType(data.relayer, data.repaymentChainId),
+        relayExecutionInfo: {
+          ...data.relayExecutionInfo,
+          updatedRecipient: toAddressType(data.relayExecutionInfo.updatedRecipient, destinationChainId),
+        },
         fillTimestamp: Number(txDetails.blockTime),
         blockNumber: Number(txDetails.slot),
         txnRef: txSignature,


### PR DESCRIPTION
Four related correctness fixes in the SVM decoding path (`src/arch/svm`):

**`findFillEvent` (SpokeUtils.ts)** — merge the `slot`/`signature` metadata carried on `EventWithData` into the object passed to `unpackFillEvent` (as `blockNumber`/`txnRef`/`txnIndex`/`logIndex`), mirroring the sibling `findDeposit`. Previously all four came back `undefined`, which breaks Arweave bundle-data reload (`convertSortableEventFieldsIntoRequiredFields` throws "Either txnRef or transactionHash must be defined") and any consumer reading `fill.txnRef`/`fill.blockNumber`.

**`fillRelayInstruction` (SpokeUtils.ts)** — derive the fill-delegate PDA from the **repayment address** (matching the on-chain seed `keccak(relayHash ‖ repaymentChainId ‖ repaymentAddress)` and the `getFillRelayTx`/`getIPFillRelayTx` siblings) rather than `signer.address`. As written, any fill requesting repayment at an address other than the signer built a `delegate` account that could not match the program-derived PDA, so the instruction reverted. Also added an optional `outputTokenProgram` argument so a Token-2022 output mint derives the relayer ATA under the correct token program (defaults to classic SPL, so existing callers are unaffected).

**`getDepositEventsFromSignature` / `getFillEventsFromSignature` (eventsClient.ts)** — resolve address fields against the `originChainId`/`destinationChainId` **function arguments** for the chain id the raw event omits: a `FundsDeposited` event carries no `originChainId` and a `FilledRelay` event carries no `destinationChainId`, so `data.originChainId`/`data.destinationChainId` were `undefined` and those addresses were silently downgraded to `RawAddress`. Also convert `relayer` and `relayExecutionInfo.updatedRecipient`, which were returned as raw hex strings mistyped as `Address`.

Full build (`build:cjs`/`esm`/`types`), prettier and eslint pass on the changed files.