### PR TITLE
chore: Bump constants to 3.1.125

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {
@@ -80,7 +80,7 @@
     "typescript": "^6"
   },
   "dependencies": {
-    "@across-protocol/constants": "^3.1.123",
+    "@across-protocol/constants": "^3.1.125",
     "@across-protocol/contracts": "5.0.26",
     "@coral-xyz/anchor": "^0.30.1",
     "@eth-optimism/sdk": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.118.tgz#3d82d1e162dc1803d0ed6cb11f3865598f46cf70"
   integrity sha512-JIUzkl285Oyfs1nnqubUlb4p5gCPh6RcirPR6o2MWUShSwq99sh1z62wDfOBheiCDnYfqgMoC2iVjDbFJWISXA==
 
-"@across-protocol/constants@^3.1.123":
-  version "3.1.123"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.123.tgz#72c9f8aecdbced2a21d7d2313398db87f5193af8"
-  integrity sha512-68SA6sNd/DsVJU/RbhmyC+u40iScoX+QDQNdPBAUJjG1khHc3+ltFz4oy3ahnxCOA+nHNwXJ6on8piI31m4/rA==
+"@across-protocol/constants@^3.1.125":
+  version "3.1.125"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.125.tgz#0f17e71ee7be27ef93ba0c8dece41e9ed8438bd8"
+  integrity sha512-JAq4fqvdF5RDsZrFTnINVxzBH+UP+HT+JQb2QiBeyHRSElHSondpSPCVnoQkR3I/bPVrx2j27jRc+kvfBdEjqw==
 
 "@across-protocol/contracts@5.0.26":
   version "5.0.26"


### PR DESCRIPTION
Bumps `@across-protocol/constants` `^3.1.123` -> `^3.1.125`, SDK 4.4.19 -> 4.4.20.

Upstream: Plasma `cctpDomain` -1 -> 33 (no collision); new ETH/Robinhood, USDC/Plasma, USDT/Tempo, WETH/Monad addresses; `XYZ` dropped from `TOKEN_SYMBOLS_MAP` — unreferenced here.

Local: `yarn build`, `yarn lint-check` clean; `yarn test` 469 passing.

## ⚠️ Behavior change — needs a maintainer call

The Plasma `cctpDomain` change is not inert. `chainIsCCTPEnabled()` is derived from it:

```ts
// src/utils/NetworkUtils.ts:160
return PRODUCTION_NETWORKS[chainId]?.cctpDomain !== CCTP_NO_DOMAIN && !cctpExceptions.includes(chainId);
```

Verified against both published packages:

| constants | Plasma `cctpDomain` | `chainIsCCTPEnabled(9745)` |
| --- | --- | --- |
| 3.1.123 | `-1` (`CCTP_NO_DOMAIN`) | `false` |
| 3.1.125 | `33` | **`true`** |

Knock-on effects:

- `chainRequiresL1ToL2Finalization(9745)` also flips `false` -> `true` (`NetworkUtils.ts:196`).
- Both are re-exported via `src/utils/index.ts`, so this propagates to downstream consumers (relayer/finalizer), not just this repo.
- Plasma is already in the `oftEnabled` list (`NetworkUtils.ts:182`), and 3.1.125 also adds a native USDC address for Plasma — so Plasma becomes both CCTP- and OFT-eligible for USDC.
- No test covers `chainIsCCTPEnabled` / `chainRequiresL1ToL2Finalization`, so green CI does not validate this.

`chainIsCCTPEnabled` carries a purpose-built escape hatch whose comment describes exactly this case:

```ts
// Add chainIds to cctpExceptions to administratively disable CCTP on a chain.
// This is useful if constants has been updated to specify a CCTP domain in advance of it being activated.
const cctpExceptions: number[] = [];
```

**If CCTP is live on Plasma, merge as-is** — this is the intended effect of the bump. **If it is not yet activated**, add `CHAIN_IDs.PLASMA` to `cctpExceptions` in this PR. Deliberately not making that call here, since suppressing it would be wrong if activation is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
