### PR TITLE
fix(bundle): resolve fill repayment against the resolved chain and bundle-end block

### DIFF
--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../utils";
 import { HubPoolClient } from "../../HubPoolClient";
 import { SVMProvider } from "../../../arch/svm";
+import { isChainDisabledAtBlock } from "./PoolRebalanceUtils";
 
 /**
  * @notice Addresses that must never be paid out of a root bundle (as repayment, deposit refund, or slow fill).
@@ -133,6 +134,14 @@ export async function verifyFillRepayment(
       // also be the same mapping as the repayment token on the repayment chain.
       if (
         !matchedDeposit.fromLiteChain &&
+        // areTokensEquivalent() only inspects PoolRebalanceRoutes, so the destination chain must additionally be
+        // enabled at the bundle end block -- the same gate _getRepaymentChainId applies to the requested chain.
+        // Switching to a disabled destination would be undone downstream: getRefundInformationFromFill re-resolves
+        // it back to the origin chain, and the msg.sender assigned below is only guaranteed to be valid on the
+        // destination chain, so updateBundleFillsV3 would silently drop the fill instead of recording it as
+        // unrepayable. Declining the switch here falls through to the check below, which correctly returns
+        // undefined when the resolved chain can't repay this address.
+        !isChainDisabledAtBlock(fill.destinationChainId, bundleEndBlockForMainnet, hubPoolClient.configStoreClient) &&
         hubPoolClient.areTokensEquivalent(
           fill.inputToken,
           fill.originChainId,
@@ -193,9 +202,11 @@ function _getRepaymentChainId(
 
   // Repayment chain is valid if the input token and repayment chain are mapped to the same PoolRebalanceRoute and the repayment chain is not disabled in protocol.
   const repaymentTokenIsValid = _repaymentChainTokenIsValid(relayData, hubPoolClient, bundleEndBlockForMainnet);
-  const repaymentChainIsValid = !hubPoolClient.configStoreClient
-    .getDisabledChainsForBlock(bundleEndBlockForMainnet)
-    .includes(relayData.repaymentChainId);
+  const repaymentChainIsValid = !isChainDisabledAtBlock(
+    relayData.repaymentChainId,
+    bundleEndBlockForMainnet,
+    hubPoolClient.configStoreClient
+  );
   if (repaymentTokenIsValid && repaymentChainIsValid) {
     return relayData.repaymentChainId;
   }

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -109,8 +109,12 @@ export async function verifyFillRepayment(
   );
 
   // Repayments will always go to the fill.relayer address so check if its a valid EVM address. If its not, attempt
-  // to change it to the msg.sender of the FilledRelay.
-  if (_repaymentAddressNeedsToBeOverwritten(fill)) {
+  // to change it to the msg.sender of the FilledRelay. Validate against the *resolved* repayment chain
+  // (repaymentChainId), not the fill's originally-requested chain: _getRepaymentChainId can fall back to the
+  // origin chain (lite chain, or a disabled/invalid repayment route), and a relayer address whose family
+  // matches the requested chain but not the resolved fallback would otherwise skip the overwrite and be
+  // returned as repayable, only to be silently dropped later in updateBundleFillsV3.
+  if (_repaymentAddressNeedsToBeOverwritten(fill, repaymentChainId)) {
     // TODO: Handle case where fill was sent on non-EVM chain, in which case the following call would fail
     // or return something unexpected. We'd want to return undefined here.
     if (chainIsEvm(fill.destinationChainId)) {
@@ -133,7 +137,11 @@ export async function verifyFillRepayment(
           fill.inputToken,
           fill.originChainId,
           fill.outputToken,
-          fill.destinationChainId
+          fill.destinationChainId,
+          // Evaluate token equivalence at the bundle's mainnet end block rather than the client's current
+          // sync head; otherwise a SetPoolRebalanceRoute landing after the bundle end block can flip the
+          // answer, making the resolved repayment chain non-deterministic across validators for the same fill.
+          bundleEndBlockForMainnet
         )
       ) {
         repaymentChainId = fill.destinationChainId;
@@ -226,7 +234,7 @@ function _repaymentChainTokenIsValid(
   return true;
 }
 
-function _repaymentAddressNeedsToBeOverwritten(fill: Fill): boolean {
+function _repaymentAddressNeedsToBeOverwritten(fill: Fill, repaymentChainId: number): boolean {
   // Slow fills don't result in repayments so they're always valid.
   if (isSlowFill(fill)) {
     return false;
@@ -234,6 +242,6 @@ function _repaymentAddressNeedsToBeOverwritten(fill: Fill): boolean {
 
   // @dev If the repayment chain is EVM, the repayment address is valid if the address is 20 bytes.
   // If the repayment chain is SVM, the repayment address is valid if the address is strictly greater than
-  // 20 bytes.
-  return !fill.relayer.isValidOn(fill.repaymentChainId);
+  // 20 bytes. repaymentChainId is the resolved repayment chain, which may differ from fill.repaymentChainId.
+  return !fill.relayer.isValidOn(repaymentChainId);
 }

--- a/test/FillUtils.ts
+++ b/test/FillUtils.ts
@@ -27,6 +27,16 @@ describe("FillUtils", function () {
 
   const INVALID_EVM_ADDRESS = createRandomBytes32();
 
+  // Mark `chainIds` as disabled as of mainnet block 0, which is the bundle end block used throughout these tests.
+  const disableChains = (chainIds: number[]) =>
+    hubPoolClient.configStoreClient.cumulativeDisabledChainUpdates.push({
+      chainIds,
+      blockNumber: 0,
+      txnIndex: 0,
+      logIndex: 0,
+      txnRef: "0x",
+    });
+
   beforeEach(async function () {
     relayer = toAddressType(randomAddress(), originChainId);
     [owner] = await ethers.getSigners();
@@ -244,6 +254,43 @@ describe("FillUtils", function () {
         expect(result!.relayer.eq(relayer)).to.be.true;
         // Repayment chain gets overwritten to destination chain.
         expect(result!.repaymentChainId).to.equal(destinationChainId);
+      });
+      it("Relayer is not valid EVM address, repayment does not get overwritten to a destination chain that is disabled", async function () {
+        // The destination chain has a valid PoolRebalanceRoute mapping but is disabled at the bundle end block.
+        // areTokensEquivalent() only inspects token mappings, so the disabled check has to be applied separately;
+        // otherwise getRefundInformationFromFill would resolve the disabled chain back to the origin chain and the
+        // fill would be silently dropped by updateBundleFillsV3.
+        hubPoolClient.setTokenMapping(ZERO_ADDRESS, deposit.destinationChainId, deposit.outputToken.toNative());
+        disableChains([destinationChainId]);
+        const invalidRepaymentFill = {
+          ...fill,
+          relayer: toAddressType(INVALID_EVM_ADDRESS, destinationChainId),
+        };
+        spokeProvider._setTransaction(fill.txnRef, {
+          from: relayer.toNative(),
+        } as unknown as TransactionResponse);
+        const result = await verifyFillRepayment(invalidRepaymentFill, spokeProvider, deposit, hubPoolClient, 0);
+        expect(result).to.not.be.undefined;
+        expect(result!.relayer.eq(relayer)).to.be.true;
+        // Repayment stays on the resolved repayment chain instead of moving to the disabled destination chain.
+        expect(result!.repaymentChainId).to.equal(repaymentChainId);
+      });
+      it("Destination chain is disabled and resolved repayment chain is not EVM; fill is unrepayable", async function () {
+        // The resolved repayment chain is SVM, so the EVM msg.sender cannot be repaid there, and the disabled
+        // destination chain is not a legal fallback. The fill must be reported as unrepayable rather than returned
+        // as repayable and then silently dropped downstream.
+        hubPoolClient.setTokenMapping(ZERO_ADDRESS, CHAIN_IDs.SOLANA, createRandomBytes32());
+        hubPoolClient.setTokenMapping(ZERO_ADDRESS, deposit.destinationChainId, deposit.outputToken.toNative());
+        disableChains([destinationChainId]);
+        const svmRepaymentFill = {
+          ...fill,
+          repaymentChainId: CHAIN_IDs.SOLANA,
+        };
+        spokeProvider._setTransaction(fill.txnRef, {
+          from: relayer.toNative(),
+        } as unknown as TransactionResponse);
+        const result = await verifyFillRepayment(svmRepaymentFill, spokeProvider, deposit, hubPoolClient, 0);
+        expect(result).to.be.undefined;
       });
       it("Relayer is not valid EVM address, relayer gets overwritten to msg.sender on original repayment chain if destination chain does not have valid PoolRebalanceRoute mapping", async function () {
         // valid chain ID's doesn't contain repayment chain.


### PR DESCRIPTION
Two block-height / repayment-chain consistency fixes in `verifyFillRepayment` (`BundleDataClient/utils/FillUtils.ts`):

1. **Relayer validity checked against the requested, not resolved, repayment chain.** `_getRepaymentChainId` resolves the repayment chain (falling back to the origin chain for lite chains, or for a disabled/invalid repayment route), but `_repaymentAddressNeedsToBeOverwritten` evaluated `!fill.relayer.isValidOn(fill.repaymentChainId)` against the fill's *originally-requested* chain. When the relayer address family matches the requested chain but not the resolved fallback (e.g. an EVM relayer on a lite-chain deposit that resolves back to a Solana origin), the overwrite was skipped, `fill.repaymentChainId` was set to the incompatible resolved chain, and the fill was returned as repayable — then silently discarded in `updateBundleFillsV3` (`isValidOn(repaymentChainId)` guard) with no refund and no entry in `bundleUnrepayableFillsV3`. Now validated against the resolved `repaymentChainId`, so such fills are correctly routed to the unrepayable set.

2. **Token equivalence read at the wrong block.** `areTokensEquivalent(...)` was called without the optional hub-block argument, so it resolved at the client's `latestHeightSearched` rather than the bundle's mainnet end block. A `SetPoolRebalanceRoute` landing between the bundle end block and a validator's head could flip equivalence, making the resolved repayment chain differ across validators for the same fill in the same bundle. Now passes `bundleEndBlockForMainnet`, consistent with the rest of the file.

Typecheck (`tsc --project tsconfig.build.json`), prettier and eslint pass.