### PR TITLE
fix(DepositUtils): use family-agnostic comparison in validateFillForDeposit

### DIFF
--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -19,6 +19,9 @@ import { getDepositInCache, getDepositKey, setDepositInCache } from "./CachingUt
 import { getCurrentTime } from "./TimeUtils";
 import { isDefined } from "./TypeGuards";
 import { isDepositFormedCorrectly } from "./ValidatorUtils";
+import { utils as ethersUtils } from "ethers";
+import bs58 from "bs58";
+import { TronWeb } from "tronweb";
 
 // Load a deposit for a fill if the fill's deposit ID is outside this client's search range.
 // This can be used by the Dataworker to determine whether to give a relayer a refund for a fill
@@ -194,7 +197,37 @@ export function validateFillForDeposit(
   // Note: this short circuits when a key is found where the comparison doesn't match.
   // TODO: if we turn on "strict" in the tsconfig, the elements of FILL_DEPOSIT_COMPARISON_KEYS will be automatically
   // validated against the fields in Fill and Deposit, generating an error if there is a discrepancy.
-  let invalidKey = RELAYDATA_KEYS.find((key) => relayData[key].toString() !== deposit[key].toString());
+  // Address fields must be compared family-agnostically.
+  // Address.toString() / toNative() is family-dependent (EVM checksummed hex vs TVM T... base58
+  // vs SVM base58). See AddressUtils.ts:221: "this is not an identity... Use eq()/compare()...".
+  // toBytes32() is family-agnostic (32-byte hex, base-class, not overridden) and is consistent
+  // across EvmAddress/SvmAddress/TvmAddress/RawAddress. Also handles cached string values
+  // (Address serialises via toJSON() -> native string) by re-deriving bytes32.
+  const ADDRESS_KEYS = new Set<string>(["depositor", "recipient", "inputToken", "outputToken", "exclusiveRelayer"]);
+  const toComparable = (key: string, v: unknown): string => {
+    const isAddressField = ADDRESS_KEYS.has(key);
+    if (isAddressField) {
+      if (typeof v === "string") {
+        const s = (v as string).trim();
+        if (!s) return s;
+        try {
+          if (s.startsWith("0x")) return ethersUtils.hexZeroPad(ethersUtils.hexStripZeros(s), 32).toLowerCase();
+          if (s.length === 34 && TronWeb.isAddress(s)) {
+            const hex = TronWeb.address.toHex(s);
+            return ethersUtils.hexZeroPad("0x" + hex.slice(2), 32).toLowerCase();
+          }
+          const decoded = bs58.decode(s);
+          if (decoded.length <= 32) return ethersUtils.hexZeroPad(ethersUtils.hexlify(decoded), 32).toLowerCase();
+        } catch {}
+        return s.toLowerCase();
+      }
+      if (v !== null && typeof v === "object" && "__address_type_brand" in (v as Record<string, unknown>)) {
+        return (v as { toBytes32(): string }).toBytes32();
+      }
+    }
+    return (v as { toString(): string }).toString();
+  };
+  let invalidKey = RELAYDATA_KEYS.find((key) => toComparable(key, relayData[key]) !== toComparable(key, deposit[key]));
 
   // There should be no paths for `messageHash` to be unset, but mask it off anyway.
   if (!isDefined(invalidKey) && [relayData.messageHash, deposit.messageHash].includes(UNDEFINED_MESSAGE_HASH)) {

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -550,4 +550,84 @@ describe("SpokePoolClient: Fill Validation", function () {
     expect(result.valid).to.be.false;
     expect((result as { reason: string }).reason.startsWith("recipient mismatch")).to.be.true;
   });
+  it("Matches fills with deposits across different address families (family-agnostic comparison)", async function () {
+    // This test isolates validateFillForDeposit itself (not construction paths).
+    // Bypass toAddressType by injecting address objects of different families that share raw bytes.
+    // Old code using toString() would false-negative here; new code uses toBytes32() so it passes.
+    const { SvmAddress, TvmAddress, EvmAddress, RawAddress } = await import("../src/utils/AddressUtils");
+    const { utils } = await import("ethers");
+    const bs58 = await import("bs58");
+
+    // Use a 20-byte value that is valid as EVM and TVM, and use its 32-byte padded form for SVM.
+    const raw20 = "0x" + "ab".repeat(20);
+    const raw32Hex = utils.hexZeroPad(raw20, 32).toLowerCase();
+
+    // Build addresses of different families wrapping the SAME raw bytes
+    const evmAddr = EvmAddress.from(raw20);
+    const tvmAddr = TvmAddress.from(raw20);
+    // SVM needs 32 bytes with non-zero leading bytes; our raw32 has 12 zero leading bytes -> SvmAddress.validate would reject.
+    // Use a 32-byte value with non-zero prefix for SVM, and compare EVM vs Raw instead for the core assertion.
+    // For EVM vs TVM, both are 20-byte, so they share exact raw bytes -> strongest proof.
+    expect(evmAddr.toBytes32()).to.equal(tvmAddr.toBytes32());
+    expect(evmAddr.toString()).to.not.equal(tvmAddr.toString()); // doc says toString is not identity
+
+    // Construct minimal RelayData-like objects to exercise validateFillForDeposit directly
+    const baseRelay: any = {
+      depositId: toBN(1),
+      originChainId,
+      destinationChainId,
+      depositor: evmAddr,
+      recipient: evmAddr,
+      inputToken: evmAddr,
+      inputAmount: toBNWei(1),
+      outputToken: evmAddr,
+      outputAmount: toBNWei(1),
+      fillDeadline: Math.floor(Date.now() / 1000) + 3600,
+      exclusivityDeadline: 0,
+      exclusiveRelayer: EvmAddress.from("0x0000000000000000000000000000000000000000"),
+      messageHash: utils.keccak256("0x"),
+    };
+    const baseDeposit: any = {
+      ...baseRelay,
+      message: "0x",
+      messageHash: baseRelay.messageHash,
+      quoteTimestamp: Math.floor(Date.now() / 1000),
+      fromLiteChain: false,
+      toLiteChain: false,
+    };
+
+    // Same family — should pass (baseline)
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, { ...baseDeposit, depositor: evmAddr }).valid).to.be.true;
+
+    // Cross-family same bytes — OLD toString would fail, NEW toBytes32 must pass
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, { ...baseDeposit, depositor: tvmAddr }).valid).to.be.true;
+    expect(validateFillForDeposit({ ...baseRelay, recipient: tvmAddr }, { ...baseDeposit, recipient: evmAddr }).valid).to.be.true;
+    expect(validateFillForDeposit({ ...baseRelay, inputToken: tvmAddr }, { ...baseDeposit, inputToken: evmAddr }).valid).to.be.true;
+    expect(validateFillForDeposit({ ...baseRelay, outputToken: evmAddr }, { ...baseDeposit, outputToken: tvmAddr }).valid).to.be.true;
+    expect(validateFillForDeposit({ ...baseRelay, exclusiveRelayer: evmAddr }, { ...baseDeposit, exclusiveRelayer: tvmAddr }).valid).to.be.true;
+
+    // RawAddress (fallback family) vs EvmAddress same bytes — must also pass
+    const rawAddr = new RawAddress(utils.arrayify(raw32Hex));
+    expect(rawAddr.toBytes32()).to.equal(evmAddr.toBytes32());
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, { ...baseDeposit, depositor: rawAddr }).valid).to.be.true;
+
+    // Different bytes must still be rejected — prove we didn't make comparison too permissive
+    const other20 = "0x" + "cd".repeat(20);
+    const otherEvm = EvmAddress.from(other20);
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, { ...baseDeposit, depositor: otherEvm }).valid).to.be.false;
+    expect(validateFillForDeposit({ ...baseRelay, depositor: otherEvm }, { ...baseDeposit, depositor: evmAddr }).valid).to.be.false;
+
+    // Cached-string interop: deposit comes from JSON cache (Address.toJSON() -> native string)
+    // Simulate by using string instead of Address object for deposit side
+    const cachedDeposit = { ...baseDeposit, depositor: evmAddr.toString() as any }; // string, not Address
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, cachedDeposit).valid).to.be.true;
+    // Cached TVM string vs EVM object — same raw bytes, different native encodings -> must still match
+    const cachedTvmString = tvmAddr.toString();
+    expect(validateFillForDeposit({ ...baseRelay, depositor: evmAddr }, { ...baseDeposit, depositor: cachedTvmString as any }).valid).to.be.true;
+
+    // Non-address field mismatch must still be detected (sanity: we didn't break primitive comparison)
+    expect(validateFillForDeposit({ ...baseRelay, depositId: toBN(999) }, baseDeposit).valid).to.be.false;
+    expect(validateFillForDeposit({ ...baseRelay, inputAmount: toBNWei(999) }, baseDeposit).valid).to.be.false;
+  });
+
 });


### PR DESCRIPTION
…eposit

Address.toString()/toNative() is family-dependent (EVM hex vs TVM T... vs SVM base58). Use toBytes32() for 5 address fields so same raw bytes compare equal regardless of family. Handles cached strings via deterministic bytes32 re-derivation. Non-address fields unchanged.