### PR TITLE
improve(svm): gate the typed event query on the SvmSpoke IDL

### DIFF
--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -85,6 +85,11 @@ export class SvmCpiEventsClient {
   /**
    * Queries events for the SvmSpoke program filtered by event name.
    *
+   * Only valid on a client bound to the SvmSpoke IDL: the typed return narrows `data` by `name`, and that
+   * correlation is only proven for events decoded by the generated SvmSpoke decoders (see decodeEvent()).
+   * A client bound to any other IDL via createFor() may emit an identically-named event with an unrelated
+   * payload, so this rejects rather than mislabel it; use queryDerivedAddressEvents() for those programs.
+   *
    * @param eventName - The name of the event to filter by.
    * @param fromSlot - Optional starting slot.
    * @param toSlot - Optional ending slot.
@@ -97,6 +102,10 @@ export class SvmCpiEventsClient {
     toSlot?: bigint,
     options: GetSignaturesForAddressConfig = { limit: 1000, commitment: "confirmed" }
   ): Promise<EventWithData<T>[]> {
+    assert(
+      this.idl.address === SvmSpokeIdl.address,
+      `queryEvents: client is bound to ${this.idl.address ?? "an unknown IDL"}, not SvmSpoke`
+    );
     const events = await this.queryAllEvents(fromSlot, toSlot, options);
     return events.filter((event): event is EventWithData<T> => event.name === eventName);
   }

--- a/test/Solana.GenericEventDecoding.unit.test.ts
+++ b/test/Solana.GenericEventDecoding.unit.test.ts
@@ -190,4 +190,13 @@ describe("SVM event decoding (non-SvmSpoke IDLs)", () => {
     expect(matched[0].name).to.equal("DepositForBurn");
     expect(matched[0].data).to.deep.equal({ nonce: 1n });
   });
+
+  // queryEvents() narrows event.data by event.name, a correlation that only the generated SvmSpoke decoders
+  // establish. A client bound to another IDL may emit an identically-named event with an unrelated payload,
+  // so the typed query must reject it outright rather than mislabel it as an SvmSpoke event.
+  it("rejects the typed query on a client bound to a non-SvmSpoke IDL", async () => {
+    const rpc = {} as unknown as Parameters<typeof SvmCpiEventsClient.createFor>[0];
+    const client = await SvmCpiEventsClient.createFor(rpc, getRandomSvmAddress(), TokenMessengerMinterIdl);
+    await expect(client.queryEvents("FundsDeposited")).to.be.rejectedWith(/not SvmSpoke/);
+  });
 });


### PR DESCRIPTION
Addresses https://github.com/across-protocol/sdk/pull/1510#discussion_r3854478383 on #1510. Targets `pxrl/svm3` so it can be evaluated independently and squashed in (or dropped) without disturbing the parent PR.

## The problem

`queryEvents()` narrows `event.data` by `event.name`:

```ts
return events.filter((event): event is EventWithData<T> => event.name === eventName);
```

`queryAllEvents()` returns `RawEventWithData` (`data: unknown`), so the predicate is a bare assertion — nothing proves the payload layout. Since `createFor()` accepts any IDL, a client bound to another program that happens to declare a `FundsDeposited` event would have its data typed as `SvmSpokeClient.FundsDeposited`.

## Scope, for calibration

Not reachable from any current call site, and not a regression:

- A `create()`-built client cannot be fed foreign events. `processEventFromTx()` only decodes inner instructions where `programId === this.programAddress`, the sole account is that program's `__event_authority` PDA, and the Anchor CPI event tag matches (`eventsClient.ts:230-246`). The name then resolves from the SvmSpoke discriminator table, with `assert` on a miss.
- Reaching the bug requires a caller to point `createFor()` at a different program *and then* ask it for a SvmSpoke event name. Every non-Spoke consumer — relayer `CCTPUtils.ts`, both `SolanaUsdcCCTPBridge` adapters, indexer `SvmCCTPIndexerDataHandler` — uses `queryDerivedAddressEvents()`, which #1510 correctly retypes to `RawEventWithData`.
- Pre-#1510, the same unsoundness lived at call sites as explicit casts (`findDeposit()` did `event.data as unknown as { depositId: BigNumber }`). #1510 relocates an unchecked cast into shared API surface, which is the right moment to discharge it.

## The fix

```ts
assert(
  this.idl.address === SvmSpokeIdl.address,
  `queryEvents: client is bound to ${this.idl.address ?? "an unknown IDL"}, not SvmSpoke`
);
```

This discharges the predicate against an invariant `decodeEvent()` already relies on: when `idl.address === SvmSpokeIdl.address`, every event on the client was produced by `svmSpokeEventDecoders[name]`, typed `DecodedEvent<N>` — so the name/data correlation is *proven* rather than assumed. Gating on the IDL rather than the program address is deliberate: the type claim is about payload layout, and layout comes from the decoder, which the IDL selects. Whether the events came from the canonical SvmSpoke deployment is a separate provenance question that the type does not assert.

The alternative suggested in review — moving `queryEvents()` onto a Spoke-specific client — is stronger in principle (compile-time rather than runtime) but a much wider change: `SvmCpiEventsClient` is the declared parameter type on `SVMSpokePoolClient`'s constructor and on `findDeposit`/`relayFillStatus`/`fillStatusArray` in `SpokeUtils.ts`. Worth considering separately; it seemed out of scope here.

## Verification

- `tsc --project tsconfig.build.json --noEmit` clean; eslint clean.
- All 17 Solana unit tests pass, including a new regression case pinning that a `TokenMessengerMinterIdl`-bound client rejects `queryEvents("FundsDeposited")`.
- `MockSvmCpiEventsClient` is unaffected — it overrides `queryEvents()` without calling `super` (it passes `null as unknown as Idl` to the base constructor, so a `super` call would have thrown here).

## Unrelated observation

While tracing this: `decodeEvent()` gates CCTP on IDL *instance* identity (`idl === cctpProgram.idl`), with a documented rationale about version skew across `@across-protocol/contracts`, but gates SvmSpoke on *address* only (`utils.ts:285`). The skew argument applies equally to SvmSpoke — a skewed IDL instance sharing the address is decoded by the bundled generated decoders. Low risk since IDL and decoders ship from the same package, but the asymmetry is worth either tightening or commenting. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)