### PR TITLE
fix(svm): apply node quorum to SVM getTransaction event fetches

### DIFF
--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -255,6 +255,12 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
     switch (method) {
       case "getBlock":
       case "getBlockTime":
+      // getSignaturesForAddress and getTransaction are the sole source of all SpokePool events
+      // (FundsDeposited, FilledRelay, RequestedSlowFill, ...). They are historical/deterministic, so
+      // they must be quorumed — mirroring the eth_getLogs treatment in RetryProvider — otherwise a
+      // single compromised RPC provider could forge or hide deposits/fills and drive bundle data.
+      case "getSignaturesForAddress":
+      case "getTransaction":
         return this.nodeQuorumThreshold;
     }
 

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -1,6 +1,6 @@
 import { Logger } from "winston";
 import { RpcFromTransport, RpcResponse, RpcTransport, SolanaRpcApiFromTransport } from "@solana/kit";
-import { isPromiseFulfilled, isPromiseRejected } from "../../utils/TypeGuards";
+import { isDefined, isPromiseFulfilled, isPromiseRejected } from "../../utils/TypeGuards";
 import { compareSvmRpcResults, createSendErrorWithMessage } from "../utils";
 import { CachedSolanaRpcFactory } from "./cachedRpcFactory";
 import { SolanaBaseRpcFactory, SolanaClusterRpcFactory } from "./baseRpcFactories";
@@ -35,12 +35,24 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
         `nodeQuorum,Threshold cannot be < 1 and must be an integer. Currently set to ${this.nodeQuorumThreshold}`
       );
     }
+    // An unsatisfiable threshold would otherwise be accepted silently: `requiredFactories` is a slice, so
+    // it shrinks to the providers that exist and the all-agree early return below is trivially satisfied by
+    // a single provider. That reports quorum while providing none. Mirrors RetryProvider's check.
+    if (this.nodeQuorumThreshold > this.rpcFactories.length) {
+      throw new Error(
+        `nodeQuorumThreshold (${this.nodeQuorumThreshold}) must be <= the number of providers (${this.rpcFactories.length})`
+      );
+    }
   }
 
   public createTransport(): RpcTransport {
     return async <TResponse>(...args: Parameters<RpcTransport>): Promise<RpcResponse<TResponse>> => {
       const { method, params } = args[0].payload as { method: string; params?: unknown[] };
       const quorumThreshold = this._getQuorum(method, params ?? []);
+      // A missing result only counts as a vote for methods where absence is a fact about the chain. See
+      // ABSENCE_IS_PROVIDER_LOCAL.
+      const absenceIsProviderLocal = ABSENCE_IS_PROVIDER_LOCAL.includes(method);
+      const isMissingResult = (response: unknown) => absenceIsProviderLocal && !isDefined(unwrapRpcResult(response));
       const requiredFactories = this.rpcFactories.slice(0, quorumThreshold);
       const fallbackFactories = [...this.rpcFactories.slice(quorumThreshold)];
       const errors: [SolanaClusterRpcFactory, string][] = [];
@@ -120,8 +132,15 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
 
       const values = results.map((result) => result.value);
       // Start at element 1 and begin comparing.
-      // If _all_ values are equal, we have hit quorum, so return.
-      if (values.slice(1).every(([, output]) => compareSvmRpcResults(method, values[0][1], output))) {
+      const allValuesAgree = values.slice(1).every(([, output]) => compareSvmRpcResults(method, values[0][1], output));
+      // "Everyone agrees the transaction is missing" is only a real answer once there is nobody left to ask;
+      // until then the required providers may simply be the pruned or lagging ones. Fall through to the
+      // fallbacks so a provider that actually holds the transaction can overrule them.
+      const missingNeedsCorroboration = isMissingResult(values[0][1]) && fallbackFactories.length > 0;
+
+      // If _all_ values are equal, we have hit quorum, so return. The length check is belt-and-braces against
+      // a `requiredFactories` slice shorter than the threshold; the constructor already rejects that config.
+      if (allValuesAgree && values.length >= quorumThreshold && !missingNeedsCorroboration) {
         return values[0][1];
       }
 
@@ -222,18 +241,28 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
       // This filters only the fallbacks that succeeded.
       const fallbackValues = fallbackResults.filter(isPromiseFulfilled).map((promise) => promise.value);
 
-      const [quorumResult, count] = getHighestCountResult([...values, ...fallbackValues]);
+      const allValues = [...values, ...fallbackValues];
+
+      // Only providers that actually returned the transaction get a vote, so that a pruned or lagging node
+      // cannot outvote an archival one and silently erase a real deposit or fill.
+      const votingValues = allValues.filter(([, result]) => !isMissingResult(result));
+      if (absenceIsProviderLocal && votingValues.length === 0) {
+        // Nobody we consulted has it, so the absence is a property of the chain rather than of one provider.
+        return allValues[0][1];
+      }
+
+      const [quorumResult, count] = getHighestCountResult(votingValues);
       // If this count is less than we need for quorum, throw the quorum error.
 
       if (count < quorumThreshold) {
-        throwQuorumError(quorumResult, [...values, ...fallbackValues]);
+        throwQuorumError(quorumResult, allValues);
       }
 
       // If we've achieved quorum, then we should still log the providers that mismatched with the quorum result.
-      const mismatchedProviders = [...values, ...fallbackValues]
+      const mismatchedProviders = allValues
         .filter(([, result]) => !compareSvmRpcResults(method, result, quorumResult))
         .map(([factory]) => factory.clusterUrl);
-      const successfulProviderUrls = [...values, ...fallbackValues].map(([provider]) => provider.clusterUrl);
+      const successfulProviderUrls = allValues.map(([provider]) => provider.clusterUrl);
       if (mismatchedProviders.length > 0 || errors.length > 0) {
         logQuorumMismatchOrFailureDetails(
           method,
@@ -251,15 +280,22 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
 
   _getQuorum(method: string, _params: Array<unknown>): number {
     // Only use quorum if this is a historical query that doesn't depend on the current block number.
-
+    //
+    // getTransaction returns the instruction data that every SpokePool event (FundsDeposited, FilledRelay,
+    // RequestedSlowFill, ...) is decoded from, so without quorum a single compromised provider can fabricate
+    // a fill and drive a fraudulent relayer-refund leaf. It is historical and deterministic once the slot is
+    // confirmed, which makes it safe to quorum — mirroring the eth_getLogs treatment in RetryProvider.
+    //
+    // getSignaturesForAddress is deliberately NOT quorumed. arch/svm/eventsClient fetches the newest page and
+    // filters by slot afterwards instead of pinning the request, so the page tracks the confirmed tip: two
+    // honest providers a slot apart return different leading signatures, and deep equality would fail quorum
+    // and stall all event ingestion. This mirrors RetryProvider excluding "latest"/"pending" from
+    // eth_getBlockByNumber quorum. It leaves an omission vector — a malicious provider can withhold
+    // signatures — that needs a range-reconciling comparator rather than deep equality, so it is left to a
+    // follow-up.
     switch (method) {
       case "getBlock":
       case "getBlockTime":
-      // getSignaturesForAddress and getTransaction are the sole source of all SpokePool events
-      // (FundsDeposited, FilledRelay, RequestedSlowFill, ...). They are historical/deterministic, so
-      // they must be quorumed — mirroring the eth_getLogs treatment in RetryProvider — otherwise a
-      // single compromised RPC provider could forge or hide deposits/fills and drive bundle data.
-      case "getSignaturesForAddress":
       case "getTransaction":
         return this.nodeQuorumThreshold;
     }
@@ -272,3 +308,18 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
 // These methods return a bigint and their results are loggable because they are succinct and can further assist
 // quorum debugging.
 const METHODS_RETURNING_BIGINT = ["getBlockTime", "getSlot"];
+
+// Methods whose null result is a statement about the queried provider rather than about the chain: a pruned or
+// lagging node answering "I don't have this transaction" is not the same claim as "this transaction does not
+// exist". arch/svm/eventsClient decodes a null transaction as "no events", so letting absence win a quorum vote
+// would silently drop the deposit or fill instead of surfacing the disagreement.
+const ABSENCE_IS_PROVIDER_LOCAL = ["getTransaction"];
+
+// The SVM transports resolve to the JSON-RPC envelope ({ jsonrpc, id, result }); unwrap it so that a missing
+// payload is detected whether we are handed the envelope or a bare result.
+function unwrapRpcResult(response: unknown): unknown {
+  if (isDefined(response) && typeof response === "object" && "result" in (response as Record<string, unknown>)) {
+    return (response as Record<string, unknown>).result;
+  }
+  return response;
+}

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -246,7 +246,11 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
       // Only providers that actually returned the transaction get a vote, so that a pruned or lagging node
       // cannot outvote an archival one and silently erase a real deposit or fill.
       const votingValues = allValues.filter(([, result]) => !isMissingResult(result));
-      if (absenceIsProviderLocal && votingValues.length === 0) {
+      // Absence is only conclusive once every provider we consulted actually answered. A fallback that
+      // rejected — say the one archival node still holding the transaction is briefly unreachable — has not
+      // agreed that it is missing, so fail loudly and let the caller retry rather than dropping the event.
+      const everyFallbackAnswered = fallbackResults.every(isPromiseFulfilled);
+      if (absenceIsProviderLocal && votingValues.length === 0 && everyFallbackAnswered) {
         // Nobody we consulted has it, so the absence is a property of the chain rather than of one provider.
         return allValues[0][1];
       }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -286,13 +286,43 @@ const SVM_IGNORED_FIELDS: Record<string, string[]> = {
   getTransaction: ["computeUnitsConsumed", "stackHeight", "logMessages", "rewards"],
 };
 
-export function compareSvmRpcResults(method: string, rpcResultA: unknown, rpcResultB: unknown): boolean {
-  const ignoredKeys = SVM_IGNORED_FIELDS[method];
-  if (!isDefined(ignoredKeys)) {
-    return isEqual(rpcResultA, rpcResultB);
+/**
+ * The SVM transports resolve to the raw JSON-RPC envelope, and its `id` is a per-process counter that the
+ * provider echoes back (`createRpcMessage` in @solana/rpc-spec-types). CachedSolanaRpcFactory caches whole
+ * envelopes under a key that excludes the id, with no TTL, and only once a transaction is finalized — so two
+ * providers that reach finality at different moments cache different ids for the identical transaction, and
+ * comparing them would report a permanent disagreement. Drop the id before comparing.
+ *
+ * Only the top-level envelope id is dropped. This deliberately does not recurse — a result payload may carry
+ * its own `id` field — and the envelope is only recognised when `jsonrpc` sits alongside. The rest of the
+ * envelope is left intact, including `error`, so that two differing error responses still compare as a
+ * disagreement instead of collapsing onto an absent `result`.
+ */
+function stripJsonRpcEnvelopeId(response: unknown): unknown {
+  if (!isDefined(response) || typeof response !== "object" || Array.isArray(response)) {
+    return response;
   }
 
-  return isEqual(deleteIgnoredKeysDeep(ignoredKeys, rpcResultA), deleteIgnoredKeysDeep(ignoredKeys, rpcResultB));
+  const envelope = response as Record<string, unknown>;
+  if (!("id" in envelope) || !("jsonrpc" in envelope)) {
+    return response;
+  }
+
+  const withoutId = { ...envelope };
+  delete withoutId.id;
+  return withoutId;
+}
+
+export function compareSvmRpcResults(method: string, rpcResultA: unknown, rpcResultB: unknown): boolean {
+  const resultA = stripJsonRpcEnvelopeId(rpcResultA);
+  const resultB = stripJsonRpcEnvelopeId(rpcResultB);
+
+  const ignoredKeys = SVM_IGNORED_FIELDS[method];
+  if (!isDefined(ignoredKeys)) {
+    return isEqual(resultA, resultB);
+  }
+
+  return isEqual(deleteIgnoredKeysDeep(ignoredKeys, resultA), deleteIgnoredKeysDeep(ignoredKeys, resultB));
 }
 
 export enum CacheType {

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -247,8 +247,52 @@ export function compareRpcResults(method: string, rpcResultA: unknown, rpcResult
   }
 }
 
-export function compareSvmRpcResults(_method: string, rpcResultA: unknown, rpcResultB: unknown): boolean {
-  return isEqual(rpcResultA, rpcResultB);
+/**
+ * Recursively strip `ignoredKeys` from anywhere in a JSON-RPC response. Unlike the EVM helpers above this
+ * walks nested objects and arrays, because the volatile Solana fields are nested — for example
+ * `meta.computeUnitsConsumed` and `meta.innerInstructions[].instructions[].stackHeight`.
+ */
+function deleteIgnoredKeysDeep(ignoredKeys: string[], value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((element) => deleteIgnoredKeysDeep(ignoredKeys, element));
+  }
+
+  // Non-objects (including bigint, and null/undefined) are already comparable as-is.
+  if (!isDefined(value) || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !ignoredKeys.includes(key))
+      .map(([key, nested]) => [key, deleteIgnoredKeysDeep(ignoredKeys, nested)])
+  );
+}
+
+/**
+ * Fields that healthy Solana providers may legitimately disagree on, because they are optional in the
+ * JSON-RPC spec and gated on node version or configuration rather than on consensus. This is the SVM
+ * counterpart of IGNORED_FIELDS above.
+ */
+const SVM_IGNORED_FIELDS: Record<string, string[]> = {
+  // 2026-08-15 computeUnitsConsumed and stackHeight are omitted by older Agave/Solana node versions,
+  // logMessages is truncated at a node-configurable byte limit, and rewards is omitted by some
+  // providers on non-vote transactions. A mixed-version provider set therefore returns materially
+  // identical transactions that are not deeply equal. None of these are read by the SDK.
+  //
+  // Deliberately NOT ignored: blockTime (consumed as depositTimestamp in arch/svm/eventsClient), and
+  // meta.err / meta.innerInstructions / meta.loadedAddresses / transaction.message.accountKeys, which
+  // are exactly the fields an attacker would have to alter to forge or hide an event.
+  getTransaction: ["computeUnitsConsumed", "stackHeight", "logMessages", "rewards"],
+};
+
+export function compareSvmRpcResults(method: string, rpcResultA: unknown, rpcResultB: unknown): boolean {
+  const ignoredKeys = SVM_IGNORED_FIELDS[method];
+  if (!isDefined(ignoredKeys)) {
+    return isEqual(rpcResultA, rpcResultB);
+  }
+
+  return isEqual(deleteIgnoredKeysDeep(ignoredKeys, rpcResultA), deleteIgnoredKeysDeep(ignoredKeys, rpcResultB));
 }
 
 export enum CacheType {

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -424,6 +424,27 @@ describe("QuorumFallbackSolanaRpcFactory getTransaction quorum", () => {
     }
     expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
   });
+
+  it("still compares an id nested inside the result payload", async () => {
+    // Only the top-level envelope id is provider-local bookkeeping. An `id` occurring inside the result is
+    // payload data, so stripping it would blind the comparison to a real difference. This pins the strip to
+    // the envelope: making it recurse would let these two disagreeing payloads reach quorum.
+    const factory = buildFactory(
+      [
+        resolvingTransport({ jsonrpc: "2.0", id: "42", result: { slot: 421829272, parsed: { id: "one" } } }),
+        resolvingTransport({ jsonrpc: "2.0", id: "42", result: { slot: 421829272, parsed: { id: "two" } } }),
+      ],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
 });
 
 function signaturePage(signatures: { signature: string; slot: number }[]) {

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -371,6 +371,59 @@ describe("QuorumFallbackSolanaRpcFactory getTransaction quorum", () => {
     const response = await factory.createTransport()(payload("getTransaction", ["sig"]));
     expect(response).to.deep.equal({ result: null });
   });
+
+  it("does not treat absence as unanimous when a consulted fallback failed", async () => {
+    // Two pruned providers agree on null while the archival node that may hold the transaction is briefly
+    // unreachable. It never agreed the transaction is missing, so this must not resolve to "no events".
+    const factory = buildFactory(
+      [
+        resolvingTransport({ result: null }),
+        resolvingTransport({ result: null }),
+        rejectingTransport(new Error("archival node unreachable")),
+      ],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
+
+  it("reaches quorum when cached envelopes carry different JSON-RPC ids", async () => {
+    // The transports resolve to the raw envelope, and CachedSolanaRpcFactory caches it whole (no TTL) only
+    // once a transaction is finalized. Providers that finalize at different moments therefore serve the same
+    // transaction under different per-process ids, which must not read as a provider disagreement.
+    const cached = { jsonrpc: "2.0", id: "42", ...getTransactionResponse() };
+    const fresh = { jsonrpc: "2.0", id: "57", ...getTransactionResponse() };
+    const factory = buildFactory([resolvingTransport(cached), resolvingTransport(fresh)], 2);
+
+    const response = await factory.createTransport()(payload("getTransaction", ["sig"]));
+    expect(response).to.deep.equal(cached);
+  });
+
+  it("still reports a disagreement when envelopes differ beyond the JSON-RPC id", async () => {
+    // Guards the id-stripping above from over-normalising: only the id is dropped, so differing errors on
+    // otherwise identical envelopes remain a genuine mismatch.
+    const factory = buildFactory(
+      [
+        resolvingTransport({ jsonrpc: "2.0", id: "42", error: { code: -32001, message: "a" } }),
+        resolvingTransport({ jsonrpc: "2.0", id: "57", error: { code: -32009, message: "b" } }),
+      ],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
 });
 
 function signaturePage(signatures: { signature: string; slot: number }[]) {

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -372,3 +372,44 @@ describe("QuorumFallbackSolanaRpcFactory getTransaction quorum", () => {
     expect(response).to.deep.equal({ result: null });
   });
 });
+
+function signaturePage(signatures: { signature: string; slot: number }[]) {
+  return {
+    result: signatures.map(({ signature, slot }) => ({
+      signature,
+      slot,
+      err: null,
+      memo: null,
+      blockTime: 1735689600,
+      confirmationStatus: "confirmed",
+    })),
+  };
+}
+
+describe("QuorumFallbackSolanaRpcFactory getSignaturesForAddress", () => {
+  it("does not quorum the moving signature page, so providers at different tips cannot stall ingestion", async () => {
+    // arch/svm/eventsClient fetches the newest page and filters by slot afterwards rather than pinning the
+    // request, so two honest providers one slot apart legitimately return different leading signatures.
+    // Quorumming this method would turn that routine divergence into a quorum error and block all SVM event
+    // ingestion, which is why _getQuorum deliberately leaves it at 1.
+    let laggingCalled = false;
+    const atTip = signaturePage([
+      { signature: "sigNew", slot: 421829273 },
+      { signature: "sigOld", slot: 421829272 },
+    ]);
+    const oneSlotBehind = signaturePage([{ signature: "sigOld", slot: 421829272 }]);
+    const factory = buildFactory(
+      [resolvingTransport(atTip), resolvingTransport(oneSlotBehind, () => (laggingCalled = true))],
+      2
+    );
+
+    const response = await factory.createTransport()(
+      payload("getSignaturesForAddress", ["SpokePool11111111111111111111111111111111", { limit: 1000 }])
+    );
+
+    expect(response).to.deep.equal(atTip);
+    // Quorum 1 means only the first provider is consulted. Re-adding this method to _getQuorum would consult
+    // both, mismatch on the leading signature, and throw -- which is exactly the regression this guards.
+    expect(laggingCalled).to.equal(false);
+  });
+});

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -254,3 +254,121 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
     expect(response).to.deep.equal({ result: "ok" });
   });
 });
+
+// A minimal getTransaction envelope carrying the fields that arch/svm/eventsClient actually decodes events from.
+function getTransactionResponse(meta: Record<string, unknown> = {}, result: Record<string, unknown> = {}) {
+  return {
+    result: {
+      slot: 421829272,
+      blockTime: 1735689600,
+      transaction: { message: { accountKeys: ["SpokePool11111111111111111111111111111111", "EventAuth1111"] } },
+      meta: {
+        err: null,
+        loadedAddresses: { writable: [], readonly: [] },
+        innerInstructions: [{ index: 0, instructions: [{ programIdIndex: 0, accounts: [1], data: "3Bxs4h" }] }],
+        ...meta,
+      },
+      ...result,
+    },
+  };
+}
+
+function resolvingTransport(response: unknown, onCall?: () => void): RpcTransport {
+  return (() => {
+    onCall?.();
+    return Promise.resolve(response);
+  }) as unknown as RpcTransport;
+}
+
+describe("QuorumFallbackSolanaRpcFactory getTransaction quorum", () => {
+  it("rejects a nodeQuorumThreshold larger than the provider set", () => {
+    expect(() => buildFactory([resolvingTransport(getTransactionResponse())], 2)).to.throw(
+      /must be <= the number of providers/
+    );
+  });
+
+  it("reaches quorum when providers differ only on optional, node-version-dependent metadata", async () => {
+    // A newer node reports compute units, stack heights and full logs; an older one omits them. Both describe
+    // the same transaction, so this must not fail quorum.
+    const verbose = getTransactionResponse({
+      computeUnitsConsumed: 42069,
+      logMessages: ["Program log: a", "Program log: b"],
+      rewards: [],
+      innerInstructions: [
+        { index: 0, instructions: [{ programIdIndex: 0, accounts: [1], data: "3Bxs4h", stackHeight: 2 }] },
+      ],
+    });
+    const terse = getTransactionResponse();
+    const factory = buildFactory([resolvingTransport(verbose), resolvingTransport(terse)], 2);
+
+    const response = await factory.createTransport()(payload("getTransaction", ["sig"]));
+    expect(response).to.deep.equal(verbose);
+  });
+
+  it("fails quorum when providers disagree on the event instruction data", async () => {
+    // The forgery this quorum exists to catch: same shape, different CPI event payload.
+    const honest = getTransactionResponse();
+    const forged = getTransactionResponse({
+      innerInstructions: [{ index: 0, instructions: [{ programIdIndex: 0, accounts: [1], data: "forged" }] }],
+    });
+    const factory = buildFactory([resolvingTransport(honest), resolvingTransport(forged)], 2);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
+
+  it("fails quorum when providers disagree on blockTime", async () => {
+    // blockTime is consumed as depositTimestamp, so it is deliberately not normalised away.
+    const factory = buildFactory(
+      [
+        resolvingTransport(getTransactionResponse()),
+        resolvingTransport(getTransactionResponse({}, { blockTime: 1735689999 })),
+      ],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
+
+  it("does not let providers missing the transaction outvote a provider that has it", async () => {
+    // Two pruned/lagging providers agree on null. That must not silently resolve to "no events" while an
+    // archival provider still holds the transaction.
+    let archivalCalled = false;
+    const present = getTransactionResponse();
+    const factory = buildFactory(
+      [
+        resolvingTransport({ result: null }),
+        resolvingTransport({ result: null }),
+        resolvingTransport(present, () => (archivalCalled = true)),
+      ],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getTransaction", ["sig"]));
+    } catch (error) {
+      caught = error;
+    }
+    expect(archivalCalled).to.equal(true);
+    expect((caught as Error)?.message).to.match(/Not enough providers agreed to meet quorum/);
+  });
+
+  it("returns a missing transaction once every provider agrees it is missing", async () => {
+    const factory = buildFactory([resolvingTransport({ result: null }), resolvingTransport({ result: null })], 2);
+
+    const response = await factory.createTransport()(payload("getTransaction", ["sig"]));
+    expect(response).to.deep.equal({ result: null });
+  });
+});


### PR DESCRIPTION
`QuorumFallbackSolanaRpcFactory._getQuorum` only applied `nodeQuorumThreshold` to `getBlock`/`getBlockTime`. **`getTransaction`** — which returns the instruction data every Solana SpokePool event (`FundsDeposited`, `FilledRelay`, `RequestedSlowFill`, `ExecutedRelayerRefundRoot`) is decoded from — resolved at quorum 1, so an operator running `nodeQuorumThreshold > 1` still trusted a single provider for event payloads. A compromised provider in that set could return a synthetic payload (fabricating a fill → fraudulent relayer-refund leaf) with no cross-check. This mirrors the `eth_getLogs` quorum treatment in `RetryProvider._getQuorum`.

Making that safe needed three supporting fixes, all raised in review:

- **Reject unsatisfiable thresholds.** `requiredFactories` is a `slice`, so `nodeQuorumThreshold: 2` with one RPC URL silently degraded to one provider, and the all-agree early return is vacuously true on a single value — reporting quorum while providing none. `RetryProvider` already had this guard; the SVM factory never copied it.
- **Normalise optional transaction metadata.** `compareSvmRpcResults` ignored its `method` argument and did a raw `isEqual`, unlike the EVM `compareRpcResults`/`IGNORED_FIELDS` layer. Mixed-version provider sets legitimately differ on `computeUnitsConsumed`, `stackHeight`, `logMessages` and `rewards`, which would have thrown spurious quorum errors. Each is verified unread by the SDK. `blockTime` is deliberately **not** normalised — `eventsClient` consumes it as `depositTimestamp`.
- **Absence must not win a vote.** A `null` `getTransaction` means the queried provider lacks it, not that it does not exist, and `processEventFromTx` decodes `null` as "no events" — so pruned or lagging nodes could silently erase a real deposit or fill. Contested absence now fails loudly; genuine unanimous absence still returns `null`, so backfills past every provider's archive horizon do not become hard failures.

### Scope: `getSignaturesForAddress` is deliberately not quorumed

An earlier revision of this PR quorumed it too. That was wrong and would have stalled SVM event ingestion. `queryAllEvents` fetches the newest page at `limit: 1000` and filters by slot only afterwards, so the page tracks the confirmed tip — any signature landing between two providers' responses shifts the window and deep equality fails. `RetryProvider` excludes `latest`/`pending` from `eth_getBlockByNumber` quorum for the same reason; `eth_getLogs` is quorum-safe only because its range is bounded.

**This leaves an omission vector open**: a malicious provider serving the signature page can withhold signatures, and quorum on `getTransaction` cannot detect what it was never asked about. Closing it needs a range-reconciling comparator — naive truncation to the common leading edge is gameable in exactly the hide direction — so it is left to a follow-up.

Note this multiplies `getTransaction` RPC volume by the quorum threshold during event scans, which only applies when `nodeQuorumThreshold > 1`.

Tests cover each case. `eslint`, `prettier`, `tsc --project tsconfig.build.json` and the SVM suites pass. The lint run also caught that the previous commit broke `no-fallthrough` by putting a comment between `case` labels; fixed here.