### PR TITLE
feat: expose source modules as named subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "*": {
       "*": [
         "./*",
-        "./dist/types/src/*"
+        "./dist/types/src/*.d.ts"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -152,6 +152,14 @@
       "import": "./dist/esm/*.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./*",
+        "./dist/types/src/*"
+      ]
+    }
+  },
   "resolutions": {
     "**/@solana/codecs": "5.4.0",
     "**/@solana/codecs-numbers": "5.4.0"

--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
       "import": "./dist/esm/src/utils/abi/typechain/index.js",
       "types": "./dist/types/src/utils/abi/typechain/index.d.ts"
     },
+    "./*": {
+      "require": "./dist/cjs/src/*.js",
+      "import": "./dist/esm/src/*.js",
+      "types": "./dist/types/src/*.d.ts"
+    },
     "./dist/cjs/*": {
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js"

--- a/package.json
+++ b/package.json
@@ -145,6 +145,11 @@
     "./dist/esm/*": {
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js"
+    },
+    "./dist/types/*": {
+      "types": "./dist/types/*.d.ts",
+      "require": "./dist/cjs/*.js",
+      "import": "./dist/esm/*.js"
     }
   },
   "resolutions": {


### PR DESCRIPTION
## Problem

A consumer that needs one helper has two options today:

```ts
import { utils } from "@across-protocol/sdk";                          // ~180MB RSS
import { isDefined } from "@across-protocol/sdk/dist/cjs/src/utils/TypeGuards"; // ~74MB, but...
```

The root eagerly loads all 17 namespaces — `export * as arch from "./arch"` compiles to an eager `require` — so a process that only wanted `constants` still pays for `@solana/kit`, `tronweb`, `@eth-optimism/sdk` and the rest.

The deep path avoids that and already works (the `./dist/cjs/*` wildcard has shipped since 4.4.18), but it hard-codes the build layout into every call site and has no `types` condition.

## Change

One wildcard mapping the published path to the source layout:

```json
"./*": {
  "require": "./dist/cjs/src/*.js",
  "import": "./dist/esm/src/*.js",
  "types": "./dist/types/src/*.d.ts"
}
```

So `@across-protocol/sdk/utils/TypeGuards` resolves for CJS, ESM and types.

## Measurements

RSS after `require`, node v22. Fresh node = 42MB.

| Specifier | RSS |
|---|---|
| `@across-protocol/sdk` | 180MB |
| `@across-protocol/sdk/utils/TypeGuards` | **74MB** |
| `@across-protocol/sdk/constants` | **75MB** |

The residual 74MB is essentially ethers — that's the floor for anything touching it, not overhead from this change.

## Compatibility

Explicit keys take precedence over a wildcard, so existing entry points are untouched. Verified against a locally-built package linked into `across-protocol/relayer`:

- `.` → still 17 namespaces
- `./typechain` → `SpokePool__factory` resolves
- `./dist/cjs/*` → still resolves (existing consumers unaffected)
- `./utils/TypeGuards` → resolves, and **types are real**: assigning its `boolean` return to a `number` correctly errors with TS2322 rather than silently passing as `any`

## One wart worth knowing

Exports wildcards are literal string substitution, not Node's directory resolution, so a directory needs an explicit `/index`:

```ts
import { ... } from "@across-protocol/sdk/arch/evm/index";  // not ".../arch/evm"
```

Leaf modules — the common case — need no suffix.

## Why this shape

This is deliberately a declarative package.json addition rather than anything that rewrites build output. It gives consumers a supported way to pay only for what they import, and it's a prerequisite for trimming memory in `across-protocol/relayer`, where trivial helpers like `src/utils/TypeGuards.ts` currently import the SDK root for a null check and cost 178MB as a result.

## Downstream verification

Enumerated every distinct `@across-protocol/sdk` specifier used across **relayer, indexer, quote-api and dapp** — 28 of them — and diffed resolution under stock vs patched `exports`, holding `dist/` constant so only the map varies.

**Node resolution (both `require` and `import` conditions): 27 of 28 identical.**

The one change was `@across-protocol/sdk/dist/types/src/relayFeeCalculator` (quote-api, 3 call sites). `./dist/types/*` was covered by no explicit key, so the new wildcard captured it and remapped it to a doubly-nested `dist/esm/src/dist/types/src/...`. Nothing observably broke — quote-api sets `moduleResolution: "node"`, which ignores `exports` entirely — but going from *cleanly blocked* to *silently pointing at nothing* is a worse failure mode, so the second commit adds an explicit `./dist/types/*` entry ahead of the wildcard.

**TypeScript resolution: identical in every mode**, checked with a probe importing all 28 specifiers:

| `moduleResolution` | consumer | stock | patched |
|---|---|---|---|
| `node` | quote-api | 0 errors | 0 errors |
| `bundler` | dapp | 2 errors | 2 errors |
| `node16` | — | 0 errors | 0 errors |

The 2 `bundler` errors are **pre-existing and unrelated**: `dist/esm/src/arch/svm` and `dist/types/src/relayFeeCalculator` are directories, and exports wildcards don't do directory resolution. Both fail identically without this PR. They're used by quote-api, which resolves in `node` mode where they're fine.

indexer only uses `@across-protocol/sdk` and `/typechain`, both unchanged, so it's unaffected regardless of its per-package resolution settings.

Scope note: this verifies module **resolution** exhaustively over the real specifier set, not full downstream builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

